### PR TITLE
chore: docs, tests, intra-doc fixes, half-space guard, Esc opt-in, cargo-doc CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,26 @@ jobs:
         env:
           WGPU_BACKEND: vulkan
         run: cargo test --workspace gpu_probe -- --include-ignored
+
+  doc:
+    name: cargo doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Linux deps for wgpu/winit
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwayland-dev libxkbcommon-dev libxkbcommon-x11-dev \
+            libx11-dev libxi-dev libxcursor-dev libxrandr-dev \
+            pkg-config
+      # `--no-deps` keeps the run fast and limits failures to our own
+      # docs. `RUSTDOCFLAGS=-D warnings` makes broken intra-doc links
+      # and missing-code-block-language warnings fail the build;
+      # docstring drift is otherwise invisible until a reader hits it.
+      - name: cargo doc --no-deps --workspace
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --workspace

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -238,6 +238,16 @@ pub struct RunConfig {
     /// `RUST_LOG` env var); `Some` installs a new global default
     /// subscriber.
     pub log_filter: Option<String>,
+    /// When true (default) the framework exits the event loop on
+    /// `Esc`. Apps that bind `Esc` to a gameplay action (pause,
+    /// menu, modal dismiss) set this to false and handle the key
+    /// inside [`App::on_event`].
+    pub esc_exits: bool,
+    /// Bail out after this many consecutive [`App::render`] errors.
+    /// The last error surfaces back through [`run_with_config`]'s
+    /// `Result` instead of looping forever on a wedged GPU. Reset to
+    /// zero on any successful frame. `0` disables the budget.
+    pub render_error_budget: u32,
 }
 
 impl Default for RunConfig {
@@ -249,6 +259,8 @@ impl Default for RunConfig {
             fixed_hz: 60,
             max_ticks_per_frame: 4,
             log_filter: None,
+            esc_exits: true,
+            render_error_budget: 8,
         }
     }
 }
@@ -313,6 +325,9 @@ struct Runner<A: App> {
     fps: f32,
 
     tick_index: u64,
+    /// Consecutive `App::render` failures since the last successful
+    /// frame. Compared against `RunConfig::render_error_budget`.
+    render_error_streak: u32,
     /// Surfaced to the user via `finish()` if the runner exited
     /// because of a setup or render error, so callers can
     /// propagate it from `main`.
@@ -337,6 +352,7 @@ impl<A: App> Runner<A> {
             frame_count: 0,
             fps: 0.0,
             tick_index: 0,
+            render_error_streak: 0,
             deferred_error: None,
         }
     }
@@ -433,7 +449,8 @@ impl<A: App> ApplicationHandler for Runner<A> {
                 return;
             }
             WindowEvent::KeyboardInput { event, .. }
-                if event.state == ElementState::Pressed
+                if self.config.esc_exits
+                    && event.state == ElementState::Pressed
                     && matches!(event.logical_key, Key::Named(NamedKey::Escape)) =>
             {
                 elwt.exit();
@@ -571,12 +588,27 @@ impl<A: App> Runner<A> {
         // 5. Render.
         match rd.begin_frame() {
             Ok((frame, view)) => {
+                let mut last_err: Option<anyhow::Error> = None;
                 if let Some(app) = self.app.as_mut() {
                     if let Err(e) = app.render(rd, &view) {
                         tracing::error!("App::render error: {e:#}");
+                        last_err = Some(e);
                     }
                 }
                 frame.present();
+                if let Some(err) = last_err {
+                    self.render_error_streak = self.render_error_streak.saturating_add(1);
+                    let budget = self.config.render_error_budget;
+                    if budget > 0 && self.render_error_streak >= budget {
+                        self.deferred_error = Some(err.context(format!(
+                            "App::render failed {budget} consecutive frames; aborting"
+                        )));
+                        elwt.exit();
+                        return;
+                    }
+                } else {
+                    self.render_error_streak = 0;
+                }
                 win.request_redraw();
             }
             Err(err) => match err {

--- a/crates/rye-asset/src/watcher.rs
+++ b/crates/rye-asset/src/watcher.rs
@@ -73,7 +73,7 @@ impl AssetWatcher {
     /// Drain all pending events, deduplicating per path.
     ///
     /// When the same path produces multiple events since the last poll,
-    /// they are merged with [`merge_kinds`]: `Created` beats `Modified`
+    /// they are merged: `Created` beats `Modified`
     /// (a new file should look new, not merely modified), otherwise the
     /// later event wins. Events that aren't create/modify/remove
     /// (access, metadata, other) are dropped.
@@ -82,7 +82,12 @@ impl AssetWatcher {
 
         while let Ok(res) = self.rx.try_recv() {
             let Ok(event) = res else {
-                tracing::debug!("notify error: {:?}", res.err());
+                // `warn` (not `debug`) because notify errors are usually
+                // platform-watcher failures (handle exhaustion on Windows,
+                // permission denied, dropped events) that silently degrade
+                // hot-reload. A user not seeing reloads should at least
+                // see something in stderr.
+                tracing::warn!("notify error: {:?}", res.err());
                 continue;
             };
             let kind = match event.kind {

--- a/crates/rye-asset/tests/watcher.rs
+++ b/crates/rye-asset/tests/watcher.rs
@@ -80,6 +80,46 @@ fn reports_modified_file() {
     );
 }
 
+/// `Removed` event fires end-to-end when a watched file is deleted.
+/// Pinned because the merge logic in `watcher.rs::merge_kinds`
+/// special-cases Created/Modified bursts but a delete should pass
+/// through cleanly.
+///
+/// Compares by file name + parent-directory containment (not
+/// `canonicalize`-equality) because `canonicalize` fails on a
+/// removed path, and on Windows the notify-reported path lacks the
+/// `\\?\` verbatim prefix that `canonicalize` would add.
+#[test]
+fn reports_removed_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("doomed.txt");
+    fs::write(&file, b"goodbye").unwrap();
+    let target_name = file.file_name().unwrap().to_owned();
+    let dir_canonical = dir.path().canonicalize().unwrap();
+
+    let mut watcher = AssetWatcher::new().unwrap();
+    watcher.watch(dir.path()).unwrap();
+    // Drain the Created event from the initial setup.
+    let _ = watcher.poll();
+
+    fs::remove_file(&file).unwrap();
+
+    wait_for(&watcher, Duration::from_secs(3), |ev| {
+        if ev.kind != AssetEventKind::Removed {
+            return false;
+        }
+        // Match by file name; verify the parent is the watched dir
+        // (canonicalise the *parent*; that path still exists).
+        ev.path.file_name() == Some(&target_name)
+            && ev
+                .path
+                .parent()
+                .and_then(|p| p.canonicalize().ok())
+                .map(|p| p == dir_canonical)
+                .unwrap_or(false)
+    });
+}
+
 #[test]
 fn poll_is_empty_when_no_changes() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/rye-camera/src/camera.rs
+++ b/crates/rye-camera/src/camera.rs
@@ -69,7 +69,7 @@ impl<S: Space<Point = Vec3, Vector = Vec3>> Camera<S> {
     /// Default-ish camera: at the origin, looking down −Z, with
     /// 60° vertical FOV and a sensible near/far for unit-scale
     /// scenes. Most callers want a controller to overwrite the
-    /// pose immediately; this exists so [`Camera::default`] is a
+    /// pose immediately; this exists so a "default" camera is a
     /// thing for `S` instances that can't auto-derive `Default`.
     pub fn at_origin() -> Self {
         Self {
@@ -226,5 +226,63 @@ mod tests {
         let mut cam = Camera::<EuclideanR3>::at_origin();
         cam.translate(Vec3::X, 2.5, &space);
         close(cam.view().position, Vec3::new(2.5, 0.0, 0.0), 1e-6);
+    }
+
+    /// `translate` in H³ must keep the position inside the Poincaré
+    /// ball and the basis finite + ≈orthonormal after parallel
+    /// transport. Catches NaN drift in `Space::exp` /
+    /// `parallel_transport_along` for `HyperbolicH3`.
+    #[test]
+    fn translate_in_hyperbolic_h3_stays_in_ball_and_orthonormal() {
+        use rye_math::HyperbolicH3;
+        let space = HyperbolicH3;
+        let mut cam = Camera::<HyperbolicH3>::at_origin();
+        // Step in +X for half a second at unit Riemannian speed.
+        cam.translate(Vec3::X, 0.5, &space);
+        assert!(
+            cam.position.length() < 1.0,
+            "camera escaped Poincaré ball: {:?}",
+            cam.position
+        );
+        assert!(cam.right.is_finite());
+        assert!(cam.up.is_finite());
+        assert!(cam.forward.is_finite());
+        // Frame remains ≈orthonormal (transport + renormalise above).
+        assert!((cam.right.length() - 1.0).abs() < 1e-3);
+        assert!((cam.up.length() - 1.0).abs() < 1e-3);
+        assert!((cam.forward.length() - 1.0).abs() < 1e-3);
+        assert!(cam.right.dot(cam.up).abs() < 1e-3);
+        assert!(cam.right.dot(cam.forward).abs() < 1e-3);
+        assert!(cam.up.dot(cam.forward).abs() < 1e-3);
+    }
+
+    /// `looking_at` with `position == target` has no defined forward
+    /// direction (`log = 0`). The fallback should produce a finite,
+    /// orthonormal frame rather than NaN/inf.
+    #[test]
+    fn looking_at_collapsed_target_falls_back_to_finite_frame() {
+        let cam = Camera::<EuclideanR3>::looking_at(Vec3::ZERO, Vec3::ZERO, Vec3::Y, &EuclideanR3);
+        assert!(cam.forward.is_finite() && cam.right.is_finite() && cam.up.is_finite());
+        // Frame is unit-length; the exact direction is unspecified
+        // (fallback), only finiteness is guaranteed.
+        assert!((cam.forward.length() - 1.0).abs() < 1e-6);
+        assert!((cam.right.length() - 1.0).abs() < 1e-6);
+        assert!((cam.up.length() - 1.0).abs() < 1e-6);
+    }
+
+    /// `looking_at` where `forward` is parallel to `world_up` makes
+    /// `forward × world_up = 0`. The fallback `right` keeps the frame
+    /// finite even though it can't be derived from the cross product.
+    #[test]
+    fn looking_at_world_up_parallel_to_forward_falls_back() {
+        let cam = Camera::<EuclideanR3>::looking_at(
+            Vec3::new(0.0, 0.0, 0.0),
+            // Look straight up; world_up is also +Y, so cross is zero.
+            Vec3::new(0.0, 1.0, 0.0),
+            Vec3::Y,
+            &EuclideanR3,
+        );
+        assert!(cam.forward.is_finite() && cam.right.is_finite() && cam.up.is_finite());
+        assert!((cam.right.length() - 1.0).abs() < 1e-6);
     }
 }

--- a/crates/rye-camera/src/controller.rs
+++ b/crates/rye-camera/src/controller.rs
@@ -195,6 +195,10 @@ impl<S: Space<Point = Vec3, Vector = Vec3>> CameraController<S> for OrbitControl
 /// Use by setting `camera.position` directly each frame (or via
 /// player physics), then calling `advance` to update the basis
 /// from yaw/pitch.
+///
+/// `advance` always integrates the mouse delta; pointer-locked
+/// windows just call it every frame. Apps that want hold-to-look
+/// gate the call themselves (`if input.left_mouse_down { ctrl.advance(...) }`).
 #[derive(Clone, Copy, Debug, Default)]
 pub struct FirstPersonController<S: Space> {
     pub yaw: f32,

--- a/crates/rye-camera/src/lib.rs
+++ b/crates/rye-camera/src/lib.rs
@@ -140,7 +140,7 @@ impl OrbitCamera {
 // ---------------------------------------------------------------------------
 
 /// Free-look first-person camera. The caller owns the position (e.g. inside a
-/// [`rye_player::PlayerState`]); this type tracks only yaw and pitch.
+/// `rye_player::PlayerState`); this type tracks only yaw and pitch.
 ///
 /// Call [`FirstPersonCamera::advance_look`] with the frame's mouse delta, then
 /// [`FirstPersonCamera::view`] with the current world position.
@@ -167,9 +167,13 @@ impl FirstPersonCamera {
         }
     }
 
-    /// Rotate look direction from mouse delta. Only applies when right mouse
-    /// is held; callers may gate on `input.left_mouse_down` or always call it
-    /// for pointer-locked windows.
+    /// Rotate look direction from mouse delta. Always integrates the
+    /// delta, so pointer-locked windows just call it every frame.
+    /// Callers that want a hold-to-look UX wrap the call in their own
+    /// `if input.left_mouse_down { ... }` (or right-button gate); doing
+    /// it inside the controller would force the always-on case to
+    /// fight against gating, which is the more common mode in
+    /// SDF-render demos.
     pub fn advance_look(&mut self, input: FrameInput) {
         self.yaw -= input.mouse_delta.x * FIRST_PERSON_MOUSE_SENSITIVITY;
         self.pitch = (self.pitch - input.mouse_delta.y * FIRST_PERSON_MOUSE_SENSITIVITY)

--- a/crates/rye-input/src/lib.rs
+++ b/crates/rye-input/src/lib.rs
@@ -1,3 +1,28 @@
+//! Per-frame input accumulator. Routes raw winit events into a
+//! [`FrameInput`] snapshot the rest of the engine consumes.
+//!
+//! ## Drain semantic
+//!
+//! [`InputState`] accumulates mouse motion / scroll / key state as
+//! winit events arrive. [`InputState::take_frame`] returns the
+//! current snapshot **and resets the per-tick deltas** (mouse delta,
+//! scroll lines): callers see exactly the motion that happened
+//! since the last drain. Held state (button-down, WASD axes) is
+//! preserved across drains so a user holding a key continues to
+//! produce non-zero `move_*` until they release.
+//!
+//! ## Focus / cursor-loss contract
+//!
+//! Window focus loss and cursor exit are handled by
+//! [`InputState::cursor_invalidated`] (called from the framework's
+//! `WindowEvent::CursorLeft` / `Focused(false)` branches). It zeroes
+//! the cursor-relative state to avoid a snap when the cursor
+//! re-enters at a different position. [`InputState::release_buttons`]
+//! is similarly called on focus loss to drop held buttons cleanly.
+//! Apps that bind their own keyboard handling should call
+//! [`InputState::release_buttons`] when their gameplay needs the
+//! same clean-on-defocus semantic.
+
 use glam::{Vec2, Vec3};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};
 use winit::keyboard::{KeyCode, PhysicalKey};

--- a/crates/rye-math/src/bivector.rs
+++ b/crates/rye-math/src/bivector.rs
@@ -457,7 +457,7 @@ impl Bivector4 {
     /// **Note for physics callers**: rigid-body dynamics wants
     /// `ω × r` with the *opposite* sign, `e_xy` "applied to" `e_x`
     /// should give `+e_y`, since rotating in the +xy plane sends the
-    /// +x axis toward +y. Use [`crate::euclidean_r4::omega_cross_r`]
+    /// +x axis toward +y. Use `rye_physics::euclidean_r4::omega_cross_r`
     /// (or just negate the result of this function) when you want
     /// the physics convention. Keeping the math primitive
     /// Clifford-pure means future generic-`N` callers and the

--- a/crates/rye-math/src/blended.rs
+++ b/crates/rye-math/src/blended.rs
@@ -42,10 +42,9 @@ use crate::space::{Space, WgslSpace};
 ///   f(p) = 4/(1-|p|²)², valid for |p| < 1.
 /// - [`crate::SphericalS3`] (stereographic model):
 ///   f(p) = 4/(1+|p|²)².
-/// - [`HyperbolicH3UpperHalf`] (upper-half-space, *future*,
+/// - `HyperbolicH3UpperHalf` (upper-half-space, *future*,
 ///   lands when the BlendedSpace demo needs an *unbounded* E³
-///   side; see [`docs/devlog/BLENDED_SPACE.md`](../../../../docs/devlog/BLENDED_SPACE.md)):
-///   f(p) = 1/z², valid for z > 0.
+///   side): f(p) = 1/z², valid for z > 0.
 ///
 /// **Why a separate trait, not a method on `Space`:** not every
 /// Space is conformally flat. Sol³ and Nil³ (two of Thurston's

--- a/crates/rye-physics/src/body.rs
+++ b/crates/rye-physics/src/body.rs
@@ -42,6 +42,18 @@ impl<S: PhysicsSpace> RigidBody<S> {
         inertia: S::Inertia,
         space: &S,
     ) -> Self {
+        // Half-spaces are infinite planes; a finite mass with infinite
+        // extent breaks the integrator's assumptions (no centre of mass,
+        // no bounded inertia). Static-only is the only sensible mode;
+        // catch the misuse in debug builds before it produces silently
+        // wrong physics in release.
+        debug_assert!(
+            !matches!(
+                collider,
+                Collider::HalfSpace { .. } | Collider::HalfSpace4D { .. }
+            ) || mass <= 0.0,
+            "half-space colliders must be static (mass <= 0); got mass = {mass}"
+        );
         let inv_mass = if mass > 0.0 { 1.0 / mass } else { 0.0 };
         Self {
             position,
@@ -72,5 +84,70 @@ impl<S: PhysicsSpace> RigidBody<S> {
             collider,
             restitution: 0.2,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::{Vec3, Vec4};
+    use rye_math::{EuclideanR3, EuclideanR4};
+
+    #[test]
+    fn dynamic_halfspace_3d_panics_in_debug() {
+        let result = std::panic::catch_unwind(|| {
+            RigidBody::<EuclideanR3>::new(
+                Vec3::ZERO,
+                Vec3::ZERO,
+                Collider::HalfSpace {
+                    normal: Vec3::Y,
+                    offset: 0.0,
+                },
+                1.0,
+                1.0,
+                &EuclideanR3,
+            )
+        });
+        assert!(
+            result.is_err(),
+            "expected debug_assert to fire on dynamic 3D half-space"
+        );
+    }
+
+    #[test]
+    fn dynamic_halfspace_4d_panics_in_debug() {
+        let result = std::panic::catch_unwind(|| {
+            RigidBody::<EuclideanR4>::new(
+                Vec4::ZERO,
+                Vec4::ZERO,
+                Collider::HalfSpace4D {
+                    normal: Vec4::Y,
+                    offset: 0.0,
+                },
+                1.0,
+                1.0,
+                &EuclideanR4,
+            )
+        });
+        assert!(
+            result.is_err(),
+            "expected debug_assert to fire on dynamic 4D half-space"
+        );
+    }
+
+    #[test]
+    fn static_halfspace_4d_is_allowed() {
+        // Mass = 0 means static; the guard must not fire.
+        let _ = RigidBody::<EuclideanR4>::new(
+            Vec4::ZERO,
+            Vec4::ZERO,
+            Collider::HalfSpace4D {
+                normal: Vec4::Y,
+                offset: 0.0,
+            },
+            0.0,
+            1.0,
+            &EuclideanR4,
+        );
     }
 }

--- a/crates/rye-physics/src/collision/epa_r4.rs
+++ b/crates/rye-physics/src/collision/epa_r4.rs
@@ -1,6 +1,6 @@
 //! EPA in R⁴, Expanding Polytope for 4D penetration depth.
 //!
-//! Parallel to [`super::epa`] (3D) with three dimensionality changes:
+//! Parallel to [`super::epa`][mod@super::epa] (3D) with three dimensionality changes:
 //!
 //! 1. **Faces** are tetrahedra (3-simplices, 4 vertex indices), not
 //!    triangles.

--- a/crates/rye-physics/src/collision/gjk.rs
+++ b/crates/rye-physics/src/collision/gjk.rs
@@ -15,7 +15,7 @@
 //! This module is the 3D specialization: a simplex can be at most a
 //! tetrahedron (4 points). The Voronoi-region logic for the
 //! line → triangle → tetrahedron cases is hand-written. The support-
-//! function side is generic over [`VectorOps`], so when 4D lands,
+//! function side is generic over `VectorOps`, so when 4D lands,
 //! only the simplex-case logic needs a 4D cousin (pentachoron = 5
 //! points); the support-function path, the iteration loop, and all
 //! the numerics are shared.

--- a/crates/rye-physics/src/collision/mod.rs
+++ b/crates/rye-physics/src/collision/mod.rs
@@ -7,7 +7,7 @@
 //!   for convex shapes via their Minkowski difference. Used for
 //!   polytope-polytope narrowphase where analytical solutions
 //!   (sphere-sphere, sphere-halfspace) don't apply.
-//! - [`epa`] / [`epa_r4`]: Expanding Polytope Algorithm for
+//! - [`epa`][mod@self::epa] / [`epa_r4`][mod@self::epa_r4]: Expanding Polytope Algorithm for
 //!   penetration depth and contact normal from a GJK-terminating
 //!   simplex.
 //! - [`simplex_r4`]: closest-point-on-simplex via Gram-matrix

--- a/crates/rye-physics/src/euclidean_r4.rs
+++ b/crates/rye-physics/src/euclidean_r4.rs
@@ -1,12 +1,12 @@
 //! `impl PhysicsSpace for EuclideanR4`, 4D Euclidean rigid-body physics.
 //!
-//! Angular velocity is a [`Bivector4`] (six rotation-plane components);
+//! Angular velocity is a `Bivector4` (six rotation-plane components);
 //! inertia is the scalar moment for isotropic bodies, same pragmatic
 //! simplification made in 3D. A full 4D inertia tensor is a 6×6
 //! bivector-to-bivector map, it doesn't land until an actual anisotropic
 //! 4D body demands it.
 //!
-//! Orientation integration uses [`Rotor4`] directly. The Clifford-rotor
+//! Orientation integration uses `Rotor4` directly. The Clifford-rotor
 //! multiplication convention is "left operand applied first" (opposite to
 //! `glam::Quat`'s "right first"), so the composed orientation after a
 //! timestep is `rotation_new = rotation_current * delta_rotor`.

--- a/crates/rye-player/src/lib.rs
+++ b/crates/rye-player/src/lib.rs
@@ -1,3 +1,21 @@
+//! Space-generic first-person player controller. Reads
+//! [`rye_input::FrameInput`] and advances a position along the
+//! ambient [`rye_math::Space`]'s geodesics, matched against a yaw
+//! angle for facing.
+//!
+//! Movement convention: WASD drives forward/back/strafe relative to
+//! the player's yaw; Space / Shift drive world-Y up/down. The tangent
+//! vector is built in the Space's chart coordinates, then `space.exp`
+//! integrates it for one tick of motion. In Euclidean Spaces this
+//! collapses to `position += tangent * speed`; in curved Spaces the
+//! geodesic step bends the path naturally without further work in
+//! the controller.
+//!
+//! Yaw is kept as an explicit `f32` (not a rotor) because the
+//! player's facing only ever rotates about the Y axis here. A 4D
+//! player or a player that needs full rotor orientation would use
+//! a different controller.
+
 use glam::Vec3;
 use rye_input::FrameInput;
 use rye_math::Space;
@@ -106,5 +124,109 @@ mod tests {
             0.002,
         );
         assert_close(player.yaw, -0.2);
+    }
+
+    /// W+D should travel `speed` units along the geodesic, not
+    /// `sqrt(2) * speed`. The tangent vector is the diagonal of forward
+    /// and right; without normalization, diagonal motion would be
+    /// faster than axis-aligned motion.
+    #[test]
+    fn advance_diagonal_input_speed_matches_axis_aligned_speed() {
+        let mut player: PlayerState<EuclideanR3> = PlayerState::new(Vec3::ZERO);
+        player.advance(
+            &FrameInput {
+                move_forward: 1.0,
+                move_right: 1.0,
+                ..FrameInput::default()
+            },
+            &EuclideanR3,
+            1.0,
+        );
+        assert_close(player.position.length(), 1.0);
+    }
+
+    #[test]
+    fn advance_move_up_lifts_player_along_world_y() {
+        let mut player: PlayerState<EuclideanR3> = PlayerState::new(Vec3::ZERO);
+        player.advance(
+            &FrameInput {
+                move_up: 1.0,
+                ..FrameInput::default()
+            },
+            &EuclideanR3,
+            1.0,
+        );
+        assert_close(player.position.x, 0.0);
+        assert_close(player.position.y, 1.0);
+        assert_close(player.position.z, 0.0);
+    }
+
+    #[test]
+    fn with_yaw_rotates_forward_direction() {
+        // yaw = +π/2 rotates forward from −Z to −X.
+        let mut player: PlayerState<EuclideanR3> =
+            PlayerState::new(Vec3::ZERO).with_yaw(std::f32::consts::FRAC_PI_2);
+        player.advance(
+            &FrameInput {
+                move_forward: 1.0,
+                ..FrameInput::default()
+            },
+            &EuclideanR3,
+            1.0,
+        );
+        assert_close(player.position.x, -1.0);
+        assert_close(player.position.y, 0.0);
+        assert_close(player.position.z, 0.0);
+    }
+
+    /// W in H³ from the origin moves along the ambient axis but the
+    /// resulting position must stay strictly inside the Poincaré ball
+    /// (`|p| < 1`), and the geodesic step is shorter than the
+    /// Euclidean equivalent because H³ stretches distance away from the
+    /// origin.
+    #[test]
+    fn advance_in_hyperbolic_h3_stays_inside_ball() {
+        use rye_math::HyperbolicH3;
+        let mut player: PlayerState<HyperbolicH3> = PlayerState::new(Vec3::ZERO);
+        player.advance(
+            &FrameInput {
+                move_forward: 1.0,
+                ..FrameInput::default()
+            },
+            &HyperbolicH3,
+            0.5,
+        );
+        assert!(player.position.is_finite());
+        assert!(
+            player.position.length() < 1.0,
+            "player escaped Poincaré ball: {:?}",
+            player.position
+        );
+        // Forward at yaw=0 is −Z, so motion is purely in −Z.
+        assert_close(player.position.x, 0.0);
+        assert_close(player.position.y, 0.0);
+        assert!(player.position.z < 0.0);
+    }
+
+    /// Same shape in S³: position must stay inside the unit-3-sphere
+    /// embedding (`|p| < 1`) and motion direction is consistent with
+    /// the −Z forward convention.
+    #[test]
+    fn advance_in_spherical_s3_stays_inside_embedding() {
+        use rye_math::SphericalS3;
+        let mut player: PlayerState<SphericalS3> = PlayerState::new(Vec3::ZERO);
+        player.advance(
+            &FrameInput {
+                move_forward: 1.0,
+                ..FrameInput::default()
+            },
+            &SphericalS3,
+            0.5,
+        );
+        assert!(player.position.is_finite());
+        assert!(player.position.length() < 1.0);
+        assert_close(player.position.x, 0.0);
+        assert_close(player.position.y, 0.0);
+        assert!(player.position.z < 0.0);
     }
 }

--- a/crates/rye-render/src/device.rs
+++ b/crates/rye-render/src/device.rs
@@ -1,3 +1,11 @@
+//! Window surface + wgpu adapter/device acquisition.
+//!
+//! [`RenderDevice::new`] picks a high-performance adapter and an sRGB
+//! surface format when available; resize is handled by
+//! [`RenderDevice::resize`]. [`RenderDevice::begin_frame`] returns the
+//! per-frame `(SurfaceTexture, TextureView)` pair the render graph
+//! draws into.
+
 use anyhow::Result;
 use std::sync::Arc;
 use wgpu::*;
@@ -51,7 +59,9 @@ impl RenderDevice {
             .unwrap_or(caps.formats[0]);
 
         let config = SurfaceConfiguration {
-            // COPY_SRC allows texture readback for frame capture.
+            // COPY_SRC keeps texture readback open for headless screenshot tools
+            // and any future capture path; cost is negligible vs. the headache of
+            // re-creating the surface to enable it later.
             usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::COPY_SRC,
             format,
             width: size.width,

--- a/crates/rye-render/src/graph.rs
+++ b/crates/rye-render/src/graph.rs
@@ -1,3 +1,12 @@
+//! Linear render-graph harness. Owns a [`Vec<Box<dyn RenderNode>>`]
+//! and runs each node's `execute` in order against a single view.
+//!
+//! No dependency tracking, no cross-node resource sharing, no
+//! parallel execution. The trait is intentionally a one-method
+//! `execute(rd, view)`: complex apps that need scheduling or
+//! aliasing should compose nodes manually rather than waiting for
+//! this graph to grow features.
+
 use crate::device::RenderDevice;
 use anyhow::Result;
 

--- a/crates/rye-render/src/lib.rs
+++ b/crates/rye-render/src/lib.rs
@@ -1,12 +1,19 @@
+//! Thin wgpu wrapper plus a tiny render-graph harness.
+//!
+//! - [`device`]: window surface + adapter/device acquisition. One
+//!   [`device::RenderDevice`] per app.
+//! - [`graph`]: linear list of [`graph::RenderNode`]s executed in
+//!   order against a [`wgpu::TextureView`].
+//! - [`raymarch`]: ready-made fullscreen-triangle ray-march nodes
+//!   (Euclidean, geodesic, hyperslice 4D); the engine's main render
+//!   path until rasterised geometry shows up.
+//!
+//! The crate stays deliberately small: it hands wgpu primitives to
+//! callers rather than abstracting them behind a higher-level engine
+//! API.
+
 pub mod device;
 pub mod graph;
 pub mod raymarch;
 
 pub use raymarch::{GeodesicRayMarchNode, RayMarchNode, RayMarchUniforms};
-
-// #[cfg(feature = "2d")]
-// pub mod two_d;
-// #[cfg(feature = "3d")]
-// pub mod three_d;
-// #[cfg(feature = "voxel")]
-// pub mod voxel;

--- a/crates/rye-render/src/raymarch/geodesic.rs
+++ b/crates/rye-render/src/raymarch/geodesic.rs
@@ -11,7 +11,7 @@ use crate::raymarch::{RayMarchNode, RayMarchUniforms};
 /// shader assembled from four layers:
 /// `[Space prelude] + [scene SDF] + [march kernel] + [user shading]`.
 ///
-/// Build the compiled `ShaderModule` with [`rye_shader::ShaderDb::load_geodesic_scene`],
+/// Build the compiled `ShaderModule` with `rye_shader::ShaderDb::load_geodesic_scene`,
 /// then pass it to [`GeodesicRayMarchNode::from_module`].
 pub struct GeodesicRayMarchNode(RayMarchNode);
 

--- a/crates/rye-render/src/raymarch/hyperslice4d.rs
+++ b/crates/rye-render/src/raymarch/hyperslice4d.rs
@@ -25,7 +25,7 @@
 //!
 //! ## What it renders
 //!
-//! - **Static scene primitives** via [`Scene4`]: hyperspheres at
+//! - **Static scene primitives** via `Scene4`: hyperspheres at
 //!   fixed centres, half-spaces, etc. The `Scene4` is captured at
 //!   construction; its primitive parameters become WGSL constants.
 //! - **Dynamic bodies** via the [`BodyUniform`] array on
@@ -61,6 +61,15 @@ use crate::graph::RenderNode;
 /// at 32; pentatope-pile scenes top out around 20 active
 /// polytopes).
 pub const MAX_BODIES: usize = 32;
+
+/// Shape table indices for `BodyKind::Polytope` bodies. Stored in
+/// [`BodyUniform::radius_or_shape`] (cast through `f32`); read by
+/// the kernel's `body_polytope_sdf_4d` dispatch chain. Mirrored as
+/// `SHAPE_*` constants in [`HYPERSLICE_KERNEL_WGSL`]; keep in sync.
+pub const SHAPE_PENTATOPE: u32 = 0;
+pub const SHAPE_TESSERACT: u32 = 1;
+pub const SHAPE_16CELL: u32 = 2;
+pub const SHAPE_24CELL: u32 = 3;
 
 /// One dynamic-body slot. Discriminated record covering both
 /// hypersphere and polytope cases, `kind` selects which fields
@@ -249,6 +258,13 @@ const MAX_BODIES: u32 = 32u;
 
 const BODY_KIND_SPHERE: u32 = 0u;
 const BODY_KIND_POLYTOPE: u32 = 1u;
+
+// Polytope shape table indices. Mirrored from rye-render Rust-side
+// `SHAPE_*` constants; keep in sync.
+const SHAPE_PENTATOPE: u32 = 0u;
+const SHAPE_TESSERACT: u32 = 1u;
+const SHAPE_16CELL: u32 = 2u;
+const SHAPE_24CELL: u32 = 3u;
 // Mirrors `BodyKind::Invalid` (CPU). Intentionally absent from the
 // dispatch chain in `rye_dynamic_bodies_sdf` and `rye_total_sdf` below:
 // neither the sphere nor the polytope branch matches, so the SDF
@@ -446,13 +462,13 @@ fn body_polytope_sdf_4d(p4: vec4<f32>, b: BodyUniform) -> f32 {
     let unit_p = local_v / size;
     let shape = u32(b.radius_or_shape + 0.5);
     var d: f32 = 1.0e9;
-    if (shape == 0u) {
+    if (shape == SHAPE_PENTATOPE) {
         d = pentatope_sdf_local(unit_p);
-    } else if (shape == 1u) {
+    } else if (shape == SHAPE_TESSERACT) {
         d = tesseract_sdf_local(unit_p);
-    } else if (shape == 2u) {
+    } else if (shape == SHAPE_16CELL) {
         d = cell16_sdf_local(unit_p);
-    } else if (shape == 3u) {
+    } else if (shape == SHAPE_24CELL) {
         d = cell24_sdf_local(unit_p);
     }
     return d * size;
@@ -610,7 +626,7 @@ fn fs_main(@builtin(position) frag_pos: vec4<f32>) -> @location(0) vec4<f32> {
 "#;
 
 /// Render node that ray-marches the 3D cross-section of a 4D
-/// scene at `u.w_slice`. Pairs with [`rye_sdf::Scene4`].
+/// scene at `u.w_slice`. Pairs with `rye_sdf::Scene4`.
 pub struct Hyperslice4DNode {
     pipeline: RenderPipeline,
     uniforms: Hyperslice4DUniforms,
@@ -1121,5 +1137,23 @@ fn rye_scene_sdf(p: vec3<f32>) -> f32 {
         // 24-cell: 1/sqrt(2) and sqrt(2) literals.
         assert!(HYPERSLICE_KERNEL_WGSL.contains("0.70710678"));
         assert!(HYPERSLICE_KERNEL_WGSL.contains("1.41421356"));
+    }
+
+    /// `BodyUniform::polytope(shape_index, ..)` writes the same numeric
+    /// table the kernel branches on. Catches the failure mode where one
+    /// side renumbers without the other.
+    #[test]
+    fn shape_constants_mirror_kernel_table() {
+        for (rust_const, wgsl_decl) in [
+            (SHAPE_PENTATOPE, "const SHAPE_PENTATOPE: u32 = 0u;"),
+            (SHAPE_TESSERACT, "const SHAPE_TESSERACT: u32 = 1u;"),
+            (SHAPE_16CELL, "const SHAPE_16CELL: u32 = 2u;"),
+            (SHAPE_24CELL, "const SHAPE_24CELL: u32 = 3u;"),
+        ] {
+            assert!(
+                HYPERSLICE_KERNEL_WGSL.contains(wgsl_decl),
+                "kernel missing `{wgsl_decl}` for Rust value {rust_const}"
+            );
+        }
     }
 }

--- a/crates/rye-render/src/raymarch/mod.rs
+++ b/crates/rye-render/src/raymarch/mod.rs
@@ -17,7 +17,7 @@ mod hyperslice4d;
 pub use geodesic::GeodesicRayMarchNode;
 pub use hyperslice4d::{
     BodyKind, BodyUniform, Hyperslice4DNode, Hyperslice4DUniforms, HYPERSLICE_KERNEL_WGSL,
-    MAX_BODIES,
+    MAX_BODIES, SHAPE_16CELL, SHAPE_24CELL, SHAPE_PENTATOPE, SHAPE_TESSERACT,
 };
 
 use anyhow::Result;
@@ -149,16 +149,13 @@ impl RayMarchNode {
             cache: None,
         });
 
-        let mut this = Self {
+        Self {
             pipeline,
             uniforms: RayMarchUniforms::default(),
             uniform_buf,
             bind_group,
             clear_color: Color::BLACK,
-        };
-        // Initial upload so the UBO isn't garbage on first frame.
-        this.upload(device);
-        this
+        }
     }
 
     pub fn uniforms(&self) -> &RayMarchUniforms {
@@ -176,19 +173,11 @@ impl RayMarchNode {
 
     /// Flush current [`RayMarchUniforms`] to the GPU. Use after mutating
     /// via [`RayMarchNode::uniforms_mut`].
+    ///
+    /// Render loops must call this (or [`set_uniforms`](Self::set_uniforms))
+    /// before the first draw; the UBO is undefined at construction time.
     pub fn flush_uniforms(&self, queue: &Queue) {
         queue.write_buffer(&self.uniform_buf, 0, bytemuck::bytes_of(&self.uniforms));
-    }
-
-    fn upload(&mut self, device: &Device) {
-        // One-shot upload via staging: we don't have a Queue here at
-        // construction time, so use create_buffer_init via the device's
-        // queue is out of reach. Instead we'll rely on the first
-        // explicit set_uniforms / flush_uniforms the user issues.
-        //
-        // This intentionally leaves the UBO undefined until first flush;
-        // render loops should always set uniforms before first draw.
-        let _ = device;
     }
 }
 

--- a/crates/rye-sdf/src/lib.rs
+++ b/crates/rye-sdf/src/lib.rs
@@ -12,6 +12,15 @@
 //! are demo-shaped scene builders consumed by the corresponding examples.
 //! They are constructed on top of the typed primitive layer (each has a
 //! `to_scene` method that returns a [`scene::Scene`]).
+//!
+//! TODO: Each demo scene is consumed by exactly one example
+//! (`geodesic_spheres`, `corridor`, `lattice`). The plan is to push each
+//! scene into its example as a private module so the example becomes
+//! self-contained and `rye-sdf` keeps only the underlying typed layer
+//! ([`Primitive`], [`Scene`]). Deferred from the cleanup batch because
+//! the move forces rewriting the demo-specific tests against synthetic
+//! constructions (the per-scene tests below depend on the demos being
+//! visible from inside `rye-sdf`'s test module).
 
 pub mod combinator;
 pub mod primitive;
@@ -39,7 +48,7 @@ use rye_math::{EuclideanR3, Space, WgslSpace};
 /// Optionally, a Euclidean-y slab (floor / ceiling planes) can be
 /// enabled as a visual cage. The slab renders honestly via
 /// chart-coord `dot(p, n) - d` in `EuclideanR3` (the Space this
-/// helper compiles against); per [`Primitive::HalfSpace`], it would
+/// helper compiles against); per [`Primitive`]'s `HalfSpace` arm, it would
 /// sentinel in H³ / S³ until geodesic-plane SDFs land.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GeodesicSpheresScene {
@@ -117,7 +126,7 @@ impl GeodesicSpheresScene {
 /// compiles against `EuclideanR3` (flat), so those wall planes
 /// emit honestly via `dot(p, n) - d`. A future
 /// `corridor_demo_wgsl_<S>` for H³ / S³ would sentinel them via
-/// [`Primitive::HalfSpace`] until geodesic-plane SDFs land.
+/// [`Primitive`]'s `HalfSpace` arm until geodesic-plane SDFs land.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CorridorScene {
     /// Half-width of the corridor along the Space X axis.
@@ -166,7 +175,7 @@ impl CorridorScene {
     /// emitted SDF for the walls depends on the Space the scene
     /// is later compiled against: `dot(p, n) - d` in flat charts
     /// (E³), sentinel in curved charts (H³ / S³). See
-    /// [`Primitive::HalfSpace`] for the `is_chart_flat` gate.
+    /// [`Primitive`]'s `HalfSpace` arm for the `is_chart_flat` gate.
     pub fn to_scene(&self) -> Scene {
         assert!(
             self.pillars_per_row % 2 == 1,

--- a/crates/rye-sdf/src/primitive.rs
+++ b/crates/rye-sdf/src/primitive.rs
@@ -19,7 +19,7 @@
 //!   H³/S³ (the trait rule treats this as accepted because no
 //!   geodesic-box SDF exists in closed form).
 //! - [`Shape::HalfSpace`], chart-coord `dot(p, n) − offset` **only
-//!   in flat Spaces** (gated by [`WgslSpace::is_chart_flat`]). In
+//!   in flat Spaces** (gated by `WgslSpace::is_chart_flat`). In
 //!   curved Spaces (H³, S³, `BlendedSpace`) it would draw the
 //!   chart's straight plane, not the geodesic plane, so the
 //!   emission falls back to the `+1e9` sentinel below until a
@@ -31,11 +31,11 @@
 //! Variants that always emit a `+1e9` invisible-far-away sentinel
 //! today:
 //!
-//! - [`Shape::HalfSpace4D`]: 4D variant; lives in [`Primitive4`].
+//! - [`Shape::HalfSpace4D`]: 4D variant; lives in [`Primitive4`](crate::Primitive4).
 //! - [`Shape::Polygon2D`], [`Shape::ConvexPolytope3D`],
 //!   [`Shape::ConvexPolytope4D`]: vertex-list shapes that need
 //!   either a baked mesh-SDF or a runtime convex-hull kernel.
-//! - [`Shape::HyperSphere4D`]: 4D variant; lives in [`Primitive4`].
+//! - [`Shape::HyperSphere4D`]: 4D variant; lives in [`Primitive4`](crate::Primitive4).
 
 use rye_math::WgslSpace;
 use rye_shape::Shape;
@@ -47,7 +47,7 @@ use rye_shape::Shape;
 /// `fn {name}(p: vec3<f32>) -> f32`. The trait rule: emitted SDFs
 /// must call only `rye_*` Space-prelude functions, never raw
 /// chart-coord arithmetic, **except** when the Space self-reports
-/// flat via [`WgslSpace::is_chart_flat`]. In flat Spaces the
+/// flat via `WgslSpace::is_chart_flat`. In flat Spaces the
 /// chart-coord and Riemannian distances coincide, so primitives
 /// like [`Shape::HalfSpace`] are free to emit `dot(p, n) - offset`
 /// directly. In curved Spaces those primitives sentinel until a

--- a/crates/rye-sdf/src/scene.rs
+++ b/crates/rye-sdf/src/scene.rs
@@ -64,7 +64,7 @@ impl SceneNode {
 
     /// Half-space leaf. SDF emission depends on the Space the
     /// scene is later compiled against (per
-    /// [`crate::Primitive::HalfSpace`]): chart-coord `dot(p, n) - d`
+    /// [`Primitive`]'s `HalfSpace` arm): chart-coord `dot(p, n) - d`
     /// in flat charts (E³), `+1e9` sentinel in curved charts (H³ /
     /// S³) until closed-form geodesic-plane SDFs land. The shape
     /// itself is canonical, also used by `rye-physics` for

--- a/crates/rye-shader/Cargo.toml
+++ b/crates/rye-shader/Cargo.toml
@@ -21,3 +21,4 @@ wgpu.workspace = true
 bytemuck.workspace = true
 glam.workspace = true
 pollster = "0.3"
+tempfile = "3"

--- a/crates/rye-shader/src/db.rs
+++ b/crates/rye-shader/src/db.rs
@@ -924,4 +924,36 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
             "actual {actual} differs from expected {expected} by more than {eps}",
         );
     }
+
+    /// Hot-reload's text path: read a shader file, assemble against a
+    /// Space prelude, validate via naga, mutate the file, repeat. Pins
+    /// the I/O + assembly + validation pipeline that
+    /// [`ShaderDb::reload`] depends on without needing a wgpu Device
+    /// (constructing one headlessly in CI is heavy and platform-
+    /// flaky). The Device-bound layer is just `create_shader_module`
+    /// over the same validated source.
+    #[test]
+    fn hot_reload_pipeline_reads_assembles_and_validates_mutated_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("probe.wgsl");
+
+        let v1 = ABI_PROBE;
+        std::fs::write(&path, v1).unwrap();
+
+        let read1 = std::fs::read_to_string(&path).unwrap();
+        let src1 = assemble_source(&EuclideanR3.wgsl_impl(), &read1);
+        validate_wgsl(&src1).expect("v1 must validate");
+
+        // Mutate the file in place: bytes change, path is identical
+        // (the same shape the watcher sees on a save). Tweak a constant
+        // rather than the structure so the v2 source still validates.
+        let v2 = ABI_PROBE.replace("vec3<f32>(0.1, 0.2, 0.3)", "vec3<f32>(0.4, 0.5, 0.6)");
+        assert_ne!(v1, v2, "test mutation should produce different source");
+        std::fs::write(&path, &v2).unwrap();
+
+        let read2 = std::fs::read_to_string(&path).unwrap();
+        assert_ne!(read1, read2, "file mutation should change bytes");
+        let src2 = assemble_source(&EuclideanR3.wgsl_impl(), &read2);
+        validate_wgsl(&src2).expect("v2 must validate after mutation");
+    }
 }

--- a/crates/rye-shader/src/kernel.wgsl
+++ b/crates/rye-shader/src/kernel.wgsl
@@ -63,6 +63,17 @@ fn rye_march_geodesic(ro: vec3<f32>, rd: vec3<f32>, ball_scale: f32) -> vec4<f32
 }
 
 // Central-difference SDF gradient at a Space-coordinate point.
+//
+// `p` and the returned normal are in the Space's *chart* coordinates
+// (Cartesian for E³, Poincaré-ball for H³, unit-3-sphere for S³),
+// matching how `rye_scene_sdf` is emitted. The chart-coord gradient
+// is **not** the Riemannian normal, but the renderer only ever uses
+// it for Lambert shading, where the chart-coord gradient and the
+// transported Riemannian gradient point in the same direction (both
+// give the Euclidean-screen-space normal the lighting kernel wants).
+// `ball_scale` widens the central-difference epsilon so curved-Space
+// SDFs near `|p| ≈ 1` (boundary of the model) don't sample across
+// the boundary and get a NaN normal.
 fn rye_estimate_normal(p: vec3<f32>, ball_scale: f32) -> vec3<f32> {
     let eps = 0.0012 * max(ball_scale, 1e-5);
     let ex = vec3<f32>(eps, 0.0, 0.0);

--- a/crates/rye-text/src/lib.rs
+++ b/crates/rye-text/src/lib.rs
@@ -84,6 +84,11 @@ pub struct TextRenderer {
     pipeline: RenderPipeline,
     bind_group: BindGroup,
     uniform_buf: Buffer,
+    // The atlas resources are referenced only through `bind_group`'s
+    // resource bindings; we hold them on the struct so they stay
+    // alive for the bind group's lifetime. Dropping them would free
+    // the GPU resource the bind group still references and crash on
+    // the next render.
     #[allow(dead_code)]
     atlas_tex: Texture,
     #[allow(dead_code)]
@@ -315,69 +320,16 @@ impl TextRenderer {
     /// Newlines (`\n`) advance to the next line. Other control
     /// characters are skipped.
     pub fn queue(&mut self, text: &str, position: [f32; 2], size_px: f32, color: [f32; 4]) {
-        let scale = size_px / self.bake_size_px;
-        let line_h = self.line_height_px * scale;
-        let mut cursor_x = position[0];
-        let mut cursor_y = position[1];
-
-        for c in text.chars() {
-            if c == '\n' {
-                cursor_x = position[0];
-                cursor_y += line_h;
-                continue;
-            }
-            if (c as u32) < 0x20 || (c as u32) > 0x7E {
-                continue;
-            }
-            let Some(g) = self.glyphs.get(&c) else {
-                // Missing glyph (atlas didn't fit it); silently skip.
-                continue;
-            };
-
-            let x0 = cursor_x + g.bearing_x * scale;
-            let y0 = cursor_y + (self.line_height_px + g.bearing_y) * scale;
-            let x1 = x0 + g.px_width * scale;
-            let y1 = y0 + g.px_height * scale;
-
-            let (u0, v0) = (g.uv_min[0], g.uv_min[1]);
-            let (u1, v1) = (g.uv_max[0], g.uv_max[1]);
-
-            // Six vertices per glyph (two triangles).
-            self.queued.extend_from_slice(&[
-                TextVertex {
-                    pos: [x0, y0],
-                    uv: [u0, v0],
-                    color,
-                },
-                TextVertex {
-                    pos: [x1, y0],
-                    uv: [u1, v0],
-                    color,
-                },
-                TextVertex {
-                    pos: [x0, y1],
-                    uv: [u0, v1],
-                    color,
-                },
-                TextVertex {
-                    pos: [x1, y0],
-                    uv: [u1, v0],
-                    color,
-                },
-                TextVertex {
-                    pos: [x1, y1],
-                    uv: [u1, v1],
-                    color,
-                },
-                TextVertex {
-                    pos: [x0, y1],
-                    uv: [u0, v1],
-                    color,
-                },
-            ]);
-
-            cursor_x += g.h_advance * scale;
-        }
+        layout_text(
+            text,
+            position,
+            size_px,
+            color,
+            &self.glyphs,
+            self.bake_size_px,
+            self.line_height_px,
+            &mut self.queued,
+        );
     }
 
     /// Render queued text into `view` at `viewport_size` (pixels) and
@@ -462,6 +414,93 @@ impl TextRenderer {
     /// each call). Useful for measurement helpers built on top.
     pub fn font_bytes(&self) -> &[u8] {
         &self.font_data
+    }
+}
+
+/// Pure layout: append the vertices for `text` (six per glyph,
+/// two triangles) into `out`. No GPU resources touched, so this
+/// can be tested with a hand-built glyph table.
+///
+/// `position` is the top-left of the first line in viewport
+/// coordinates; `size_px` is the rendered glyph height; `scale = size_px /
+/// bake_size_px` rescales the baked atlas geometry to the requested
+/// size. Newlines reset `cursor_x` to `position[0]` and advance
+/// `cursor_y` by `line_height_px * scale`. Non-printable / out-of-
+/// ASCII chars are skipped silently; chars with no glyph in the
+/// table (atlas didn't fit them) are also skipped.
+#[allow(clippy::too_many_arguments)] // pure layout helper, parameters are the layout state.
+fn layout_text(
+    text: &str,
+    position: [f32; 2],
+    size_px: f32,
+    color: [f32; 4],
+    glyphs: &HashMap<char, GlyphEntry>,
+    bake_size_px: f32,
+    line_height_px: f32,
+    out: &mut Vec<TextVertex>,
+) {
+    let scale = size_px / bake_size_px;
+    let line_h = line_height_px * scale;
+    let mut cursor_x = position[0];
+    let mut cursor_y = position[1];
+
+    for c in text.chars() {
+        if c == '\n' {
+            cursor_x = position[0];
+            cursor_y += line_h;
+            continue;
+        }
+        if (c as u32) < 0x20 || (c as u32) > 0x7E {
+            continue;
+        }
+        let Some(g) = glyphs.get(&c) else {
+            // Missing glyph (atlas didn't fit it); silently skip.
+            continue;
+        };
+
+        let x0 = cursor_x + g.bearing_x * scale;
+        let y0 = cursor_y + (line_height_px + g.bearing_y) * scale;
+        let x1 = x0 + g.px_width * scale;
+        let y1 = y0 + g.px_height * scale;
+
+        let (u0, v0) = (g.uv_min[0], g.uv_min[1]);
+        let (u1, v1) = (g.uv_max[0], g.uv_max[1]);
+
+        // Six vertices per glyph (two triangles).
+        out.extend_from_slice(&[
+            TextVertex {
+                pos: [x0, y0],
+                uv: [u0, v0],
+                color,
+            },
+            TextVertex {
+                pos: [x1, y0],
+                uv: [u1, v0],
+                color,
+            },
+            TextVertex {
+                pos: [x0, y1],
+                uv: [u0, v1],
+                color,
+            },
+            TextVertex {
+                pos: [x1, y0],
+                uv: [u1, v0],
+                color,
+            },
+            TextVertex {
+                pos: [x1, y1],
+                uv: [u1, v1],
+                color,
+            },
+            TextVertex {
+                pos: [x0, y1],
+                uv: [u0, v1],
+                color,
+            },
+        ]);
+
+        cursor_x += g.h_advance * scale;
     }
 }
 
@@ -659,5 +698,173 @@ mod tests {
         // 'A' should have nonzero pixel size.
         let a = glyphs.get(&'A').expect("A in atlas");
         assert!(a.px_width > 0.0 && a.px_height > 0.0);
+    }
+
+    /// Build a minimal glyph table for layout tests: every printable
+    /// ASCII char gets a unit-square glyph at the same UV slot. The
+    /// math we want to pin (cursor advance, newline reset, vertex
+    /// count) doesn't depend on the actual atlas geometry, only on
+    /// per-glyph `h_advance`.
+    fn mock_glyph_table(h_advance: f32) -> HashMap<char, GlyphEntry> {
+        (0x20u8..=0x7Eu8)
+            .map(|c| {
+                (
+                    c as char,
+                    GlyphEntry {
+                        uv_min: [0.0, 0.0],
+                        uv_max: [1.0, 1.0],
+                        bearing_x: 0.0,
+                        bearing_y: 0.0,
+                        px_width: 1.0,
+                        px_height: 1.0,
+                        h_advance,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Each printable glyph emits exactly 6 vertices (two triangles).
+    /// "abc" produces 18 vertices.
+    #[test]
+    fn layout_emits_six_vertices_per_glyph() {
+        let glyphs = mock_glyph_table(10.0);
+        let mut out = Vec::new();
+        layout_text(
+            "abc",
+            [0.0, 0.0],
+            16.0,
+            [1.0, 1.0, 1.0, 1.0],
+            &glyphs,
+            16.0,
+            16.0,
+            &mut out,
+        );
+        assert_eq!(out.len(), 18);
+    }
+
+    /// Newline resets `cursor_x` to `position[0]` and advances
+    /// `cursor_y` by `line_height_px * scale`. Two-line text should
+    /// produce vertices on two distinct y-bands.
+    #[test]
+    fn layout_newline_resets_x_and_advances_y() {
+        let glyphs = mock_glyph_table(10.0);
+        let mut out = Vec::new();
+        // size_px = bake_size_px = 16.0, so scale = 1.0 and line_h = 16.0.
+        layout_text(
+            "a\nb",
+            [5.0, 0.0],
+            16.0,
+            [1.0; 4],
+            &glyphs,
+            16.0,
+            16.0,
+            &mut out,
+        );
+        assert_eq!(out.len(), 12); // 6 verts × 2 glyphs
+
+        // First glyph's top-left vertex sits at (cursor_x = 5, cursor_y + line_height).
+        // After mock bearing_x = 0, bearing_y = 0: x0 = 5, y0 = 0 + (16 + 0)*1 = 16.
+        let first = out[0];
+        assert_eq!(first.pos[0], 5.0);
+        assert!((first.pos[1] - 16.0).abs() < 1e-5);
+
+        // Seventh vertex is the start of glyph 2 ('b'), after the newline.
+        // cursor_x reset to 5 (position[0]); cursor_y advanced by line_h = 16.
+        let second = out[6];
+        assert_eq!(
+            second.pos[0], 5.0,
+            "newline must reset cursor_x to position[0]"
+        );
+        assert!(
+            (second.pos[1] - 32.0).abs() < 1e-5,
+            "newline must advance cursor_y by line_h ({})",
+            16.0,
+        );
+    }
+
+    /// Cursor advances by `h_advance * scale` per glyph, both
+    /// horizontally on the baseline and through the resulting vertex
+    /// positions.
+    #[test]
+    fn layout_cursor_advances_by_h_advance_scaled() {
+        let glyphs = mock_glyph_table(10.0);
+        let mut out = Vec::new();
+        // Render at 32 px when bake is 16 px ⇒ scale = 2 ⇒ effective
+        // advance = 20 per glyph.
+        layout_text(
+            "ab",
+            [0.0, 0.0],
+            32.0,
+            [1.0; 4],
+            &glyphs,
+            16.0,
+            16.0,
+            &mut out,
+        );
+
+        // Glyph 0 starts at x = 0; glyph 1 starts at x = 20 (one
+        // scaled advance later). The top-left vertex of each glyph
+        // is the first of its 6-vertex chunk.
+        assert_eq!(out[0].pos[0], 0.0);
+        assert_eq!(out[6].pos[0], 20.0);
+    }
+
+    /// Non-ASCII / control chars are skipped without crashing or
+    /// emitting bogus vertices. Tabs, form-feeds, raw bytes 0x80+,
+    /// emoji are all silently dropped.
+    #[test]
+    fn layout_skips_unprintable_and_out_of_range_chars() {
+        let glyphs = mock_glyph_table(10.0);
+        let mut out = Vec::new();
+        layout_text(
+            "a\tb\u{80}c😀d",
+            [0.0, 0.0],
+            16.0,
+            [1.0; 4],
+            &glyphs,
+            16.0,
+            16.0,
+            &mut out,
+        );
+        // Only 'a', 'b', 'c', 'd' get glyphs. 4 × 6 = 24 vertices.
+        assert_eq!(out.len(), 24);
+    }
+
+    /// Chars with no entry in the glyph table (because the atlas
+    /// didn't fit them) are silently skipped, NOT rendered as
+    /// missing-glyph fallback boxes. This keeps the layout
+    /// deterministic when the atlas is partial.
+    #[test]
+    fn layout_skips_missing_glyphs() {
+        let mut glyphs = mock_glyph_table(10.0);
+        glyphs.remove(&'b');
+        let mut out = Vec::new();
+        layout_text(
+            "ab",
+            [0.0, 0.0],
+            16.0,
+            [1.0; 4],
+            &glyphs,
+            16.0,
+            16.0,
+            &mut out,
+        );
+        // Only 'a' produces 6 vertices.
+        assert_eq!(out.len(), 6);
+    }
+
+    /// `WGSL_SHADER` is the shader module string the GPU pipeline
+    /// loads. A naga-front parse + validate pass catches syntax /
+    /// type / binding errors at test time rather than at first
+    /// `TextRenderer::new` call (which needs a wgpu adapter).
+    #[test]
+    fn wgsl_shader_validates_via_naga() {
+        let module = naga::front::wgsl::parse_str(WGSL_SHADER).expect("WGSL parse");
+        let flags = naga::valid::ValidationFlags::all();
+        let caps = naga::valid::Capabilities::empty();
+        naga::valid::Validator::new(flags, caps)
+            .validate(&module)
+            .expect("WGSL validate");
     }
 }

--- a/examples/polytope_smoke/main.rs
+++ b/examples/polytope_smoke/main.rs
@@ -71,22 +71,18 @@ use rye_math::{Bivector, Bivector4, EuclideanR3, Rotor4};
 use rye_render::{
     device::RenderDevice,
     graph::RenderNode,
-    raymarch::{BodyUniform, Hyperslice4DNode, HYPERSLICE_KERNEL_WGSL},
+    raymarch::{
+        BodyUniform, Hyperslice4DNode, HYPERSLICE_KERNEL_WGSL, SHAPE_16CELL, SHAPE_24CELL,
+        SHAPE_PENTATOPE, SHAPE_TESSERACT,
+    },
 };
 use rye_sdf::{Scene4, SceneNode4};
 use rye_text::TextRenderer;
 use winit::window::WindowAttributes;
 
-const SHAPE_PENTATOPE: u32 = 0;
-const SHAPE_TESSERACT: u32 = 1;
-const SHAPE_16CELL: u32 = 2;
-const SHAPE_24CELL: u32 = 3;
-// Placeholders for the dodecahedron/icosahedron Platonic-slice
-// shapes, real SDFs deferred to a follow-up branch (see
-// `parse_shape_name` for the friendly-error message users see if
-// they request them by name today).
-const _SHAPE_120CELL: u32 = 4;
-const _SHAPE_600CELL: u32 = 5;
+// 120-cell / 600-cell shape indices are deliberately unallocated; the
+// SDFs land in a follow-up branch. `parse_shape_name` returns a
+// friendly error if a user asks for them by name today.
 
 const W_SCRUB_RATE: f32 = 0.5;
 const W_RANGE: f32 = 1.5;


### PR DESCRIPTION
Bundled cleanup pass across the workspace; doc / test / small-behavior fixes that don't individually merit their own PR.

## Changes

- **docs**: module-level docs added to `rye-input`, `rye-player`, `rye-render::{lib,device,graph}`. Inline justifications on `rye-text` `dead_code` allows. Re-doc'd `rye_estimate_normal` to spell out the chart-coord assumption.
- **tests**: removed-file test in `rye-asset`. Layout + naga-validation tests in `rye-text` (extracted `layout_text` free fn). H³/S³ + diagonal-speed + `move_up` + `with_yaw` tests in `rye-player`. H³ translate + degenerate `looking_at` tests in `rye-camera`. Half-space-mass guard tests in `rye-physics::body`. Hot-reload tempfile test in `rye-shader`. SHAPE_* constant-mirror test in `rye-render`.
- **rye-render**: deleted no-op `RayMarchNode::upload` stub. Lifted `SHAPE_PENTATOPE`/`TESSERACT`/`16CELL`/`24CELL` to shared Rust+WGSL constants; `polytope_smoke` now imports them.
- **rye-app**: `RunConfig.esc_exits` (default true) so apps can keep `Esc` for gameplay. `RunConfig.render_error_budget` (default 8) bails out after consecutive `App::render` failures instead of spinning on a wedged GPU.
- **rye-asset**: bumped notify-error log level from `debug` to `warn`.
- **rye-physics**: debug-mode guard rejects dynamic half-space colliders (`HalfSpace` / `HalfSpace4D` with mass > 0).
- **CI**: new `cargo doc --no-deps --workspace` job with `RUSTDOCFLAGS=-D warnings`. Also fixed all pre-existing broken intra-doc links the new gate surfaced (cross-crate refs that don't resolve, `Primitive::HalfSpace` typos, ambiguous `epa`/`epa_r4` fn-vs-mod targets, etc.).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace`