### PR TITLE
feat(blended): WGSL rye_parallel_transport now 8-step RK4 + GPU parity test

### DIFF
--- a/crates/rye-math/src/blended.rs
+++ b/crates/rye-math/src/blended.rs
@@ -826,25 +826,20 @@ impl BlendingField for LinearBlendX {
 /// shader emission is single-instantiation.
 ///
 /// **Numerical scheme.** 16 RK4 sub-steps per `rye_exp` call
-/// (controlled by `RYE_BLENDED_RK4_SUB`). `rye_parallel_transport`
-/// is a single midpoint-Euler step along the chart-coordinate line
-/// from `p_from` to `p_to`.
+/// (`RYE_BLENDED_RK4_SUB`). 8 RK4 sub-steps per `rye_parallel_transport`
+/// call (`RYE_BLENDED_TRANSPORT_SUB`), matching the CPU's
+/// `parallel_transport_segment_rk4` step-for-step.
 ///
-/// The geodesic-march kernel in `rye-shader/kernel.wgsl` calls this
-/// `rye_parallel_transport` once per ray-march sub-step (the kernel
-/// chains many small sub-steps per fragment, each over a tiny
-/// chart-coordinate segment). Per-call truncation is `O(h²)`, so
-/// cumulative error over the march stays small for the per-step `h`
-/// the kernel uses.
-/// A multi-step RK4 inside each call would multiply the kernel's
-/// cost for marginal accuracy gain. The CPU side runs 8 RK4
-/// sub-steps because it serves a different use case: path-aware
-/// transport over arcs much longer than a march sub-step.
+/// The geodesic-march kernel calls `rye_parallel_transport` once per
+/// ray-march sub-step. Internal RK4 multiplies per-call cost ~32x vs
+/// the previous single-step Euler, but `parallel_transport` only
+/// touches the curved-Space ray-march path; closed-form Spaces
+/// continue to use closed-form transport with no integrator at all.
 ///
-/// CPU/GPU parity for `exp` is pinned by
-/// `blended_e3_h3_gpu_probe_exp_matches_cpu` in `rye-shader/db.rs`;
-/// transport parity is intentionally not pinned because the two
-/// sides use different schemes by design.
+/// CPU/GPU parity is pinned by
+/// `blended_e3_h3_gpu_probe_exp_matches_cpu` (`rye_exp`) and
+/// `blended_e3_h3_gpu_probe_transport_matches_cpu`
+/// (`rye_parallel_transport`) in `rye-shader/db.rs`.
 ///
 /// **`rye_log` / `rye_distance` accuracy.** `rye_log` returns
 /// the Euclidean chart-coordinate difference (the geodesic march
@@ -863,6 +858,7 @@ const RYE_BLENDED_X_START: f32 = {start:?};
 const RYE_BLENDED_X_END:   f32 = {end:?};
 const RYE_BLENDED_X_WIDTH: f32 = {width:?};
 const RYE_BLENDED_RK4_SUB: i32 = 16;
+const RYE_BLENDED_TRANSPORT_SUB: i32 = 8;
 
 fn rye_blended_alpha(p: vec3<f32>) -> f32 {{
     let raw_t = (p.x - RYE_BLENDED_X_START) / RYE_BLENDED_X_WIDTH;
@@ -972,14 +968,27 @@ fn rye_blended_transport_rhs(p: vec3<f32>, gamma_dot: vec3<f32>, v: vec3<f32>) -
 }}
 
 fn rye_parallel_transport(p_from: vec3<f32>, p_to: vec3<f32>, v: vec3<f32>) -> vec3<f32> {{
-    // Single-step transport along the chart-coordinate straight
-    // line p_from to p_to. Matches the kernel's small-step
-    // pattern; the transport error per step is O(h²) but the
-    // kernel chains many of them so cumulative error stays small.
-    let gamma_dot = p_to - p_from;
-    let p_mid = 0.5 * (p_from + p_to);
-    let dv = rye_blended_transport_rhs(p_mid, gamma_dot, v);
-    return v + dv;
+    // 8 RK4 sub-steps along the chart-coordinate straight line from
+    // p_from to p_to. Mirrors the CPU `parallel_transport_segment_rk4`
+    // step-for-step so the two sides agree to 4th-order truncation.
+    // Pinned by `blended_e3_h3_gpu_probe_transport_matches_cpu` in
+    // rye-shader/db.rs.
+    let dgamma = p_to - p_from;
+    if dot(dgamma, dgamma) < 1e-14 {{ return v; }}
+    let h = 1.0 / f32(RYE_BLENDED_TRANSPORT_SUB);
+    var v_curr = v;
+    for (var step: i32 = 0; step < RYE_BLENDED_TRANSPORT_SUB; step = step + 1) {{
+        let t = f32(step) * h;
+        let p_t      = p_from + dgamma * t;
+        let p_t_half = p_from + dgamma * (t + h * 0.5);
+        let p_t_full = p_from + dgamma * (t + h);
+        let k1 = rye_blended_transport_rhs(p_t,      dgamma, v_curr);
+        let k2 = rye_blended_transport_rhs(p_t_half, dgamma, v_curr + k1 * (h * 0.5));
+        let k3 = rye_blended_transport_rhs(p_t_half, dgamma, v_curr + k2 * (h * 0.5));
+        let k4 = rye_blended_transport_rhs(p_t_full, dgamma, v_curr + k3 * h);
+        v_curr = v_curr + (k1 + 2.0 * k2 + 2.0 * k3 + k4) * (h / 6.0);
+    }}
+    return v_curr;
 }}
 
 fn rye_distance(a: vec3<f32>, b: vec3<f32>) -> f32 {{

--- a/crates/rye-shader/src/db.rs
+++ b/crates/rye-shader/src/db.rs
@@ -835,9 +835,10 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     }
 
     /// CPU/GPU parity for `BlendedSpace<EuclideanR3, HyperbolicH3,
-    /// LinearBlendX>`, restricted to `rye_exp` only.
+    /// LinearBlendX>`, restricted to `rye_exp`. Transport parity has
+    /// its own probe at `blended_e3_h3_gpu_probe_transport_matches_cpu`.
     ///
-    /// The other ABI methods are intentionally divergent here:
+    /// The other two ABI methods are intentionally divergent:
     /// - `rye_log` returns the chart-coordinate difference; CPU
     ///   runs Gauss-Newton shooting. The geodesic march kernel
     ///   does not call it.
@@ -845,20 +846,9 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     ///   `sqrt(f((a+b)/2)) * |a-b|`; CPU computes the full
     ///   Riemannian distance via `log` length scaled by the
     ///   conformal factor at `a`.
-    /// - `rye_parallel_transport` is a single midpoint-Euler step
-    ///   along the chart-coordinate line; CPU uses 8 RK4 sub-steps
-    ///   along the same line. Both are called by the geodesic-march
-    ///   kernel (CPU via `parallel_transport_segment_rk4`, GPU per
-    ///   march sub-step via `kernel.wgsl::rye_march_geodesic`), but
-    ///   the GPU's coarser scheme is intentional: the kernel chains
-    ///   ~256 small sub-steps per fragment so the per-call O(h^2)
-    ///   error stays bounded, while RK4 inside each call would
-    ///   multiply kernel cost for marginal accuracy gain.
     ///
-    /// `rye_exp` is the highest-leverage of the three (each kernel
-    /// sub-step's geodesic position depends on it directly), so
-    /// CPU/GPU agreement on `exp` is the load-bearing parity claim
-    /// for this `BlendedSpace` instantiation.
+    /// `rye_exp` is the highest-leverage method (each kernel
+    /// sub-step's geodesic position depends on it directly).
     ///
     /// Tolerance: GPU uses 16 RK4 sub-steps, CPU uses 32. Both
     /// are 4th-order so per-step truncation scales as h^5;
@@ -908,6 +898,63 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
             assert!(
                 diff < 5e-3,
                 "BlendedSpace exp parity failed at a={a:?} v={v:?}: cpu={cpu:?} gpu={gpu:?} diff={diff}",
+            );
+        }
+    }
+
+    /// CPU/GPU parity for `BlendedSpace<EuclideanR3, HyperbolicH3,
+    /// LinearBlendX>::parallel_transport`. Both sides run 8 RK4
+    /// sub-steps along the chart-coordinate line from `a` to `b`, so
+    /// agreement is to 4th-order truncation modulo f32 noise.
+    ///
+    /// Chosen test paths sample the three regions: pure E3 (transport
+    /// reduces to identity, tightest tolerance), the mid-zone where
+    /// the conformal factor's gradient is non-zero, and pure H3 at
+    /// moderate radius where the metric varies fastest. Tolerance
+    /// matches the exp probe's 5e-3 budget.
+    #[test]
+    #[ignore = "requires a working wgpu adapter; run manually when changing BlendedSpace WGSL"]
+    fn blended_e3_h3_gpu_probe_transport_matches_cpu() {
+        let space = BlendedSpace::new(EuclideanR3, HyperbolicH3, LinearBlendX::new(-0.5, 0.5));
+        let cases = [
+            // Pure E3: transport is identity in flat space; any drift
+            // is pure GPU-vs-CPU floating-point noise.
+            gpu_case(
+                Vec3::new(-1.0, 0.05, 0.0),
+                Vec3::new(-0.8, 0.05, 0.0),
+                Vec3::new(0.1, 0.0, 0.0),
+            ),
+            // Long traversal across the transition zone (-0.5 -> +0.5)
+            // and out into H3 at r ~ 0.7. The conformal-factor gradient
+            // varies fastest here, and the path length plus large
+            // transport vector amplifies per-step truncation. This is
+            // the case that discriminates 8-step RK4 from single-step
+            // Euler.
+            gpu_case(
+                Vec3::new(-0.6, 0.0, 0.0),
+                Vec3::new(0.7, 0.0, 0.0),
+                Vec3::new(0.5, 0.5, 0.0),
+            ),
+            // Pure H3 at r ~ 0.7 where f(p) ~ 15.4x identity.
+            gpu_case(
+                Vec3::new(0.7, 0.0, 0.0),
+                Vec3::new(0.72, 0.05, 0.0),
+                Vec3::new(0.02, 0.02, 0.0),
+            ),
+        ];
+        let out =
+            pollster::block_on(run_gpu_probe(&space, &cases)).expect("BlendedSpace GPU probe");
+
+        for (case, row) in cases.iter().zip(&out) {
+            let a = Vec3::from_array([case.a[0], case.a[1], case.a[2]]);
+            let b = Vec3::from_array([case.b[0], case.b[1], case.b[2]]);
+            let v = Vec3::from_array([case.v[0], case.v[1], case.v[2]]);
+            let cpu = space.parallel_transport(a, b, v);
+            let gpu = Vec3::new(row.transported[0], row.transported[1], row.transported[2]);
+            let diff = (cpu - gpu).length();
+            assert!(
+                diff < 5e-3,
+                "BlendedSpace transport parity failed at a={a:?} b={b:?} v={v:?}: cpu={cpu:?} gpu={gpu:?} diff={diff}",
             );
         }
     }


### PR DESCRIPTION
Closes the CPU/GPU divergence in BlendedSpace's parallel transport: GPU was a single-step midpoint Euler, CPU was 8-step RK4. The two now run identical schemes and a probe pins the parity.

## Changes

- **WGSL**: `rye_parallel_transport` now runs 8 RK4 sub-steps via the existing `rye_blended_transport_rhs` helper. New `RYE_BLENDED_TRANSPORT_SUB = 8` constant in the prelude mirrors the CPU's `PARALLEL_TRANSPORT_DEFAULT_STEPS`.
- **Test**: `blended_e3_h3_gpu_probe_transport_matches_cpu` in `rye-shader/db.rs`. Three test cases sample pure E3, a long traversal across the transition zone, and pure H3 at moderate radius. Tolerance 5e-3 matches the existing exp probe.
- **Doc cleanup**: removed the comments that called the divergence "intentional". Both sides now run RK4; the framing is parity.

## Verification

The new probe was confirmed to discriminate strongly: with the old single-step Euler restored, the long-traversal case produces `diff = 0.466` (~93x the 5e-3 tolerance). Under the RK4 port both BlendedSpace probes pass cleanly via lavapipe.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo test -p rye-shader gpu_probe -- --include-ignored` (lavapipe)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace`