### PR TITLE
chore: NaN-guard cleanup, EPA cap logging, BlendedSpace camera test, em-dash + arrow ASCII purge

### DIFF
--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -10,7 +10,7 @@
 //! - Window creation and the winit `ApplicationHandler` impl.
 //! - [`RenderDevice`] construction and surface-error recovery.
 //! - [`ShaderDb`] + [`AssetWatcher`] for shader hot-reload.
-//! - [`InputState`] event routing → drained `FrameInput` per
+//! - [`InputState`] event routing -> drained `FrameInput` per
 //!   redraw.
 //! - [`FixedTimestep`] driving `App::tick` at the fixed-rate.
 //! - FPS bookkeeping and rate-limited title updates.
@@ -45,12 +45,12 @@
 //!         create ShaderDb + AssetWatcher
 //!         A::setup(&mut SetupCtx) -> A
 //!   └─ on each redraw:
-//!         FixedTimestep::advance → ticks
+//!         FixedTimestep::advance -> ticks
 //!         for each tick: A::tick(dt, &mut TickCtx)
 //!         input.take_frame()
 //!         A::update(&mut FrameCtx)
 //!         A::on_event(...) for each WindowEvent
-//!         poll AssetWatcher → if events:
+//!         poll AssetWatcher -> if events:
 //!             shader_db.apply_events(events, app.space())
 //!             A::on_shader_reload(&mut SetupCtx)
 //!         maybe update title (rate-limited to ~1 Hz)
@@ -127,7 +127,7 @@ pub trait App: Sized + 'static {
     /// without thinking, you commit your scene to live in that
     /// Space's coordinates. For H³ that means the Poincaré ball;
     /// orbit distances inherited from a Euclidean default
-    /// (`OrbitController::default()` → `distance ≈ 3.55`) will
+    /// (`OrbitController::default()` -> `distance ≈ 3.55`) will
     /// `exp_target` into a tangent vector that lands at
     /// `tanh(1.78) ≈ 0.94` of the way to the ideal boundary, where
     /// the metric explodes. If your scene's geometry isn't actually

--- a/crates/rye-asset/src/watcher.rs
+++ b/crates/rye-asset/src/watcher.rs
@@ -28,7 +28,7 @@ pub enum AssetEventKind {
 /// Events arrive on a background thread managed by `notify`; [`poll`](Self::poll)
 /// drains the channel non-blockingly and deduplicates events per path
 /// within one poll cycle. That means editor saves that produce a burst
-/// of raw events (remove temp → create target → modify) collapse to a
+/// of raw events (remove temp -> create target -> modify) collapse to a
 /// single `Modified` or `Created` event per file. That's the usual
 /// shape a shader cache wants.
 ///
@@ -118,7 +118,7 @@ impl AssetWatcher {
 /// `fs::write` on a fresh file emits Create+Modify, and downstream
 /// consumers expect "new file" to look different from "existing file
 /// changed." Otherwise the later event wins, which correctly handles
-/// save-by-atomic-replace (Remove→Create→target exists).
+/// save-by-atomic-replace (Remove->Create->target exists).
 fn merge_kinds(old: AssetEventKind, new: AssetEventKind) -> AssetEventKind {
     use AssetEventKind::*;
     match (old, new) {

--- a/crates/rye-camera/src/controller.rs
+++ b/crates/rye-camera/src/controller.rs
@@ -363,6 +363,31 @@ mod tests {
         assert!((camera.forward.length() - 1.0).abs() < 1e-3);
     }
 
+    /// `OrbitController` against `BlendedSpace<E3, H3, LinearBlendX>`
+    /// exercises the variable-metric `parallel_transport_along` path
+    /// the closed-form Spaces never hit. Pin: targeting the H³-side of
+    /// a transition zone, the orbit produces a finite, ≈-orthonormal
+    /// frame inside the Poincaré ball.
+    #[test]
+    fn orbit_in_blended_e3_h3_produces_valid_frame() {
+        use rye_math::{BlendedSpace, EuclideanR3, HyperbolicH3, LinearBlendX};
+        let space = BlendedSpace::new(EuclideanR3, HyperbolicH3, LinearBlendX::new(-2.0, 2.0));
+        // Orbit around a point firmly inside the H³ region (x > 2).
+        let mut camera =
+            Camera::<BlendedSpace<EuclideanR3, HyperbolicH3, LinearBlendX>>::at_origin();
+        camera.position = Vec3::new(2.5, 0.0, 0.0);
+        let mut ctrl = OrbitController::around(Vec3::new(2.5, 0.0, 0.0));
+        ctrl.distance = 0.4;
+        ctrl.advance(FrameInput::default(), &mut camera, &space, 0.0);
+        assert!(camera.position.is_finite());
+        assert!(camera.right.is_finite() && camera.up.is_finite() && camera.forward.is_finite());
+        // Tolerances are looser than closed-form because the variable-
+        // metric integrator has finite step error.
+        assert!((camera.right.length() - 1.0).abs() < 1e-2);
+        assert!((camera.up.length() - 1.0).abs() < 1e-2);
+        assert!((camera.forward.length() - 1.0).abs() < 1e-2);
+    }
+
     /// Per-Space `OrbitController::advance` timing. `#[ignore]` by
     /// default, run on demand via
     ///

--- a/crates/rye-math/src/bivector.rs
+++ b/crates/rye-math/src/bivector.rs
@@ -232,6 +232,9 @@ impl Bivector for Bivector3 {
     /// decomposition needed (unlike 4D).
     fn exp(self) -> Rotor3 {
         let mag_sq = self.xy * self.xy + self.yz * self.yz + self.zx * self.zx;
+        // 1e-16 is below the squared-angle below which f32 sin/cos
+        // round-trip is dominated by floating-point noise; the linear
+        // Taylor approximation below is exact to within f32 precision.
         if mag_sq < 1e-16 {
             // Small-angle: Taylor expand `sin(θ/2)/θ ≈ 1/2`.
             return Rotor3 {
@@ -536,13 +539,13 @@ impl Bivector for Bivector4 {
     ///
     /// Three cases, handled separately to keep f32 stable:
     ///
-    /// 1. `|B|² ≈ 0` → identity rotor.
-    /// 2. `δ ≈ 0` (simple bivector, single rotation plane) → 3D-style
+    /// 1. `|B|² ≈ 0` -> identity rotor.
+    /// 2. `δ ≈ 0` (simple bivector, single rotation plane) -> 3D-style
     ///    closed form `cos(|B|/2) + sin(|B|/2)/|B| · B`.
     /// 3. `disc ≈ 0` with `δ ≠ 0` (isoclinic: equal angles in two
-    ///    orthogonal planes) → closed form using `sinc(θ)` so the
+    ///    orthogonal planes) -> closed form using `sinc(θ)` so the
     ///    general-case `1/(θ₁²−θ₂²)` singularity never appears.
-    /// 4. General case (`θ₁ ≠ θ₂`, both nonzero) → expansion of
+    /// 4. General case (`θ₁ ≠ θ₂`, both nonzero) -> expansion of
     ///    `exp(B_a/2)·exp(B_b/2)` in the basis `{1, B, B*, I}`.
     fn exp(self) -> Rotor4 {
         let s = self.magnitude_squared();
@@ -586,6 +589,8 @@ impl Bivector for Bivector4 {
             let sign_i = delta.signum();
             // b_coef = sin(θ)/(2·θ). Use the trig identity
             // sin(θ) = 2·sin(θ/2)·cos(θ/2) and divide by 2·θ.
+            // 1e-8 is the angle below which `sin(θ)/(2θ)` rounds away
+            // its leading term in f32; substitute the limit `1/2`.
             let b_coef = if theta > 1e-8 {
                 (theta.sin()) / (2.0 * theta)
             } else {
@@ -826,7 +831,7 @@ impl Rotor for Rotor4 {
     /// - `e_ijk · e_lm` with `{l,m} ⊂ {i,j,k}`: collapses to `±e_{one
     ///   remaining}` per the standard reduction.
     /// - `e_ijk · I`: `−e_l` (with `l` the missing index), signed by
-    ///   the parity of the `e_{ijk}·e_l → I` permutation.
+    ///   the parity of the `e_{ijk}·e_l -> I` permutation.
     fn apply(&self, v: Vec4) -> Vec4 {
         let (vx, vy, vz, vw) = (v.x, v.y, v.z, v.w);
         let rs = self.s;
@@ -931,16 +936,21 @@ impl Rotor for Rotor4 {
             .max(0.0)
             .sqrt();
 
-        // Isoclinic branch within `log`: t₁ ≈ t₂. bstar_coef → 0, so
+        // Isoclinic branch within `log`: t₁ ≈ t₂. bstar_coef -> 0, so
         // the inverse simplifies to `B = R / b_coef` and `b_coef` has
         // the isoclinic closed form `sin(θ)/(2·θ)`.
         if disc_target < 1e-6 * s_target.max(1.0) {
             let theta = (s_target * 0.5).sqrt();
+            // 1e-8: same sin(θ)/(2θ) cutover as `Rotor4::exp`'s
+            // isoclinic branch; below it the `0.5` limit is exact in f32.
             let b_coef = if theta > 1e-8 {
                 theta.sin() / (2.0 * theta)
             } else {
                 0.5
             };
+            // 1e-12: the inverted coefficient would amplify f32 noise
+            // beyond the correctness bound. Treat as zero rather than
+            // divide.
             if b_coef.abs() < 1e-12 {
                 return Bivector4::ZERO;
             }
@@ -1095,7 +1105,7 @@ mod tests {
 
     #[test]
     fn bivector3_xy_quarter_turn_sends_x_to_y() {
-        // Rotation in xy-plane by π/2: e1 → e2.
+        // Rotation in xy-plane by π/2: e1 -> e2.
         let r = Bivector3::new(FRAC_PI_2, 0.0, 0.0).exp();
         assert_vec3_close(r.apply(Vec3::X), Vec3::Y);
         assert_vec3_close(r.apply(Vec3::Y), -Vec3::X);
@@ -1105,7 +1115,7 @@ mod tests {
 
     #[test]
     fn bivector3_yz_rotation() {
-        // Rotation in yz-plane (e2 → e3) by π/2.
+        // Rotation in yz-plane (e2 -> e3) by π/2.
         let r = Bivector3::new(0.0, FRAC_PI_2, 0.0).exp();
         assert_vec3_close(r.apply(Vec3::Y), Vec3::Z);
         assert_vec3_close(r.apply(Vec3::Z), -Vec3::Y);
@@ -1114,7 +1124,7 @@ mod tests {
 
     #[test]
     fn bivector3_zx_rotation() {
-        // Rotation in zx-plane (e3 → e1) by π/2.
+        // Rotation in zx-plane (e3 -> e1) by π/2.
         let r = Bivector3::new(0.0, 0.0, FRAC_PI_2).exp();
         assert_vec3_close(r.apply(Vec3::Z), Vec3::X);
         assert_vec3_close(r.apply(Vec3::X), -Vec3::Z);
@@ -1175,7 +1185,7 @@ mod tests {
                 (back.xy - bv.xy).abs() < 1e-5
                     && (back.yz - bv.yz).abs() < 1e-5
                     && (back.zx - bv.zx).abs() < 1e-5,
-                "log∘exp mismatch: {bv:?} → {back:?}"
+                "log∘exp mismatch: {bv:?} -> {back:?}"
             );
         }
     }
@@ -1241,7 +1251,7 @@ mod tests {
     /// the other two are fixed.
     #[test]
     fn bivector4_single_plane_rotations_are_planar() {
-        // xy-plane (θ = π/2): x → y, y → −x, z / w fixed.
+        // xy-plane (θ = π/2): x -> y, y -> −x, z / w fixed.
         let r = Bivector4::new(FRAC_PI_2, 0.0, 0.0, 0.0, 0.0, 0.0).exp();
         assert_vec4_close(r.apply(Vec4::X), Vec4::Y);
         assert_vec4_close(r.apply(Vec4::Y), -Vec4::X);
@@ -1290,8 +1300,8 @@ mod tests {
     }
 
     /// A "double rotation" uses two complementary planes simultaneously.
-    /// Rotating by π/2 in both xy and zw: x → y, y → −x, z → w,
-    /// w → −z. The pseudoscalar component of the rotor is nonzero
+    /// Rotating by π/2 in both xy and zw: x -> y, y -> −x, z -> w,
+    /// w -> −z. The pseudoscalar component of the rotor is nonzero
     /// here, that's the fingerprint of the compound decomposition.
     #[test]
     fn bivector4_double_rotation_xy_plus_zw() {
@@ -1387,7 +1397,7 @@ mod tests {
             let rotated = r.apply(v);
             assert!(
                 (rotated.length() - v.length()).abs() < 1e-3,
-                "length drift: {v:?} → {rotated:?}"
+                "length drift: {v:?} -> {rotated:?}"
             );
         }
     }
@@ -1414,7 +1424,7 @@ mod tests {
         ] {
             let back = b.exp().log();
             let diff = (back + b * (-1.0)).magnitude();
-            assert!(diff < 1e-4, "log∘exp mismatch: {b:?} → {back:?}");
+            assert!(diff < 1e-4, "log∘exp mismatch: {b:?} -> {back:?}");
         }
     }
 

--- a/crates/rye-math/src/blended.rs
+++ b/crates/rye-math/src/blended.rs
@@ -2,12 +2,10 @@
 //! interpolates between two source Spaces A and B via a
 //! blending field F: ℝ³ -> [0, 1].
 //!
-//! THESIS §2.2 design goal: *"Seamless transitions between
-//! geometries, not camera tricks."*
-//!
-//! See [`docs/devlog/BLENDED_SPACE.md`](../../../../docs/devlog/BLENDED_SPACE.md)
-//! for the full design, math foundation, numerical scheme,
-//! validation strategy, and lock-in audit.
+//! Design goal: seamless transitions between geometries, not camera
+//! tricks. The math foundation, numerical scheme, validation strategy,
+//! and lock-in notes for this implementation live in the project's
+//! private design notes, not in this docstring.
 //!
 //! ## What ships
 //!
@@ -501,7 +499,7 @@ pub const LOG_MAX_ITERS: u32 = 12;
 pub const LOG_RESIDUAL_TOL: f32 = 1.0e-5;
 
 /// Finite-difference step for the Jacobian of `exp` w.r.t. `v`.
-/// Smaller → more accurate Jacobian but more f32 noise; 1e-3 is
+/// Smaller -> more accurate Jacobian but more f32 noise; 1e-3 is
 /// the sweet spot for f32 RK4-of-32-steps.
 const LOG_JACOBIAN_EPS: f32 = 1.0e-3;
 
@@ -1345,7 +1343,7 @@ mod tests {
         // At x = -1 (alpha=0): factor = 1 (pure E³).
         close(bs.conformal_factor(Vec3::new(-1.0, 0.0, 0.0)), 1.0, 1e-6);
         // At x = 1 (alpha=1): factor = HyperbolicH3 at x=1, but
-        // x=1 is on the Poincaré boundary so f → ∞. Use a point
+        // x=1 is on the Poincaré boundary so f -> ∞. Use a point
         // *near* x=1 but slightly inside.
         let p = Vec3::new(0.99, 0.0, 0.0);
         let alpha = LinearBlendX::new(-1.0, 1.0).weight(p);

--- a/crates/rye-math/src/euclidean.rs
+++ b/crates/rye-math/src/euclidean.rs
@@ -231,11 +231,11 @@ mod tests {
     fn parallel_transport_along_default_impl_is_identity_in_flat_space() {
         let s = r3();
         let v = Vec3::new(1.7, -0.3, 0.5);
-        // Empty path → unchanged.
+        // Empty path -> unchanged.
         assert_eq!(s.parallel_transport_along(&[], v), v);
-        // Single point → unchanged.
+        // Single point -> unchanged.
         assert_eq!(s.parallel_transport_along(&[Vec3::ZERO], v), v);
-        // Multi-segment polyline → still identity in E³.
+        // Multi-segment polyline -> still identity in E³.
         let path = [
             Vec3::ZERO,
             Vec3::new(1.0, 0.0, 0.0),

--- a/crates/rye-math/src/hyperbolic.rs
+++ b/crates/rye-math/src/hyperbolic.rs
@@ -12,8 +12,8 @@
 //! model, composition is matmul, which the GPU and existing transform
 //! graphs are already good at. See [`Iso3H`].
 //!
-//! Applying an isometry to a point projects Poincaré → hyperboloid →
-//! matmul → Poincaré. Round-trip cost is paid per `iso_apply`, not per
+//! Applying an isometry to a point projects Poincaré -> hyperboloid ->
+//! matmul -> Poincaré. Round-trip cost is paid per `iso_apply`, not per
 //! shader fragment.
 //!
 //! ## Curvature
@@ -511,7 +511,7 @@ mod tests {
     #[test]
     fn small_scale_distance_matches_euclidean_via_metric_factor() {
         // At the origin, ds_hyp = 2 · ds_euc. So for tiny offsets,
-        // d_hyp(0, p) → 2 · |p|. This is the small-scale "flat limit"
+        // d_hyp(0, p) -> 2 · |p|. This is the small-scale "flat limit"
         // up to the constant conformal factor.
         let s = h3();
         let eps = 1e-3;
@@ -525,7 +525,7 @@ mod tests {
         // at 60° opening. Gauss-Bonnet for K = -1 gives:
         //   π − (α + β + γ) = area
         // For an equilateral hyperbolic triangle of side L the area
-        // approaches the Euclidean (√3/4) L² as L → 0.
+        // approaches the Euclidean (√3/4) L² as L -> 0.
         let s = h3();
         let l = 0.05;
         let v_norm = l * 0.5; // exp from origin moves 2·|v|

--- a/crates/rye-math/src/spherical.rs
+++ b/crates/rye-math/src/spherical.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::space::{Space, WgslSpace};
 
-/// Closest `|p|²` is allowed to 1.0. At the equator `w = sqrt(1 − |p|²) → 0`
+/// Closest `|p|²` is allowed to 1.0. At the equator `w = sqrt(1 − |p|²) -> 0`
 /// and the tangent formula saturates; this shell keeps `w ≥ ~1e-3`.
 const SPHERE_R2_MAX: f32 = 1.0 - 1e-6;
 
@@ -124,10 +124,10 @@ impl Iso4 {
         let k = c - 1.0; // reused below
 
         // Givens rotation in the {n_4d, e_w} plane by angle θ (cos=c, sin=s)
-        // mapping e_w → qt. Derivation: for each basis vector e_i, decompose
+        // mapping e_w -> qt. Derivation: for each basis vector e_i, decompose
         // into (component along n_4d, component along e_w, perpendicular)
         // and apply the 2D rotation. The result is the same algebraic form as
-        // H³'s Lorentz boost with sinh→sin, cosh→cos, and a sign flip on the
+        // H³'s Lorentz boost with sinh->sin, cosh->cos, and a sign flip on the
         // (xyz, w) block (SO(4) vs SO⁺(3,1)).
         Self {
             matrix: Mat4::from_cols(
@@ -169,7 +169,7 @@ impl Space for SphericalS3 {
         }
         let q = to_sphere(at);
         // Lift v to a 4D tangent perpendicular to q.
-        // Constraint: dot(v4, q) = dot(v, at) + vw·q.w = 0 → vw = −dot(v,at)/q.w
+        // Constraint: dot(v4, q) = dot(v, at) + vw·q.w = 0 -> vw = −dot(v,at)/q.w
         let vw = -v.dot(at) / q.w;
         let v4 = Vec4::new(v.x, v.y, v.z, vw);
         let mag = v4.length();

--- a/crates/rye-physics/Cargo.toml
+++ b/crates/rye-physics/Cargo.toml
@@ -9,5 +9,6 @@ description = "Rye rigid-body physics: Space-generic integration, narrowphase di
 
 [dependencies]
 glam.workspace = true
+tracing.workspace = true
 rye-math  = { path = "../rye-math" }
 rye-shape = { path = "../rye-shape" }

--- a/crates/rye-physics/src/collision/epa.rs
+++ b/crates/rye-physics/src/collision/epa.rs
@@ -125,7 +125,7 @@ impl Polytope {
         for f in self.faces.drain(..) {
             let view = support.point - self.vertices[f.v[0]].point;
             if f.normal.dot(view) > 0.0 {
-                // Face faces the new point → remove, record edges.
+                // Face faces the new point -> remove, record edges.
                 add_or_remove_edge(&mut horizon, f.v[0], f.v[1]);
                 add_or_remove_edge(&mut horizon, f.v[1], f.v[2]);
                 add_or_remove_edge(&mut horizon, f.v[2], f.v[0]);
@@ -286,6 +286,13 @@ pub fn epa<A: SupportFn, B: SupportFn>(
 
     // Iteration cap reached; return the current best estimate rather
     // than failing outright. Happens only for nearly-degenerate inputs.
+    // Emit a debug-level trace so developers tuning narrowphase can
+    // count cap hits without spamming release logs.
+    tracing::debug!(
+        max_iterations = EPA_MAX_ITERATIONS,
+        vertices = polytope.vertices.len(),
+        "EPA 3D hit iteration cap; returning best-estimate contact",
+    );
     let face_idx = polytope.closest_face()?;
     contact_from_face(&polytope, polytope.faces[face_idx])
 }
@@ -363,7 +370,7 @@ mod tests {
 
     #[test]
     fn box_box_axis_aligned_overlap_penetration_matches_axis() {
-        // Unit boxes offset by 1.5 along X → 0.5 overlap along +X.
+        // Unit boxes offset by 1.5 along X -> 0.5 overlap along +X.
         let va = box_vertices(Vec3::ZERO, Vec3::ONE);
         let vb = box_vertices(Vec3::new(1.5, 0.0, 0.0), Vec3::ONE);
         let a = ConvexHull { vertices: &va };
@@ -377,7 +384,7 @@ mod tests {
         );
         assert!(
             info.normal.dot(Vec3::X) > 0.0,
-            "normal not A→B: {:?}",
+            "normal not A->B: {:?}",
             info.normal
         );
         assert_close(info.penetration, 0.5, 1e-3);
@@ -397,7 +404,7 @@ mod tests {
             radius: 0.5,
         };
 
-        // Put the box as A and the sphere as B so normal A→B points
+        // Put the box as A and the sphere as B so normal A->B points
         // toward (1, 1, 1)/√3.
         let info = run(&b, &s, Vec3::new(1.0, 1.0, 1.0));
         let expected = Vec3::new(1.0, 1.0, 1.0).normalize();

--- a/crates/rye-physics/src/collision/epa_r4.rs
+++ b/crates/rye-physics/src/collision/epa_r4.rs
@@ -139,7 +139,7 @@ impl Polytope4 {
         for f in self.faces.drain(..) {
             let view = support.point - self.vertices[f.v[0]].point;
             if f.normal.dot(view) > 0.0 {
-                // Visible from the new point → remove.
+                // Visible from the new point -> remove.
                 for tri in tet_triangles(&f.v) {
                     add_or_remove_triangle(&mut horizon, tri);
                 }
@@ -149,7 +149,7 @@ impl Polytope4 {
         }
         self.faces = keep;
 
-        // Each horizon triangle + new vertex → new tetrahedral face.
+        // Each horizon triangle + new vertex -> new tetrahedral face.
         // Re-uses the seed centroid as the interior reference,
         // still inside the (only-expanding) polytope by convexity.
         let centroid = self.centroid;
@@ -176,10 +176,10 @@ type Triangle = (usize, usize, usize);
 /// one vertex in the rotation `(a, b, c, d)`.
 fn tet_triangles(tet: &[usize; 4]) -> [Triangle; 4] {
     // The opposite-vertex-excluded triangles:
-    //   exclude d → (a, b, c)
-    //   exclude c → (a, b, d) but with flipped winding
-    //   exclude b → (a, c, d)
-    //   exclude a → (b, c, d) with flipped winding
+    //   exclude d -> (a, b, c)
+    //   exclude c -> (a, b, d) but with flipped winding
+    //   exclude b -> (a, c, d)
+    //   exclude a -> (b, c, d) with flipped winding
     //
     // Signs don't matter here since we use an order-insensitive
     // match (see `add_or_remove_triangle`). Use the canonical
@@ -223,7 +223,7 @@ fn sort_triangle(t: Triangle) -> (usize, usize, usize) {
 /// cases, where the face is degenerate anyway).
 ///
 /// Returns `None` when the face is degenerate (three edges nearly
-/// coplanar → tiny normal magnitude).
+/// coplanar -> tiny normal magnitude).
 fn build_face(
     verts: &[MinkowskiPoint4],
     a: usize,
@@ -254,7 +254,7 @@ fn build_face(
     } else {
         // Origin lies on the face plane. Use the centroid as
         // tiebreaker: if centroid is on `+normal` side (relative to
-        // pa), `+normal` points toward interior → flip.
+        // pa), `+normal` points toward interior -> flip.
         let signed_c = normal.dot(centroid - pa);
         signed_c > 0.0
     };
@@ -280,7 +280,7 @@ fn build_face(
 /// Generalized 4D cross product: the vector perpendicular to three
 /// 4-vectors `u`, `v`, `w`. Equal to the Hodge dual of the trivector
 /// `u ∧ v ∧ w`, which for basis `e_ijk` maps
-/// `e_123 → −e_4, e_124 → +e_3, e_134 → −e_2, e_234 → +e_1`.
+/// `e_123 -> −e_4, e_124 -> +e_3, e_134 -> −e_2, e_234 -> +e_1`.
 ///
 /// Components are four 3×3 determinants of the column-sub-matrices
 /// of `[u; v; w]`, with alternating signs.
@@ -292,7 +292,7 @@ fn hodge_dual_of_trivector_wedge(u: Vec4, v: Vec4, w: Vec4) -> Vec4 {
     let t_124 = det3(u.x, u.y, u.w, v.x, v.y, v.w, w.x, w.y, w.w);
     let t_123 = det3(u.x, u.y, u.z, v.x, v.y, v.z, w.x, w.y, w.z);
 
-    // Hodge dual: e_123 → −e_4, e_124 → +e_3, e_134 → −e_2, e_234 → +e_1.
+    // Hodge dual: e_123 -> −e_4, e_124 -> +e_3, e_134 -> −e_2, e_234 -> +e_1.
     Vec4::new(t_234, -t_134, t_124, -t_123)
 }
 
@@ -356,7 +356,13 @@ pub fn epa_r4<A: SupportFn4, B: SupportFn4>(
     }
 
     // Iteration cap, return best-estimate contact from current
-    // closest face rather than failing.
+    // closest face rather than failing. Debug-level trace so the
+    // 4D narrowphase tuning has the same observability as 3D.
+    tracing::debug!(
+        max_iterations = EPA_MAX_ITERATIONS,
+        vertices = polytope.vertices.len(),
+        "EPA 4D hit iteration cap; returning best-estimate contact",
+    );
     let face_idx = polytope.closest_face()?;
     contact_from_face(&polytope, polytope.faces[face_idx])
 }
@@ -547,7 +553,7 @@ mod tests {
     }
 
     /// 16-cell vs 16-cell: the cross-polytope with 8 vertices. Tests
-    /// the GJK→EPA pipeline on a sharp-vertexed polytope that has
+    /// the GJK->EPA pipeline on a sharp-vertexed polytope that has
     /// fewer support points than the tesseract.
     #[test]
     fn cell16_cell16_penetration_nonzero() {

--- a/crates/rye-physics/src/collision/gjk.rs
+++ b/crates/rye-physics/src/collision/gjk.rs
@@ -9,12 +9,12 @@
 //!   `s_{A⊖B}(d) = s_A(d) − s_B(−d)`.
 //! - GJK maintains a simplex of such support points inside `A ⊖ B` and
 //!   iteratively refines it, always moving toward the origin, until it
-//!   either encloses the origin (→ intersection) or finds a direction
-//!   where no new support point makes progress (→ separation).
+//!   either encloses the origin (-> intersection) or finds a direction
+//!   where no new support point makes progress (-> separation).
 //!
 //! This module is the 3D specialization: a simplex can be at most a
 //! tetrahedron (4 points). The Voronoi-region logic for the
-//! line → triangle → tetrahedron cases is hand-written. The support-
+//! line -> triangle -> tetrahedron cases is hand-written. The support-
 //! function side is generic over `VectorOps`, so when 4D lands,
 //! only the simplex-case logic needs a 4D cousin (pentachoron = 5
 //! points); the support-function path, the iteration loop, and all
@@ -335,9 +335,9 @@ fn do_tetrahedron(simplex: &mut [MinkowskiPoint; 4]) -> (bool, usize, Vec3) {
     if adb.dot(ao) > 0.0 {
         // Drop C, recurse on triangle [B, D, A].
         let d_point = simplex[0];
-        simplex[0] = simplex[2]; // B → [0]
-        simplex[1] = d_point; // D → [1]
-        simplex[2] = simplex[3]; // A → [2]
+        simplex[0] = simplex[2]; // B -> [0]
+        simplex[1] = d_point; // D -> [1]
+        simplex[2] = simplex[3]; // A -> [2]
         return do_triangle(simplex);
     }
 
@@ -429,8 +429,8 @@ mod tests {
     #[test]
     fn sphere_vs_sphere_matches_distance_test() {
         for &(ax, bx, overlap) in &[
-            (0.0, 3.0, false), // 3 apart, radii 1 each → gap of 1
-            (0.0, 1.5, true),  // 1.5 apart, radii 1 each → overlap
+            (0.0, 3.0, false), // 3 apart, radii 1 each -> gap of 1
+            (0.0, 1.5, true),  // 1.5 apart, radii 1 each -> overlap
             (0.0, 2.0, true),  // exactly touching
         ] {
             let a = Sphere {
@@ -455,8 +455,8 @@ mod tests {
         // Unit box with corner at (1,1,1). Sphere at (1+d, 1+d, 1+d)
         // reaches the corner when d·√3 ≤ r, i.e. d ≤ r/√3.
         // For r=0.5: threshold d ≈ 0.2887.
-        //   d = 0.35 → distance 0.606 > 0.5 → no overlap
-        //   d = 0.20 → distance 0.346 < 0.5 → overlap
+        //   d = 0.35 -> distance 0.606 > 0.5 -> no overlap
+        //   d = 0.20 -> distance 0.346 < 0.5 -> overlap
         let vb = box_vertices(Vec3::ZERO, Vec3::ONE);
         let b = ConvexHull { vertices: &vb };
 

--- a/crates/rye-physics/src/collision/gjk_r4.rs
+++ b/crates/rye-physics/src/collision/gjk_r4.rs
@@ -114,8 +114,8 @@ const GJK_EPS: f32 = 1e-6;
 /// (via [`closest_to_origin`]), drops any unused vertices, then
 /// searches for a new support in the direction from the closest point
 /// toward the origin. Terminates when (i) a new support can't advance
-/// toward the origin (→ separated), (ii) the simplex's closest point
-/// reaches the origin (→ intersecting), or (iii) iteration cap is hit.
+/// toward the origin (-> separated), (ii) the simplex's closest point
+/// reaches the origin (-> intersecting), or (iii) iteration cap is hit.
 pub fn gjk_intersect_r4<A: SupportFn4, B: SupportFn4>(
     a: &A,
     b: &B,
@@ -132,9 +132,9 @@ pub fn gjk_intersect_r4<A: SupportFn4, B: SupportFn4>(
 
     // ---- Phase 1: standard GJK, searching toward the origin.
     // Terminates when either (a) a new support fails to cross the
-    // origin along the search direction (→ Separated) or (b) the
+    // origin along the search direction (-> Separated) or (b) the
     // current simplex's closest-point to origin is already at the
-    // origin (→ shapes intersect, exit to Phase 2 to grow the
+    // origin (-> shapes intersect, exit to Phase 2 to grow the
     // simplex to 5 points for EPA).
     for _ in 0..GJK_MAX_ITERATIONS {
         if dir.length_squared() < GJK_EPS {

--- a/crates/rye-physics/src/euclidean_r2.rs
+++ b/crates/rye-physics/src/euclidean_r2.rs
@@ -387,7 +387,7 @@ fn sphere_polygon_r2(
     if point_in_convex_ccw(&vb, center) {
         // Sphere center is inside the polygon, maximal penetration.
         // Push the sphere out along (center - closest) = toward the
-        // nearest edge. Normal A→B is from sphere toward polygon =
+        // nearest edge. Normal A->B is from sphere toward polygon =
         // (closest - center) direction, but since the center is inside
         // we flip to push it out.
         let dir = (center - closest).try_normalize().unwrap_or(Vec2::Y);
@@ -439,7 +439,7 @@ pub fn regular_polygon_vertices(n: u32, r: f32) -> Vec<Vec2> {
 /// `I = (m·r²/6) · (1 + 2·cos²(π/n))`
 ///
 /// Reduces to `m·r²/4` for n=3, `m·r²/3` for n=4, and `m·r²/2` in the
-/// disk limit as n→∞.
+/// disk limit as n->∞.
 pub fn regular_polygon_inertia(mass: f32, n: u32, r: f32) -> f32 {
     use std::f32::consts::PI;
     let c = (PI / n as f32).cos();
@@ -606,12 +606,12 @@ mod tests {
         register_default_narrowphase(&mut np);
 
         // Two axis-aligned unit squares (half-extent 1), centers 1.5
-        // apart along X → x-extents overlap by 0.5.
+        // apart along X -> x-extents overlap by 0.5.
         let a = aa_box(Vec2::ZERO, Vec2::ONE, 1.0);
         let b = aa_box(Vec2::new(1.5, 0.0), Vec2::ONE, 1.0);
 
         let c = np.test(&a, &b, &EuclideanR2).expect("should collide");
-        // Normal A→B should point along ±X; minimum overlap 0.5.
+        // Normal A->B should point along ±X; minimum overlap 0.5.
         assert!(
             c.normal.dot(Vec2::X).abs() > 0.99,
             "normal not ±X: {:?}",
@@ -619,7 +619,7 @@ mod tests {
         );
         assert!(
             c.normal.dot(Vec2::X) > 0.0,
-            "normal not A→B: {:?}",
+            "normal not A->B: {:?}",
             c.normal
         );
         assert!(
@@ -655,7 +655,7 @@ mod tests {
 
         // Rotate B by 45°. Its x-extent becomes ±√2/2 ≈ ±0.707, so the
         // gap between A's right edge (x=1) and B's left edge (x=1.9−0.707=1.193)
-        // is positive → no collision.
+        // is positive -> no collision.
         let mut b = polygon_body(Vec2::new(1.9, 0.0), Vec2::ZERO, 4, 1.0, 1.0);
         b.orientation = Iso2 {
             rotation: rye_math::Bivector2(std::f32::consts::FRAC_PI_4).exp(),
@@ -670,7 +670,7 @@ mod tests {
         register_default_narrowphase(&mut np);
 
         // Square circumradius 1 at origin. Its right edge is at x=1.
-        // Sphere radius 0.5 at (1.3, 0) → distance from center to edge
+        // Sphere radius 0.5 at (1.3, 0) -> distance from center to edge
         // is 0.3, penetration = 0.5 − 0.3 = 0.2.
         let square = polygon_body(Vec2::ZERO, Vec2::ZERO, 4, 1.0, 1.0);
         let sphere = sphere_body(Vec2::new(1.3, 0.0), Vec2::ZERO, 0.5, 1.0);
@@ -678,7 +678,7 @@ mod tests {
         let c = np
             .test(&sphere, &square, &EuclideanR2)
             .expect("should collide");
-        // Normal sphere→square (A→B): points from sphere toward polygon = −X.
+        // Normal sphere->square (A->B): points from sphere toward polygon = −X.
         assert!(c.normal.dot(-Vec2::X) > 0.99, "normal: {:?}", c.normal);
         assert!(
             (c.penetration - 0.2).abs() < 1e-4,
@@ -708,11 +708,11 @@ mod tests {
         let square = polygon_body(Vec2::ZERO, Vec2::ZERO, 4, 1.0, 1.0);
         let sphere = sphere_body(Vec2::new(1.3, 0.0), Vec2::ZERO, 0.5, 1.0);
 
-        // polygon first, sphere second → dispatch flips.
+        // polygon first, sphere second -> dispatch flips.
         let c = np
             .test(&square, &sphere, &EuclideanR2)
             .expect("should collide");
-        // Normal polygon→sphere (A→B): now points from polygon toward sphere = +X.
+        // Normal polygon->sphere (A->B): now points from polygon toward sphere = +X.
         assert!(c.normal.dot(Vec2::X) > 0.99, "normal: {:?}", c.normal);
     }
 

--- a/crates/rye-physics/src/euclidean_r3.rs
+++ b/crates/rye-physics/src/euclidean_r3.rs
@@ -6,7 +6,7 @@
 //! when a game actually needs them, a full 3×3 `Inertia` type is a
 //! structural change to the trait and can happen later.
 //!
-//! Orientation integration bridges `Bivector3` → `Rotor3` → `Quat` (the
+//! Orientation integration bridges `Bivector3` -> `Rotor3` -> `Quat` (the
 //! type stored in `Iso3`). The conversion is a fixed mapping
 //! (xy↔z, yz↔x, zx↔y) defined by how rotor sandwich matches quaternion
 //! conjugation for the three cardinal axes.
@@ -41,7 +41,7 @@ fn omega_cross_r(w: Bivector3, r: Vec3) -> Vec3 {
     )
 }
 
-/// Wedge product `r ∧ f` → bivector. Components match `r × f` mapped
+/// Wedge product `r ∧ f` -> bivector. Components match `r × f` mapped
 /// via the (xy↔z, yz↔x, zx↔y) correspondence used by `rotor_to_quat`.
 fn wedge(r: Vec3, f: Vec3) -> Bivector3 {
     Bivector3::new(
@@ -71,13 +71,13 @@ impl PhysicsSpace for EuclideanR3 {
     type Inertia = f32;
 
     fn integrate_orientation(&self, iso: Iso3, omega: Bivector3, dt: f32) -> Iso3 {
-        // Guard against NaN/infinite angular velocity leaking into the
-        // orientation. Without this, one bad impulse → NaN ω → NaN
-        // rotor → NaN quaternion → downstream wgpu validation blows up
-        // when it hits the GPU buffer.
-        if !(omega.xy.is_finite() && omega.yz.is_finite() && omega.zx.is_finite()) {
-            return iso;
-        }
+        // Catch NaN/infinite angular velocity at the source rather
+        // than letting it propagate through the rotor and into the
+        // GPU buffer. Debug-only; release builds trust internal callers.
+        debug_assert!(
+            omega.xy.is_finite() && omega.yz.is_finite() && omega.zx.is_finite(),
+            "non-finite Bivector3 angular velocity in integrate_orientation",
+        );
         let delta_rotor = (omega * dt).exp();
         let delta_quat = rotor_to_quat(delta_rotor);
         // Compose: delta applied after existing rotation. Renormalize
@@ -198,7 +198,7 @@ fn sphere_halfspace_r3(
     if penetration <= 0.0 {
         return None;
     }
-    // Contact normal A→B points *into* the half-space (into the wall),
+    // Contact normal A->B points *into* the half-space (into the wall),
     // i.e. opposite to the half-space's outward normal. Pushing along this
     // separates the sphere from the wall.
     let contact_normal = -normal;
@@ -346,7 +346,7 @@ fn sphere_polytope_r3(
 
 /// Polytope vs half-space: analytical deep-vertex search. The polytope
 /// vertex penetrating deepest into the half-space is the contact point;
-/// normal = −plane_normal (A→B, from polytope into the solid side),
+/// normal = −plane_normal (A->B, from polytope into the solid side),
 /// depth = how far that vertex is beyond the plane.
 fn polytope_halfspace_r3(
     a: &RigidBody<EuclideanR3>,
@@ -700,7 +700,7 @@ mod tests {
     fn off_center_glancing_hit_produces_angular_velocity() {
         // A static-ish target sphere at the origin is hit by a moving
         // sphere offset vertically from the collision axis. The
-        // contact point lies off each body's geometric center → the
+        // contact point lies off each body's geometric center -> the
         // impact should impart angular velocity.
         let mut world = World::new(EuclideanR3);
         register_default_narrowphase(&mut world.narrowphase);

--- a/crates/rye-physics/src/euclidean_r4.rs
+++ b/crates/rye-physics/src/euclidean_r4.rs
@@ -62,17 +62,18 @@ impl PhysicsSpace for EuclideanR4 {
     type Inertia = f32;
 
     fn integrate_orientation(&self, iso: Iso4Flat, omega: Bivector4, dt: f32) -> Iso4Flat {
-        // Guard against NaN/infinite angular velocity leaking into
-        // the orientation, same defense in depth as the 3D path.
-        if !(omega.xy.is_finite()
-            && omega.xz.is_finite()
-            && omega.xw.is_finite()
-            && omega.yz.is_finite()
-            && omega.yw.is_finite()
-            && omega.zw.is_finite())
-        {
-            return iso;
-        }
+        // Catch NaN/infinite angular velocity at the source rather
+        // than letting it propagate through the rotor and into the
+        // GPU buffer. Debug-only; release builds trust internal callers.
+        debug_assert!(
+            omega.xy.is_finite()
+                && omega.xz.is_finite()
+                && omega.xw.is_finite()
+                && omega.yz.is_finite()
+                && omega.yw.is_finite()
+                && omega.zw.is_finite(),
+            "non-finite Bivector4 angular velocity in integrate_orientation",
+        );
         let delta = (omega * dt).exp();
         // Rotor4 multiplication is left-first: `A · B` applies A then
         // B. To apply `iso_current` then `delta`, compose as
@@ -197,7 +198,7 @@ fn sphere_halfspace_r4(
     if penetration <= 0.0 {
         return None;
     }
-    // A→B normal points *into* the half-space (opposite the
+    // A->B normal points *into* the half-space (opposite the
     // half-space's outward normal); pushing along it separates the
     // sphere from the wall.
     let contact_normal = -normal;
@@ -692,7 +693,7 @@ mod tests {
     /// (not None from `validate_contact4`), comes to rest above the
     /// floor, and stays there with bounded angular velocity.
     /// End-to-end integration test of the full
-    /// `gravity → integrator → polytope_halfspace_r4 → manifold → PGS`
+    /// `gravity -> integrator -> polytope_halfspace_r4 -> manifold -> PGS`
     /// pipeline in 4D.
     ///
     /// **Catches:**
@@ -1052,7 +1053,7 @@ mod tests {
         );
     }
 
-    /// Separated 4D polytopes → no contact. Exercises the bounding-
+    /// Separated 4D polytopes -> no contact. Exercises the bounding-
     /// sphere pre-cull plus GJK's Separated path.
     #[test]
     fn separated_pentatopes_produce_no_contact() {

--- a/crates/rye-physics/src/field.rs
+++ b/crates/rye-physics/src/field.rs
@@ -3,7 +3,7 @@
 //!
 //! Register any number of force fields on a [`crate::World`]. Each
 //! integration tick, [`crate::World::step`] samples every field at each
-//! body's position, accumulates the forces, and applies `v ← v + F·dt/m`
+//! body's position, accumulates the forces, and applies `v += F*dt/m`
 //! before advancing bodies along geodesics.
 
 use crate::body::RigidBody;

--- a/crates/rye-physics/src/integrator.rs
+++ b/crates/rye-physics/src/integrator.rs
@@ -35,7 +35,7 @@ pub trait PhysicsSpace: Space {
     fn integrate_orientation(&self, iso: Self::Iso, omega: Self::AngVel, dt: f32) -> Self::Iso;
 
     /// Apply the inverse inertia to a torque-bivector. Used by the
-    /// solver for `ω ← ω + I⁻¹τ dt`.
+    /// solver for `ω += I⁻¹τ dt`.
     fn apply_inv_inertia(&self, inertia: Self::Inertia, torque: Self::AngVel) -> Self::AngVel;
 
     /// World-space velocity of `body` at world point `p`, accounting

--- a/crates/rye-physics/src/lib.rs
+++ b/crates/rye-physics/src/lib.rs
@@ -8,7 +8,7 @@
 //!   velocity, mass, and a [`Collider`].
 //! - [`World<S>`] owns bodies, force fields, and a [`Narrowphase`]
 //!   dispatch table. One `step(dt)` advances the simulation by one tick.
-//! - [`Narrowphase<S>`] is a registry of `(ColliderKind, ColliderKind) →
+//! - [`Narrowphase<S>`] is a registry of `(ColliderKind, ColliderKind) ->
 //!   NarrowphaseFn<S>` entries. New collider types / new spaces / new
 //!   collision algorithms are added by registering functions in this
 //!   table; no existing code changes.

--- a/crates/rye-physics/src/manifold.rs
+++ b/crates/rye-physics/src/manifold.rs
@@ -7,7 +7,7 @@
 //! bodies stable: the bottom body has one contact with the floor, one
 //! with the body above; each frame's resolution applies an impulse,
 //! the next frame finds the bodies still slightly overlapping (due to
-//! gravity over `dt`), repeat → jitter forever.
+//! gravity over `dt`), repeat -> jitter forever.
 //!
 //! The standard fix is two-fold:
 //!
@@ -175,7 +175,7 @@ pub const DEFAULT_PGS_ITERS: usize = 8;
 
 /// Baumgarte bias coefficient: how aggressively the velocity-level
 /// constraint corrects positional error per timestep. β ∈ [0.1, 0.3]
-/// is the standard range. Higher → faster correction, more energetic
+/// is the standard range. Higher -> faster correction, more energetic
 /// (can introduce small bursts of velocity). 0.2 is the Bullet /
 /// rapier default.
 pub const BAUMGARTE_BETA: f32 = 0.2;

--- a/crates/rye-physics/src/world.rs
+++ b/crates/rye-physics/src/world.rs
@@ -297,9 +297,13 @@ fn solve_normal_then_tangent<S>(
     S: PhysicsSpace,
     S::Vector: VectorOps,
 {
-    if !VectorOps::is_finite(cp.normal) || !cp.penetration.is_finite() {
-        return;
-    }
+    // Contacts reach the solver only after narrowphase validation; a
+    // non-finite slot here means a bug upstream, not a runtime case to
+    // silently skip. Catch it in debug; release trusts narrowphase.
+    debug_assert!(
+        VectorOps::is_finite(cp.normal) && cp.penetration.is_finite(),
+        "non-finite contact in solve_normal_then_tangent",
+    );
 
     // ---- Normal solve ----
     let v_rel_n_vec =

--- a/crates/rye-player/src/lib.rs
+++ b/crates/rye-player/src/lib.rs
@@ -26,7 +26,7 @@ use rye_math::Space;
 /// [`PlayerState::advance`] every tick to move along geodesics driven by WASD,
 /// and [`PlayerState::advance_look`] to update yaw from mouse.
 ///
-/// The space type `S` must map `Vec3 → Vec3` (point and tangent vector both live
+/// The space type `S` must map `Vec3 -> Vec3` (point and tangent vector both live
 /// in R³ from the Space's ambient embedding, e.g. Poincaré ball for H³).
 pub struct PlayerState<S: Space<Point = Vec3, Vector = Vec3>> {
     pub position: Vec3,
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn advance_forward_moves_in_minus_z() {
         let mut player: PlayerState<EuclideanR3> = PlayerState::new(Vec3::ZERO);
-        // yaw=0 → forward = −Z
+        // yaw=0 -> forward = −Z
         player.advance(
             &FrameInput {
                 move_forward: 1.0,

--- a/crates/rye-render/src/device.rs
+++ b/crates/rye-render/src/device.rs
@@ -11,12 +11,18 @@ use std::sync::Arc;
 use wgpu::*;
 use winit::window::Window;
 
+/// Surface + per-frame configuration. Owned by [`RenderDevice`]; held
+/// out as a struct so resize-aware code can read the current size and
+/// format without poking at private fields.
 pub struct SurfaceBundle {
     pub surface: Surface<'static>,
     pub config: SurfaceConfiguration,
     pub size: winit::dpi::PhysicalSize<u32>,
 }
 
+/// All wgpu state the engine carries: shared `Instance`, the chosen
+/// `Adapter`, the logical `Device`, the submission `Queue`, and the
+/// current surface bundle. One per app; cloning this is not supported.
 pub struct RenderDevice {
     pub instance: Instance,
     pub adapter: Adapter,
@@ -26,6 +32,10 @@ pub struct RenderDevice {
 }
 
 impl RenderDevice {
+    /// Acquire a surface for `window`, request a high-performance
+    /// adapter, and configure the surface for sRGB rendering when
+    /// the platform supports it. Async because both adapter and
+    /// device creation are async on every wgpu backend.
     pub async fn new(window: Arc<Window>) -> Result<Self> {
         let instance = Instance::default();
 
@@ -87,6 +97,9 @@ impl RenderDevice {
         })
     }
 
+    /// Reconfigure the surface for the new window size. No-ops on
+    /// width or height of zero (the minimized-window case wgpu rejects
+    /// outright).
     pub fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
         if new_size.width == 0 || new_size.height == 0 {
             return;
@@ -99,6 +112,10 @@ impl RenderDevice {
             .configure(&self.device, &self.surface_bundle.config);
     }
 
+    /// Acquire the next swapchain texture and its default view, ready
+    /// for a render pass. Returns the wgpu surface error directly so
+    /// callers can branch on `Lost` / `Outdated` / `Timeout` without
+    /// extra wrapping.
     pub fn begin_frame(
         &self,
     ) -> std::result::Result<(SurfaceTexture, TextureView), wgpu::SurfaceError> {

--- a/crates/rye-render/src/graph.rs
+++ b/crates/rye-render/src/graph.rs
@@ -10,26 +10,39 @@
 use crate::device::RenderDevice;
 use anyhow::Result;
 
+/// One render-pass-or-equivalent unit of work the graph runs.
 pub trait RenderNode {
+    /// Static label used for tracing / debug output. Returned by
+    /// reference because most impls hand back a string literal.
     fn name(&self) -> &'static str;
+
+    /// Run the node against the given device + target view. Errors
+    /// abort the rest of the graph.
     fn execute(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> Result<()>;
 }
 
+/// Linear sequence of [`RenderNode`]s. Construction is fluent
+/// ([`RenderGraph::add_node`]); execution runs them in order against
+/// the same view ([`RenderGraph::run`]).
 #[derive(Default)]
 pub struct RenderGraph {
     nodes: Vec<Box<dyn RenderNode>>,
 }
 
 impl RenderGraph {
+    /// Empty graph; pair with chained [`Self::add_node`] calls.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Append a node and return self by value so calls chain.
     pub fn add_node<N: RenderNode + 'static>(mut self, node: N) -> Self {
         self.nodes.push(Box::new(node));
         self
     }
 
+    /// Run every node in insertion order, propagating the first error
+    /// the graph encounters and aborting subsequent nodes.
     pub fn run(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> Result<()> {
         for n in &mut self.nodes {
             n.execute(rd, view)?;

--- a/crates/rye-sdf/src/primitive4.rs
+++ b/crates/rye-sdf/src/primitive4.rs
@@ -134,7 +134,7 @@ mod tests {
     use glam::Vec4;
 
     /// Each emit produces a syntactically valid WGSL function with
-    /// the expected `vec4<f32> → f32` signature. We don't run the
+    /// the expected `vec4<f32> -> f32` signature. We don't run the
     /// shader here (that's the naga-validation test in
     /// `rye-shader`); we just sanity-check the textual output so
     /// the round-trip with the WGSL builder downstream stays

--- a/crates/rye-sdf/src/scene4.rs
+++ b/crates/rye-sdf/src/scene4.rs
@@ -10,13 +10,10 @@
 //!   is a uniform. This is the production path today,
 //!   `Hyperslice4DNode` consumes it as the SDF for a 3D ray march.
 //!
-//! See [`docs/devlog/4D_RENDERING.md`](../../../../docs/devlog/4D_RENDERING.md)
-//! for the design rationale.
-//!
 //! ## Why a parallel `Scene4`, not `Scene<S, const DIM>`
 //!
-//! Per the 4D-rendering design doc: the 3D and 4D paths share no
-//! shader code (different SDF signatures, different ray equations,
+//! The 3D and 4D paths share no shader code (different SDF signatures,
+//! different ray equations,
 //! different uniforms), so dimensioning [`crate::scene::Scene`]
 //! generically saves no implementation work and obscures the
 //! difference. Parallel hierarchies keep each clear.

--- a/crates/rye-shader/src/kernel.wgsl
+++ b/crates/rye-shader/src/kernel.wgsl
@@ -1,4 +1,4 @@
-// Geodesic ray march kernel — rye engine WGSL library.
+// Geodesic ray march kernel: rye engine WGSL library.
 //
 // Functions: rye_safe_normalize, rye_march_geodesic, rye_estimate_normal.
 //
@@ -21,24 +21,37 @@ fn rye_safe_normalize(v: vec3<f32>, fallback: vec3<f32>) -> vec3<f32> {
 //
 // Returns vec4(p_space, t_scene) on hit; w = -1.0 on miss or boundary escape.
 fn rye_march_geodesic(ro: vec3<f32>, rd: vec3<f32>, ball_scale: f32) -> vec4<f32> {
+    // Floor `ball_scale` so curved Spaces near the camera don't divide by
+    // zero on degenerate inputs.
     let scale = max(ball_scale, 1e-5);
     var p = ro * scale;
 
     // Probe the Riemannian norm of the camera-space direction at p to
     // initialise a Riemannian-unit tangent vector. Space-agnostic via ABI.
     let rd_unit = rye_safe_normalize(rd, vec3<f32>(0.0, 0.0, -1.0));
+    // Small finite-difference step to estimate the local Riemannian
+    // metric scaling without wandering far from `p`.
     let probe_eps = 1e-4;
     let probed     = rye_exp(p, rd_unit * probe_eps);
     let riem_norm  = rye_distance(p, probed) / probe_eps;
+    // Floor the divisor to keep the tangent finite when the metric
+    // collapses (rare boundary case in curved Spaces).
     var v = rd_unit / max(riem_norm, 1e-7);
 
     var t_scene = 0.0;
     var t_arc   = 0.0;
-    let hit_eps  = 0.001 * scale;
-    let min_step = 0.0001 * scale;
+    // Hit/min-step thresholds scale with `ball_scale` so a small camera
+    // (close-up demo) and a large camera (overview) get the same number
+    // of march steps over their respective fields of view.
+    let hit_eps  = 0.001  * scale;  // 1/1000 of camera-scale, the tightest hit gap
+    let min_step = 0.0001 * scale;  // 1/10000 of camera-scale, prevents stalls in flat regions
 
+    // 256 steps caps worst-case work at ~40K SDF evals per pixel; demos
+    // converge well under that even in H³.
     for (var i = 0; i < 256; i = i + 1) {
-        // Guard: escape near the Space boundary (Poincaré ball / S³ hemisphere).
+        // Escape near the Space boundary (Poincaré ball / S³ hemisphere).
+        // 0.92 leaves a small buffer so the ABI's saturating distance
+        // doesn't asymptote into a stall before the escape fires.
         if rye_origin_distance(p) > RYE_MAX_ARC * 0.92 {
             return vec4<f32>(0.0, 0.0, 0.0, -1.0);
         }
@@ -46,9 +59,14 @@ fn rye_march_geodesic(ro: vec3<f32>, rd: vec3<f32>, ball_scale: f32) -> vec4<f32
         if d < hit_eps {
             return vec4<f32>(p, t_scene);
         }
+        // 40.0 is the Euclidean-equivalent march cap (well past the
+        // typical scene); RYE_MAX_ARC caps Riemannian arc-length and is
+        // the curved-Space-specific termination.
         if t_scene > 40.0 || t_arc > RYE_MAX_ARC {
             return vec4<f32>(0.0, 0.0, 0.0, -1.0);
         }
+        // 0.85 under-steps the SDF, eliminates overshoot when the SDF
+        // is an approximation (typical for any non-trivial CSG tree).
         let step   = max(d * 0.85, min_step);
         let next_p = rye_exp(p, v * step);
         let next_v = rye_parallel_transport(p, next_p, v);
@@ -75,6 +93,9 @@ fn rye_march_geodesic(ro: vec3<f32>, rd: vec3<f32>, ball_scale: f32) -> vec4<f32
 // SDFs near `|p| ≈ 1` (boundary of the model) don't sample across
 // the boundary and get a NaN normal.
 fn rye_estimate_normal(p: vec3<f32>, ball_scale: f32) -> vec3<f32> {
+    // 0.0012 is slightly larger than the march `hit_eps = 0.001` so the
+    // gradient probe sees real surface variation rather than landing
+    // inside the same hit cell. Floor by 1e-5 to avoid degenerate eps.
     let eps = 0.0012 * max(ball_scale, 1e-5);
     let ex = vec3<f32>(eps, 0.0, 0.0);
     let ey = vec3<f32>(0.0, eps, 0.0);

--- a/examples/blended/blended.wgsl
+++ b/examples/blended/blended.wgsl
@@ -1,11 +1,11 @@
-// BlendedSpace demo — user shading layer.
+// BlendedSpace demo: user shading layer.
 //
 // The Space prelude (BlendedSpace<E3, H3, LinearBlendX>), scene SDF, and
 // geodesic march kernel are prepended by rye-shader before this file is
 // compiled. Available functions:
 //   rye_safe_normalize, rye_march_geodesic, rye_estimate_normal (kernel)
 //   rye_distance, rye_exp, rye_parallel_transport (Space prelude)
-//   rye_blended_alpha (BlendedSpace prelude — for tinting by zone)
+//   rye_blended_alpha (BlendedSpace prelude, for tinting by zone)
 //   rye_scene_sdf (scene module)
 //
 // Edit while the example is running; ShaderDb hot-reloads this file.
@@ -63,7 +63,7 @@ fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
     let ambient   = 0.22;
 
     // Tint by blending zone: E³ side cool blue, H³ side warm red.
-    // The transition zone shows a smooth gradient — *that* is the
+    // The transition zone shows a smooth gradient; *that* is the
     // visible BlendedSpace seam.
     let alpha = rye_blended_alpha(hit_space);
     let e3_color = vec3<f32>(0.40, 0.62, 0.95);

--- a/examples/corridor/corridor.wgsl
+++ b/examples/corridor/corridor.wgsl
@@ -1,4 +1,4 @@
-// Corridor geodesic raymarch demo — user shading layer.
+// Corridor geodesic raymarch demo: user shading layer.
 //
 // The Space prelude, scene SDF, and geodesic march kernel are prepended by
 // rye-shader before this file is compiled. Available functions:
@@ -40,7 +40,7 @@ fn vs_fullscreen(@builtin(vertex_index) vid: u32) -> @builtin(position) vec4<f32
 fn surface_base_color(n: vec3<f32>, hit: vec3<f32>) -> vec3<f32> {
     // Floor: normal points up strongly.
     if (n.y > 0.75) {
-        // Checkerboard in Space coords — tile lines are geodesic in E³,
+        // Checkerboard in Space coords; tile lines are geodesic in E³,
         // tanh-spaced in H³, sin-spaced in S³. The tiling is the grid.
         let cell = floor(hit.x * 10.0) + floor(hit.z * 10.0);
         let light_cell = 0.72;

--- a/examples/fractal/fractal.wgsl
+++ b/examples/fractal/fractal.wgsl
@@ -1,4 +1,4 @@
-// Mandelbulb raymarcher — the fractal demo for Rye.
+// Mandelbulb raymarcher: the fractal demo for Rye.
 //
 // Edit this file while the example is running; the ShaderDb watcher
 // recompiles and RayMarchNode rebuilds on the next frame.

--- a/examples/geodesic_spheres/spheres.wgsl
+++ b/examples/geodesic_spheres/spheres.wgsl
@@ -1,4 +1,4 @@
-// Geodesic spheres raymarch demo — user shading layer.
+// Geodesic spheres raymarch demo: user shading layer.
 //
 // The Space prelude, scene SDF, and geodesic march kernel are prepended by
 // rye-shader before this file is compiled. Available functions:

--- a/examples/hypersphere/hypersphere.wgsl
+++ b/examples/hypersphere/hypersphere.wgsl
@@ -5,7 +5,7 @@
 //   `sqrt(r² − (w₀ − c.w)²)`
 // centered at `(c.x, c.y, c.z)`. Outside that w-band the cross-section
 // is empty. As the user slides `w₀` the rendered sphere grows from a
-// point to its maximum radius and back — the visible signature of
+// point to its maximum radius and back: the visible signature of
 // slicing a 4-ball.
 //
 // Rendering: ray march the union of every active body's cross-section
@@ -55,7 +55,7 @@ struct SceneHit {
     // MAX_BODIES     = ground
     // MAX_BODIES + 1 = empty
     material: u32,
-    // For body hits, `dw` from this body's w to the slice plane —
+    // For body hits, `dw` from this body's w to the slice plane;
     // used by the fragment shader for the warm/cold tint.
     dw: f32,
 };
@@ -122,7 +122,7 @@ fn sky(rd: vec3<f32>) -> vec3<f32> {
 }
 
 /// Per-body base hue. Cycles through 8 distinct hues so adjacent
-/// bodies in the spawn order render in distinguishable colors —
+/// bodies in the spawn order render in distinguishable colors;
 /// useful when many cross-sections overlap in the slice plane.
 fn body_base_color(idx: u32) -> vec3<f32> {
     let i = idx % 8u;
@@ -147,14 +147,14 @@ fn body_base_color(idx: u32) -> vec3<f32> {
 /// Returns `(rgb, alpha)` in pre-multiplied form, ready to composite
 /// over a background.
 ///
-/// Cost: `MAX_STEPS × body_count` per pixel — roughly 250 × 32 ≈ 8K
+/// Cost: `MAX_STEPS × body_count` per pixel, roughly 250 × 32 ≈ 8K
 /// per pixel for the worst case. GPU absorbs this fine at 1080p; the
 /// inner loop early-exits as soon as accumulated alpha saturates.
 fn ghost_volume(ro: vec3<f32>, rd: vec3<f32>, body_count: u32, t_max: f32) -> vec4<f32> {
     let r4 = u.radius4;
     let r4_sq = r4 * r4;
     // Step size and extinction. Sigma is high enough that the
-    // visible silhouette matches the body's geometric radius — at
+    // visible silhouette matches the body's geometric radius: at
     // sigma = 1.5 a ray through the centre reaches alpha ≈ 0.99 and
     // a glancing ray with `p_perp = 0.9·r` still reaches alpha ≈ 0.6,
     // so the ghost reads as a soft-edged solid ball rather than a
@@ -241,7 +241,7 @@ fn fs_main(@builtin(position) frag_pos: vec4<f32>) -> @location(0) vec4<f32> {
     if (u.ghost_mode_f > 0.5) {
         let bg = ghost_background(ro, rd);
         // Volumetric march up to the floor (or 60 units if no floor
-        // hit). We don't penetrate the floor — bodies below `y = 0`
+        // hit). We don't penetrate the floor; bodies below `y = 0`
         // are unphysical anyway.
         let t_max = select(60.0, bg.w, bg.w > 0.0);
         let ghost = ghost_volume(ro, rd, body_count, t_max);

--- a/examples/lattice/lattice.wgsl
+++ b/examples/lattice/lattice.wgsl
@@ -1,4 +1,4 @@
-// Geodesic lattice demo — user shading layer.
+// Geodesic lattice demo: user shading layer.
 //
 // The Space prelude, scene SDF, and geodesic march kernel are prepended by
 // rye-shader (or the local assemble() call) before this file is compiled.
@@ -57,9 +57,9 @@ fn panel_ray_dir(frag_pos: vec4<f32>) -> vec3<f32> {
 
 // Per-space accent color for visual distinction between panels.
 fn accent_color(panel_idx: f32) -> vec3<f32> {
-    if panel_idx < 0.5 { return vec3<f32>(0.35, 0.60, 1.00); } // E³ — blue
-    if panel_idx < 1.5 { return vec3<f32>(1.00, 0.52, 0.18); } // H³ — orange
-    return vec3<f32>(0.22, 0.85, 0.58);                          // S³ — teal
+    if panel_idx < 0.5 { return vec3<f32>(0.35, 0.60, 1.00); } // E³: blue
+    if panel_idx < 1.5 { return vec3<f32>(1.00, 0.52, 0.18); } // H³: orange
+    return vec3<f32>(0.22, 0.85, 0.58);                          // S³: teal
 }
 
 @fragment

--- a/examples/pentatope_slice/pentatope_slice.wgsl
+++ b/examples/pentatope_slice/pentatope_slice.wgsl
@@ -1,4 +1,4 @@
-// Pentatope w-slice viewer — live physics edition.
+// Pentatope w-slice viewer: live physics edition.
 //
 // Differences from the static viewer that preceded this:
 //
@@ -7,7 +7,7 @@
 //   physics body's position + Rotor4 orientation on the CPU.
 // - There's a 4D ground at `y = 0` (a half-space whose normal is
 //   `+y` in 4D, with `w` component zero). Its cross-section at any
-//   `w = w₀` is the 3D half-space `y ≥ 0` — i.e. a horizontal floor
+//   `w = w₀` is the 3D half-space `y ≥ 0`: a horizontal floor
 //   plane that doesn't move when you change `w₀`.
 //
 // Rendering: ray march the union of the pentatope cross-section and
@@ -61,7 +61,7 @@ fn slice_sdf(p: vec3<f32>, w0: f32) -> SliceHit {
 
     // First pass: collect every edge-crossing point and average them
     // for an interior reference. The 4D body-centroid projected to
-    // xyz is *not* reliable here — once the body has rotated, that
+    // xyz is *not* reliable here: once the body has rotated, that
     // point can sit outside the cross-section, flipping face
     // normals and making the SDF read huge regions as "inside."
     // Cross-section vertices are always inside the cross-section's
@@ -97,7 +97,7 @@ fn slice_sdf(p: vec3<f32>, w0: f32) -> SliceHit {
             }
         }
 
-        // 6 cell edges → up to 4 cross-section vertices.
+        // 6 cell edges -> up to 4 cross-section vertices.
         var verts: array<vec3<f32>, 4>;
         var nv: i32 = 0;
         for (var i: i32 = 0; i < 4; i = i + 1) {

--- a/examples/physics2d/physics2d.wgsl
+++ b/examples/physics2d/physics2d.wgsl
@@ -107,7 +107,7 @@ fn color_for_kind(kind: u32) -> vec3<f32> {
 
 @fragment
 fn fs_main(@builtin(position) frag_pos: vec4<f32>) -> @location(0) vec4<f32> {
-    // Pixel → UV → world (y flipped so +Y is up).
+    // Pixel -> UV -> world (y flipped so +Y is up).
     let uv = frag_pos.xy / scene.resolution;
     let world = vec2<f32>(
         scene.view.x + uv.x * scene.view.z,

--- a/examples/physics3d/physics3d.wgsl
+++ b/examples/physics3d/physics3d.wgsl
@@ -1,4 +1,4 @@
-// 3D physics demo shader — renders a scene of mixed convex bodies
+// 3D physics demo shader: renders a scene of mixed convex bodies
 // (spheres, oriented boxes) plus an infinite floor via exact ray-shape
 // intersection. Spheres use analytical quadratic; boxes use the
 // slab method in the body's local frame.
@@ -95,7 +95,7 @@ fn intersect_plane(ro: vec3<f32>, rd: vec3<f32>, n: vec3<f32>, offset: f32) -> f
 /// Ray vs oriented box via the slab method. Ray is transformed to the
 /// box's local frame (position at origin, axis-aligned) before testing.
 fn intersect_box(ro: vec3<f32>, rd: vec3<f32>, center: vec3<f32>, half: vec3<f32>, rot: vec4<f32>) -> f32 {
-    // World → body-local: rotate by the inverse (conjugate) of rot.
+    // World -> body-local: rotate by the inverse (conjugate) of rot.
     let inv_rot = quat_conjugate(rot);
     let ro_local = quat_rotate(inv_rot, ro - center);
     let rd_local = quat_rotate(inv_rot, rd);

--- a/examples/polytope_smoke/main.rs
+++ b/examples/polytope_smoke/main.rs
@@ -3,7 +3,7 @@
 //! 16-cell, 24-cell, in a row on a 4D `y = 0` floor, with
 //! user-controllable `w`-slice scrubbing and a per-plane toggle
 //! UI for arbitrary 4D rotations. The user composes their own
-//! motion by toggling individual rotation planes (1..6 → xy, xz,
+//! motion by toggling individual rotation planes (1..6 -> xy, xz,
 //! xw, yz, yw, zw); active planes' bivectors sum into the
 //! per-frame angular velocity, which integrates into a rotor via
 //! `(ω · dt).exp()`. Sum-of-bivectors composition is commutative,
@@ -395,7 +395,7 @@ struct PolytopeSmokeApp {
     rot_state: Rotor4,
     /// Toggle bitmap for the six rotation planes; sum of active
     /// planes' unit bivectors becomes the per-frame angular
-    /// velocity. See [`PLANES`] for the index → plane mapping.
+    /// velocity. See [`PLANES`] for the index -> plane mapping.
     active: [bool; 6],
     rate_scale: f32,
     /// Accumulated time spent rotating (advances only while

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,26 @@
+//! `rye` aggregator crate.
+//!
+//! ## Facade scope
+//!
+//! Re-exports the foundational + rendering crates that an external
+//! consumer is most likely to want by short name:
+//!
+//! - [`asset`] (filesystem watcher)
+//! - [`math`] (Space trait + closed-form Spaces + bivectors)
+//! - [`render`] (wgpu wrapper + ray-march nodes)
+//! - [`shader`] (WGSL hot reload + Space-prelude injection)
+//! - [`time`] (fixed-timestep accumulator)
+//!
+//! The remaining crates (`rye-app`, `rye-camera`, `rye-input`,
+//! `rye-physics`, `rye-player`, `rye-sdf`, `rye-shape`, `rye-text`)
+//! are deliberately not re-exported here. They form the
+//! application/runtime layer and are best depended on directly so
+//! consumers see them in their own `Cargo.toml` rather than nested
+//! under `rye::*`. Revisit if the surface stabilizes and a flat
+//! `rye::*` import becomes the dominant ergonomic.
+//!
+//! Common types are gathered in [`prelude`] for `use rye::prelude::*;`.
+
 pub use rye_asset as asset;
 pub use rye_math as math;
 pub use rye_render as render;


### PR DESCRIPTION
Cleanup pass across the workspace; small fixes that don't individually merit their own PR.

## Changes

- **rye-physics**: defensive NaN guards in `integrate_orientation` (E³, E⁴) and `world::solve_normal_then_tangent` converted to `debug_assert!` so a non-finite value bubbles up to the actual bug rather than getting silently absorbed. Validation filters in `validate_contact*` stay (they are real filters, not silent-skip).
- **rye-physics**: EPA 3D + 4D iteration-cap fallback now emits `tracing::debug!` so cap hits are observable when tuning narrowphase.
- **rye-camera**: `orbit_in_blended_e3_h3_produces_valid_frame` test exercises `OrbitController` against `BlendedSpace<E3, H3, LinearBlendX>`, the variable-metric path the closed-form Spaces never hit.
- **rye-render**: per-fn docs on `RenderDevice::{new, resize, begin_frame}`, `RenderNode::{name, execute}`, `RenderGraph::{new, add_node, run}`, `SurfaceBundle`.
- **rye-shader**: every magic constant in `kernel.wgsl`'s march loop and normal-estimator now has a one-line provenance comment (`hit_eps`, `min_step`, `0.92` boundary buffer, `40.0` Euclidean cap, `0.85` under-step factor, `0.0012` normal-eps).
- **rye-math**: `bivector.rs` small-angle thresholds (`1e-16` / `1e-8` / `1e-12`) annotated with f32-precision rationale.
- **workspace**: `src/lib.rs` documents the deliberate facade subset (5 of 14 crates) so consumers know which crates are crate-direct.
- **sweep**: 22 em dashes and 103 unicode arrow characters across kernels, shaders, and Rust source replaced with ASCII equivalents. Keyboard `↑` / `↓` in user-facing controls help kept (they refer to physical keys).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (506 tests pass)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace`