### PR TITLE
fix(rye-math): Rotor4::mul sign errors in xy output (issue #37); diagnostics now regression gates

### DIFF
--- a/crates/rye-math/src/bivector.rs
+++ b/crates/rye-math/src/bivector.rs
@@ -1501,6 +1501,168 @@ mod tests {
         assert_vec4_close_tol(rotated, expected, 1e-5);
     }
 
+    /// Composition `(R_xy * R_xw).apply(v)` must equal
+    /// `R_xw.apply(R_xy.apply(v))`. The earlier
+    /// `rotor4_composition_matches_sequential_apply` test only
+    /// covers two pure-3D planes (xy + yz); a sign error specific
+    /// to the geometric product's w-mixing terms would survive
+    /// that test and only show up here.
+    #[test]
+    fn rotor4_composition_xy_then_xw_matches_sequential_apply() {
+        let r_xy = Bivector4::new(0.4, 0.0, 0.0, 0.0, 0.0, 0.0).exp();
+        let r_xw = Bivector4::new(0.0, 0.0, 0.5, 0.0, 0.0, 0.0).exp();
+        let composed = r_xy * r_xw;
+        for v in [
+            Vec4::X,
+            Vec4::Y,
+            Vec4::Z,
+            Vec4::W,
+            Vec4::new(0.7, -0.3, 1.1, 0.2),
+        ] {
+            assert_vec4_close_tol(composed.apply(v), r_xw.apply(r_xy.apply(v)), 1e-4);
+        }
+    }
+
+    /// The polytope_smoke demo's update loop:
+    ///   per frame at 60 Hz: orientation = (omega * dt).exp() * orientation
+    /// Over N steps with constant `omega`, the result must equal the
+    /// closed-form `(omega * N * dt).exp()` within float tolerance.
+    /// Catches both additive (sum-of-plane-bivectors) and
+    /// multiplicative (rotor compose) drift specific to compound
+    /// bivectors that include w-mixing planes.
+    ///
+    /// `omega = e_xy + e_xz + e_xw + e_yz` is the exact bivector the
+    /// user's failing screenshot has active.
+    #[test]
+    #[ignore = "rotor4 multiplicative drift — see issue #TBD"]
+    fn rotor4_compound_xy_xz_xw_yz_integrated_matches_closed_form() {
+        let omega = Bivector4::new(1.0, 1.0, 1.0, 1.0, 0.0, 0.0);
+        let dt = 1.0 / 60.0;
+        let n_steps = 60_u32; // 1 second of integration
+        let total_angle = dt * n_steps as f32; // 1.0
+        let delta = (omega * dt).exp();
+
+        let mut integrated = Rotor4::IDENTITY;
+        for _ in 0..n_steps {
+            integrated = delta * integrated;
+        }
+        let closed_form = (omega * total_angle).exp();
+
+        // Compare on a probe vector set: rotors that map the same
+        // way on a basis are equal up to global sign (and the
+        // sandwich kills the global sign anyway).
+        for v in [
+            Vec4::X,
+            Vec4::Y,
+            Vec4::Z,
+            Vec4::W,
+            Vec4::new(1.0, 2.0, 3.0, 4.0),
+            Vec4::new(-0.5, 0.5, -0.5, 0.5),
+        ] {
+            let via_integrated = integrated.apply(v);
+            let via_closed = closed_form.apply(v);
+            let diff = (via_integrated - via_closed).length();
+            assert!(
+                diff < 5e-3,
+                "compound xy+xz+xw+yz integration drift: v={v:?} \
+                 integrated={via_integrated:?} closed={via_closed:?} \
+                 diff={diff}",
+            );
+        }
+    }
+
+    /// 60 Hz × 15 s = 900 rotor multiplications, mirroring the
+    /// pentatope_smoke screenshot's `t = 14.97 s` state. The rotor's
+    /// norm-squared must stay near 1; visible drift here would mean
+    /// vertices grow / shrink under sustained spin (suspect for the
+    /// "polytopes appear to grow" symptom).
+    #[test]
+    #[ignore = "rotor4 multiplicative drift — see issue #TBD"]
+    fn rotor4_compound_integration_preserves_unit_norm_over_900_steps() {
+        let omega = Bivector4::new(1.0, 1.0, 1.0, 1.0, 0.0, 0.0);
+        let dt = 1.0 / 60.0;
+        let delta = (omega * dt).exp();
+        let mut r = Rotor4::IDENTITY;
+        for _ in 0..900 {
+            r = delta * r;
+        }
+        let n2 = r.norm_squared();
+        assert!(
+            (n2 - 1.0).abs() < 1e-3,
+            "rotor norm drifted after 900 compositions: |R|² = {n2}",
+        );
+    }
+
+    /// Vertex-level invariant for the polytope-smoke "are the shapes
+    /// growing?" question: a unit-radius polytope vertex started at
+    /// `(1, 0, 0, 0)` must stay at radius 1 after sustained
+    /// integration. Length drift here would expand the rendered
+    /// cross-section even for pure 3D rotations. Tests **raw**
+    /// composition without intermediate `.normalize()` to catch
+    /// algebraic drift in the geometric product itself.
+    #[test]
+    #[ignore = "rotor4 multiplicative drift — see issue #TBD"]
+    fn polytope_vertex_stays_on_unit_hypersphere_over_900_steps() {
+        let omega = Bivector4::new(1.0, 1.0, 1.0, 1.0, 0.0, 0.0);
+        let dt = 1.0 / 60.0;
+        let delta = (omega * dt).exp();
+        let mut r = Rotor4::IDENTITY;
+        for _ in 0..900 {
+            r = delta * r;
+        }
+        for v0 in [
+            Vec4::X,
+            Vec4::Y,
+            Vec4::Z,
+            Vec4::W,
+            Vec4::new(0.5, 0.5, 0.5, 0.5), // tesseract vertex (radius 1)
+        ] {
+            let v_rotated = r.apply(v0);
+            let l0 = v0.length();
+            let l_rot = v_rotated.length();
+            assert!(
+                (l_rot - l0).abs() < 5e-3,
+                "vertex length drift over 900 steps: {v0:?} (|v|={l0}) → {v_rotated:?} (|Rv|={l_rot})",
+            );
+        }
+    }
+
+    /// Same 900-step integration but **with `.normalize()` after each
+    /// composition**, mirroring the actual integrator path in
+    /// `rye_physics::euclidean_r4::integrate_orientation`. If this
+    /// fails, the polytope-smoke "shapes growing" symptom is the
+    /// visible bug; if this passes, the integrator's existing
+    /// normalize handles the algebraic drift the previous test
+    /// catches and the visual issue is somewhere else (cross-section
+    /// shape change, dispatcher inverse rotor, etc.).
+    #[test]
+    #[ignore = "rotor4 multiplicative drift — see issue #TBD"]
+    fn polytope_vertex_stays_on_unit_hypersphere_with_normalize_path() {
+        let omega = Bivector4::new(1.0, 1.0, 1.0, 1.0, 0.0, 0.0);
+        let dt = 1.0 / 60.0;
+        let delta = (omega * dt).exp();
+        let mut r = Rotor4::IDENTITY;
+        for _ in 0..900 {
+            r = (delta * r).normalize();
+        }
+        for v0 in [
+            Vec4::X,
+            Vec4::Y,
+            Vec4::Z,
+            Vec4::W,
+            Vec4::new(0.5, 0.5, 0.5, 0.5),
+        ] {
+            let v_rotated = r.apply(v0);
+            let l0 = v0.length();
+            let l_rot = v_rotated.length();
+            assert!(
+                (l_rot - l0).abs() < 5e-3,
+                "normalized-path vertex length drift over 900 steps: \
+                 {v0:?} (|v|={l0}) → {v_rotated:?} (|Rv|={l_rot})",
+            );
+        }
+    }
+
     /// `Bivector4::contract_vec` is the **Clifford left-contraction**
     /// `B ⌋ v` (grade-1 part of `B · v`), not the physics-side
     /// `ω × r`. This test pins down the sign convention so the

--- a/crates/rye-math/src/bivector.rs
+++ b/crates/rye-math/src/bivector.rs
@@ -748,8 +748,12 @@ impl Mul for Rotor4 {
         //   e23·I = −e14, e24·I = +e13, e34·I = −e12.
         // (Left-multiplication by I has the same signs since I
         // commutes with every bivector in G(4,0).)
-        let xy = a0 * b12 + a12 * b0 - a13 * b23 + a14 * b24 + a23 * b13
-            - a24 * b14
+        // Bivector-bivector contributions to `e12`:
+        //   e13·e23 = -e12, e23·e13 = +e12, e14·e24 = -e12, e24·e14 = +e12.
+        // The previous version had the e14·e24 / e24·e14 pair's signs
+        // swapped, which produced visible drift under sustained rotation
+        // by non-simple bivectors mixing w-planes (issue #37).
+        let xy = a0 * b12 + a12 * b0 - a13 * b23 + a23 * b13 - a14 * b24 + a24 * b14
             - a34 * b_i
             - a_i * b34;
         let xz = a0 * b13 + a13 * b0 + a12 * b23 - a14 * b34 - a23 * b12
@@ -1532,9 +1536,11 @@ mod tests {
     /// bivectors that include w-mixing planes.
     ///
     /// `omega = e_xy + e_xz + e_xw + e_yz` is the exact bivector the
-    /// user's failing screenshot has active.
+    /// failing-screenshot polytope_smoke run had active. Regression
+    /// gate for the issue #37 fix in `Rotor4::mul` (the e14·e24 /
+    /// e24·e14 pair's signs in the e12 output were swapped). Pre-fix
+    /// drift was ~1.3%; post-fix it sits at f32 noise (~5e-7).
     #[test]
-    #[ignore = "rotor4 multiplicative drift — see issue #TBD"]
     fn rotor4_compound_xy_xz_xw_yz_integrated_matches_closed_form() {
         let omega = Bivector4::new(1.0, 1.0, 1.0, 1.0, 0.0, 0.0);
         let dt = 1.0 / 60.0;
@@ -1562,8 +1568,12 @@ mod tests {
             let via_integrated = integrated.apply(v);
             let via_closed = closed_form.apply(v);
             let diff = (via_integrated - via_closed).length();
+            // 1e-5 gives ~20x headroom over the post-fix f32 noise
+            // floor (observed: ~5e-7). Tight enough to catch a
+            // regression of the e12-component sign error; loose
+            // enough to survive cross-machine f32 variation.
             assert!(
-                diff < 5e-3,
+                diff < 1e-5,
                 "compound xy+xz+xw+yz integration drift: v={v:?} \
                  integrated={via_integrated:?} closed={via_closed:?} \
                  diff={diff}",
@@ -1577,7 +1587,6 @@ mod tests {
     /// vertices grow / shrink under sustained spin (suspect for the
     /// "polytopes appear to grow" symptom).
     #[test]
-    #[ignore = "rotor4 multiplicative drift — see issue #TBD"]
     fn rotor4_compound_integration_preserves_unit_norm_over_900_steps() {
         let omega = Bivector4::new(1.0, 1.0, 1.0, 1.0, 0.0, 0.0);
         let dt = 1.0 / 60.0;
@@ -1587,8 +1596,11 @@ mod tests {
             r = delta * r;
         }
         let n2 = r.norm_squared();
+        // Post-fix observed: |R|² ≈ 1.0 + 2.3e-6 after 900 raw
+        // multiplications (no normalize). Pre-fix the bug pushed it
+        // to 25.4. 1e-5 is a comfortable post-fix gate.
         assert!(
-            (n2 - 1.0).abs() < 1e-3,
+            (n2 - 1.0).abs() < 1e-5,
             "rotor norm drifted after 900 compositions: |R|² = {n2}",
         );
     }
@@ -1601,7 +1613,6 @@ mod tests {
     /// composition without intermediate `.normalize()` to catch
     /// algebraic drift in the geometric product itself.
     #[test]
-    #[ignore = "rotor4 multiplicative drift — see issue #TBD"]
     fn polytope_vertex_stays_on_unit_hypersphere_over_900_steps() {
         let omega = Bivector4::new(1.0, 1.0, 1.0, 1.0, 0.0, 0.0);
         let dt = 1.0 / 60.0;
@@ -1620,9 +1631,11 @@ mod tests {
             let v_rotated = r.apply(v0);
             let l0 = v0.length();
             let l_rot = v_rotated.length();
+            // Pre-fix: vertex grew to ~16.4. Post-fix: drift sits at
+            // ~2e-6 from f32 accumulation over 900 raw composes.
             assert!(
-                (l_rot - l0).abs() < 5e-3,
-                "vertex length drift over 900 steps: {v0:?} (|v|={l0}) → {v_rotated:?} (|Rv|={l_rot})",
+                (l_rot - l0).abs() < 1e-5,
+                "vertex length drift over 900 steps: {v0:?} (|v|={l0}) -> {v_rotated:?} (|Rv|={l_rot})",
             );
         }
     }
@@ -1636,7 +1649,6 @@ mod tests {
     /// catches and the visual issue is somewhere else (cross-section
     /// shape change, dispatcher inverse rotor, etc.).
     #[test]
-    #[ignore = "rotor4 multiplicative drift — see issue #TBD"]
     fn polytope_vertex_stays_on_unit_hypersphere_with_normalize_path() {
         let omega = Bivector4::new(1.0, 1.0, 1.0, 1.0, 0.0, 0.0);
         let dt = 1.0 / 60.0;
@@ -1655,10 +1667,15 @@ mod tests {
             let v_rotated = r.apply(v0);
             let l0 = v0.length();
             let l_rot = v_rotated.length();
+            // Pre-fix (with normalize): vertex shrunk to ~0.65 because
+            // normalization to a unit 8-sphere is the wrong manifold
+            // when the rotor itself was wrong. Post-fix the drift is
+            // essentially zero (the normalize re-projects onto the
+            // correct manifold each step).
             assert!(
-                (l_rot - l0).abs() < 5e-3,
+                (l_rot - l0).abs() < 1e-5,
                 "normalized-path vertex length drift over 900 steps: \
-                 {v0:?} (|v|={l0}) → {v_rotated:?} (|Rv|={l_rot})",
+                 {v0:?} (|v|={l0}) -> {v_rotated:?} (|Rv|={l_rot})",
             );
         }
     }


### PR DESCRIPTION
Closes issue #37 — visible polytope-growth drift in polytope_smoke under sustained 4D rotation by non-simple bivectors that mix w-planes.

## Root cause

Two sign errors in `Rotor4::mul`'s computation of the `xy` (e12) output component, in the bivector-bivector cross-term contributions:

- `e14 · e24` evaluates to `-e12` (verifiable: `e1·e4·e2·e4 = -e1·e2·e4·e4 = -e12`), so the contribution to xy should be `-a14·b24`. The code had `+a14·b24`.
- `e24 · e14` evaluates to `+e12`, so the contribution should be `+a24·b14`. The code had `-a24·b14`.

The signs of the two terms were swapped relative to each other; magnitudes were correct. Other 5 bivector components (xz, xw, yz, yw, zw) and the pseudoscalar all check out.

## Why the bug was so visible

Sustained `Rotor4 * Rotor4` composition (per-frame integration) accumulates the per-step error. Pre-fix:

- 1 second of integration: ~1.3% drift from closed-form `(omega·t).exp()`.
- 900 raw multiplications: `\|R\|² = 25.4`, vertex length 16.4.
- 900 multiplications with `.normalize()` each step: vertex length 0.65 (because normalization to a unit 8-sphere is the wrong manifold when the rotor itself is wrong).

The single-plane and isoclinic test paths passed because they don't exercise the e14·e24 cross-terms.

## What this PR does

1. **Fixes the two signs** in `Rotor4::mul`, with an explanatory comment naming the issue.
2. **Un-ignores the four diagnostic tests** that were added in the previous commit on this branch, since they now pass at f32-noise levels.
3. **Tightens the diagnostic tolerances** from the post-bug-spec values (5e-3, 1e-3) down to `1e-5` across the board, matching the post-fix observed drift floor with ~20x headroom for cross-machine f32 variation.
4. **Updates the test docstrings** to describe what they pin (regression gates), with the pre-fix vs post-fix drift numbers inline.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (43 bivector tests pass, 0 ignored)
- [x] `cargo test gpu_probe -- --include-ignored` (lavapipe GPU parity probes still green)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace`
- [ ] **Eyes-on**: run `cargo run --release --example polytope_smoke -- --shapes pentatope tesseract 16-cell 24-cell` with the `xy + xz + xw + yz` plane combination active for 30+ seconds and confirm the polytopes stop visibly growing. Tracking this as the explicit visual-verification gate per CONVENTIONS.

## Issue #17 (lensing) hypothesis

Issue #17's "dimples on the floor where polytopes overlap" symptom is plausibly downstream of this bug: the polytope SDF in WGSL evaluates the per-shape SDF at body-local coordinates produced by `rotor4_inverse_apply`. With the rotor wrong, `local_v` is wrong, and the SDF returns near-zero values at xy positions where the polytope isn't actually close to the slice plane — false hits on the floor's surface. Recommend retesting #17 after this lands and closing as fixed-by-#37 if the dimples are gone. The WGSL `rotor4_inverse_apply` itself is structurally identical to the (correct) CPU `Rotor4::apply`, so no separate WGSL fix is needed.