### PR TITLE
feat(rye-egui): egui integration via App::ui + world_to_screen helper + ui_smoke example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/rye-physics",
   "crates/rye-app",
   "crates/rye-text",
+  "crates/rye-egui",
 ]
 resolver = "2"
 
@@ -32,9 +33,9 @@ glam = { version = "0.27", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 ron = "0.8"
 
-wgpu  = { version = "26", features = ["wgsl"] }
+wgpu  = { version = "27", features = ["wgsl"] }
 winit = "0.30"
-naga = { version = "26", features = ["wgsl-in"] }
+naga = { version = "27", features = ["wgsl-in"] }
 bytemuck = { version = "1", features = ["derive"] }
 notify = "6"
 

--- a/crates/rye-app/Cargo.toml
+++ b/crates/rye-app/Cargo.toml
@@ -23,3 +23,4 @@ rye-math   = { path = "../rye-math" }
 rye-render = { path = "../rye-render" }
 rye-shader = { path = "../rye-shader" }
 rye-time   = { path = "../rye-time" }
+rye-egui   = { path = "../rye-egui" }

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -38,17 +38,19 @@
 //!
 //! ```text
 //! run::<MyApp>()
-//!   └─ EventLoop::new
-//!   └─ on `resumed`:
+//!   * EventLoop::new
+//!   * on `resumed`:
 //!         create Window
 //!         create RenderDevice
 //!         create ShaderDb + AssetWatcher
+//!         create UiIntegration (egui)
 //!         A::setup(&mut SetupCtx) -> A
-//!   └─ on each redraw:
+//!   * on each redraw:
 //!         FixedTimestep::advance -> ticks
 //!         for each tick: A::tick(dt, &mut TickCtx)
 //!         input.take_frame()
 //!         A::update(&mut FrameCtx)
+//!         A::ui(&egui::Context, &mut FrameCtx)
 //!         A::on_event(...) for each WindowEvent
 //!         poll AssetWatcher -> if events:
 //!             shader_db.apply_events(events, app.space())
@@ -56,8 +58,10 @@
 //!         maybe update title (rate-limited to ~1 Hz)
 //!         RenderDevice::begin_frame
 //!         A::render(rd, view)
+//!         UiIntegration::paint  (egui overlay, LoadOp::Load)
 //!         frame.present
-//!   └─ on `Esc` or `CloseRequested`: exit cleanly
+//!   * on `Esc` or `CloseRequested`: exit cleanly
+//!     (Esc is suppressed when an egui TextEdit has keyboard focus)
 //! ```
 
 use std::borrow::Cow;
@@ -74,6 +78,7 @@ use winit::{
 };
 
 use rye_asset::AssetWatcher;
+use rye_egui::UiIntegration;
 use rye_input::{FrameInput, InputState};
 use rye_math::WgslSpace;
 use rye_render::device::RenderDevice;
@@ -86,6 +91,9 @@ pub use rye_camera::{
     Camera, CameraController, CameraView, FirstPersonController, OrbitController,
 };
 pub use rye_input::FrameInput as Input;
+// Re-export the egui surface so apps that override `App::ui` depend on
+// `rye-app` only and the version pin lives in `rye-egui`.
+pub use rye_egui::{egui, world_to_screen};
 
 // ---------------------------------------------------------------------------
 // App trait
@@ -174,6 +182,31 @@ pub trait App: Sized + 'static {
     /// returns.
     fn render(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> anyhow::Result<()>;
 
+    /// Build this frame's egui UI. Called after [`App::update`] and
+    /// before [`App::render`]; the framework paints the resulting
+    /// widgets as a 2D overlay on the surface view.
+    ///
+    /// Default impl is a no-op; apps that want UI override this with
+    /// immediate-mode egui code:
+    ///
+    /// ```ignore
+    /// fn ui(&mut self, ctx: &egui::Context, frame: &mut FrameCtx<'_>) {
+    ///     egui::Window::new("Settings").show(ctx, |ui| {
+    ///         ui.add(egui::Slider::new(&mut self.fov, 30.0..=120.0));
+    ///         if ui.button("Reset").clicked() { self.reset(); }
+    ///     });
+    /// }
+    /// ```
+    ///
+    /// Gameplay code that reads input should gate on
+    /// [`FrameCtx::ui_has_focus`] so a player typing into a settings
+    /// field doesn't also fire WASD movement.
+    ///
+    /// For "egui label that follows a 3D object," use
+    /// [`world_to_screen`] to project the world point and place an
+    /// `egui::Area` at the resulting pixel.
+    fn ui(&mut self, _ctx: &egui::Context, _frame: &mut FrameCtx<'_>) {}
+
     /// Title bar text. Default returns the static name
     /// `"rye app"`. Override for live FPS / state readouts; the
     /// framework rate-limits the actual `set_title` call to
@@ -218,6 +251,12 @@ pub struct FrameCtx<'a> {
     pub fps: f32,
     pub n_ticks: usize,
     pub tick: u64,
+    /// `true` if egui is consuming pointer or keyboard input this
+    /// frame (a widget is hovered, focused, or accepting text).
+    /// Gameplay code should gate movement / mouselook on
+    /// `!ctx.ui_has_focus` so typing into a settings field doesn't
+    /// also fire WASD or rotate the camera.
+    pub ui_has_focus: bool,
     /// Phantom for forward-compat: future fields here mustn't
     /// silently break code that pattern-matches on the struct.
     _non_exhaustive: PhantomData<()>,
@@ -315,6 +354,7 @@ struct Runner<A: App> {
     rd: Option<RenderDevice>,
     shader_db: Option<ShaderDb>,
     watcher: Option<AssetWatcher>,
+    ui: Option<UiIntegration>,
     app: Option<A>,
 
     minimized: bool,
@@ -346,6 +386,7 @@ impl<A: App> Runner<A> {
             rd: None,
             shader_db: None,
             watcher: None,
+            ui: None,
             app: None,
             minimized: false,
             last_fps_update: Instant::now(),
@@ -419,10 +460,18 @@ impl<A: App> ApplicationHandler for Runner<A> {
             }
         };
 
+        // 1 sample = no MSAA on the egui pass. Tracks the surface's
+        // own sample count, which is also 1 today (Rye doesn't
+        // configure MSAA on the swapchain). If a future render path
+        // enables MSAA on the main scene, this needs to bump in
+        // lockstep so egui paints into the same multisample target.
+        let ui = UiIntegration::new(&rd.device, &win, rd.surface_bundle.config.format, 1);
+
         self.window = Some(win.clone());
         self.rd = Some(rd);
         self.shader_db = Some(shader_db);
         self.watcher = watcher;
+        self.ui = Some(ui);
         self.app = Some(app);
         self.minimized = false;
         self.start = Instant::now();
@@ -442,7 +491,16 @@ impl<A: App> ApplicationHandler for Runner<A> {
             return;
         };
 
-        // Esc / close: exit cleanly.
+        // Forward to egui first so it can claim hover/focus/clicks
+        // before Rye's own routing translates the event for gameplay.
+        // egui consuming the event is informational; Rye still sees it.
+        if let Some(ui) = self.ui.as_mut() {
+            let _ = ui.handle_event(&win, &ev);
+        }
+
+        // Esc / close: exit cleanly. (When egui has keyboard focus,
+        // e.g. a TextEdit is active, swallow Esc so it dismisses the
+        // edit instead of exiting the app.)
         match &ev {
             WindowEvent::CloseRequested => {
                 elwt.exit();
@@ -451,7 +509,8 @@ impl<A: App> ApplicationHandler for Runner<A> {
             WindowEvent::KeyboardInput { event, .. }
                 if self.config.esc_exits
                     && event.state == ElementState::Pressed
-                    && matches!(event.logical_key, Key::Named(NamedKey::Escape)) =>
+                    && matches!(event.logical_key, Key::Named(NamedKey::Escape))
+                    && !self.ui.as_ref().is_some_and(|u| u.ui_has_focus()) =>
             {
                 elwt.exit();
                 return;
@@ -502,6 +561,7 @@ impl<A: App> ApplicationHandler for Runner<A> {
         let tick = self.tick_index;
         if let Some(app) = self.app.as_mut() {
             if let Some(rd) = self.rd.as_ref() {
+                let ui_has_focus = self.ui.as_ref().is_some_and(|u| u.ui_has_focus());
                 let mut ctx = FrameCtx {
                     rd,
                     input: FrameInput::default(),
@@ -509,6 +569,7 @@ impl<A: App> ApplicationHandler for Runner<A> {
                     fps,
                     n_ticks: 0,
                     tick,
+                    ui_has_focus,
                     _non_exhaustive: PhantomData,
                 };
                 app.on_event(&ev, &mut ctx);
@@ -540,7 +601,13 @@ impl<A: App> Runner<A> {
             }
         }
 
-        // 2. Per-frame update with drained input.
+        // 2. Per-frame update with drained input + UI build.
+        // egui's focus reading reflects the *previous* frame's state
+        // (egui hasn't run yet for this frame). That one-frame
+        // staleness is fine: focus changes one frame at a time, and
+        // `App::update` needs to know "should I gate gameplay input"
+        // before this frame's UI runs.
+        let ui_has_focus = self.ui.as_ref().is_some_and(|u| u.ui_has_focus());
         let input = self.input.take_frame();
         if let Some(app) = self.app.as_mut() {
             let mut fctx = FrameCtx {
@@ -550,9 +617,17 @@ impl<A: App> Runner<A> {
                 fps: self.fps,
                 n_ticks: n_capped,
                 tick: self.tick_index,
+                ui_has_focus,
                 _non_exhaustive: PhantomData,
             };
             app.update(&mut fctx);
+
+            // Build this frame's UI. egui captures the widgets;
+            // `paint` later renders them after `App::render`.
+            if let Some(ui) = self.ui.as_mut() {
+                let egui_ctx = ui.begin_frame(win.as_ref()).clone();
+                app.ui(&egui_ctx, &mut fctx);
+            }
         }
 
         // 3. Hot-reload poll.
@@ -585,7 +660,7 @@ impl<A: App> Runner<A> {
             }
         }
 
-        // 5. Render.
+        // 5. Render: scene (App::render) then UI overlay.
         match rd.begin_frame() {
             Ok((frame, view)) => {
                 let mut last_err: Option<anyhow::Error> = None;
@@ -594,6 +669,26 @@ impl<A: App> Runner<A> {
                         tracing::error!("App::render error: {e:#}");
                         last_err = Some(e);
                     }
+                }
+                // Paint egui on top of whatever the app rendered.
+                // Uses `LoadOp::Load` internally so the scene shows
+                // through where no widgets cover it.
+                if let Some(ui) = self.ui.as_mut() {
+                    let mut encoder =
+                        rd.device
+                            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                                label: Some("rye-app::ui-paint"),
+                            });
+                    let viewport = (rd.surface_bundle.size.width, rd.surface_bundle.size.height);
+                    ui.paint(
+                        &rd.device,
+                        &rd.queue,
+                        &mut encoder,
+                        &view,
+                        win.as_ref(),
+                        viewport,
+                    );
+                    rd.queue.submit(Some(encoder.finish()));
                 }
                 frame.present();
                 if let Some(err) = last_err {

--- a/crates/rye-egui/Cargo.toml
+++ b/crates/rye-egui/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rye-egui"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Rye + egui integration: ApplicationHandler glue, wgpu paint pass, world-anchored label helper. Wraps egui rather than abstracting over UI frameworks; the name reflects that."
+
+[dependencies]
+glam.workspace = true
+wgpu.workspace = true
+winit.workspace = true
+
+# Pin all three egui crates to the same patch series. The trio share an
+# internal ABI; mixing minor versions silently breaks at runtime.
+egui = "0.33"
+egui-wgpu = { version = "0.33", default-features = false, features = ["winit"] }
+egui-winit = { version = "0.33", default-features = false, features = ["clipboard", "links"] }
+
+rye-camera = { path = "../rye-camera" }
+
+[dev-dependencies]
+glam = { workspace = true }

--- a/crates/rye-egui/src/integration.rs
+++ b/crates/rye-egui/src/integration.rs
@@ -1,0 +1,176 @@
+//! egui ↔ wgpu ↔ winit integration owned by `rye-app::Runner`.
+//!
+//! The lifecycle the framework runs each frame:
+//!
+//! 1. Window events feed `egui_winit::State::on_window_event` so egui
+//!    sees clicks, key presses, IME, scroll, focus.
+//! 2. Before the user's `App::ui` runs, the framework drains accumulated
+//!    input via [`UiIntegration::begin_frame`].
+//! 3. The user's `App::ui` runs; egui builds a frame's worth of paint
+//!    commands.
+//! 4. After `App::render`, the framework calls [`UiIntegration::paint`]
+//!    to overlay the egui output on the surface.
+
+use std::sync::Arc;
+
+use egui_wgpu::{Renderer, RendererOptions, ScreenDescriptor};
+use winit::window::Window;
+
+/// Per-window egui state. One instance lives inside the `rye-app`
+/// `Runner`; user apps don't construct this themselves.
+pub struct UiIntegration {
+    ctx: egui::Context,
+    winit_state: egui_winit::State,
+    renderer: Renderer,
+    /// Pixels-per-point at the time of the most recent `begin_frame`.
+    /// Cached so `paint` doesn't have to re-query the window.
+    pixels_per_point: f32,
+    /// `wants_pointer_input || wants_keyboard_input` from the last
+    /// frame. Fed back to apps via `FrameCtx::ui_has_focus`.
+    last_focus: bool,
+}
+
+impl UiIntegration {
+    /// Construct. Called from `Runner::resumed` once the device and
+    /// window are available.
+    ///
+    /// **Note on sRGB framebuffers.** `RenderDevice` deliberately
+    /// picks an sRGB surface format because Rye's scene rendering
+    /// wants gamma-correct output. egui-wgpu logs a warning that it
+    /// "prefers Rgba8Unorm or Bgra8Unorm" because its shader's blend
+    /// math assumes linear space; on an sRGB surface egui internally
+    /// gamma-corrects with a small color shift that's invisible at
+    /// HUD/widget scale. Accepting the warning is the right tradeoff
+    /// for v0; rendering egui to a non-sRGB intermediate texture and
+    /// compositing onto the sRGB surface would be the correct fix
+    /// when widget color fidelity becomes load-bearing.
+    pub fn new(
+        device: &wgpu::Device,
+        window: &Arc<Window>,
+        surface_format: wgpu::TextureFormat,
+        msaa_samples: u32,
+    ) -> Self {
+        let ctx = egui::Context::default();
+        // egui-winit translates winit events into egui events; the
+        // viewport id is `ROOT` for single-window apps.
+        let winit_state = egui_winit::State::new(
+            ctx.clone(),
+            egui::ViewportId::ROOT,
+            window.as_ref(),
+            Some(window.scale_factor() as f32),
+            window.theme(),
+            None,
+        );
+        let renderer = Renderer::new(
+            device,
+            surface_format,
+            RendererOptions {
+                msaa_samples,
+                ..Default::default()
+            },
+        );
+        let pixels_per_point = window.scale_factor() as f32;
+        Self {
+            ctx,
+            winit_state,
+            renderer,
+            pixels_per_point,
+            last_focus: false,
+        }
+    }
+
+    /// Forward a winit event to egui. Returns `true` if egui consumed
+    /// the event (caller can still see it; the bool just signals
+    /// "egui acted on this," useful for debug logging).
+    pub fn handle_event(
+        &mut self,
+        window: &Window,
+        event: &winit::event::WindowEvent,
+    ) -> egui_winit::EventResponse {
+        self.winit_state.on_window_event(window, event)
+    }
+
+    /// Drain accumulated input + start a fresh egui frame. Returns the
+    /// `egui::Context` for the user's `App::ui` to build against.
+    pub fn begin_frame(&mut self, window: &Window) -> &egui::Context {
+        let raw_input = self.winit_state.take_egui_input(window);
+        self.pixels_per_point = window.scale_factor() as f32;
+        self.ctx.begin_pass(raw_input);
+        &self.ctx
+    }
+
+    /// Finish the egui frame, capture output, and paint onto `view`
+    /// using the supplied encoder. Pairs with `begin_frame`.
+    ///
+    /// `viewport` is `(width_px, height_px)`. Caller is responsible for
+    /// having already cleared and rendered the main scene; this paint
+    /// overlays with `LoadOp::Load`.
+    pub fn paint(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        view: &wgpu::TextureView,
+        window: &Window,
+        viewport: (u32, u32),
+    ) {
+        let full_output = self.ctx.end_pass();
+        self.last_focus = self.ctx.wants_pointer_input() || self.ctx.wants_keyboard_input();
+
+        // Forward platform output (cursor changes, clipboard writes,
+        // open-link requests). Without this, hovering a button never
+        // changes the cursor and clicking a `Hyperlink` does nothing.
+        self.winit_state
+            .handle_platform_output(window, full_output.platform_output);
+
+        let primitives = self
+            .ctx
+            .tessellate(full_output.shapes, self.pixels_per_point);
+
+        let screen = ScreenDescriptor {
+            size_in_pixels: [viewport.0, viewport.1],
+            pixels_per_point: self.pixels_per_point,
+        };
+
+        for (id, image_delta) in &full_output.textures_delta.set {
+            self.renderer
+                .update_texture(device, queue, *id, image_delta);
+        }
+        self.renderer
+            .update_buffers(device, queue, encoder, &primitives, &screen);
+
+        {
+            let pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("rye-egui::paint"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            // egui-wgpu wants a `RenderPass<'static>`; forward_render
+            // is the helper that does that lifetime dance for us.
+            self.renderer
+                .render(&mut pass.forget_lifetime(), &primitives, &screen);
+        }
+
+        for id in &full_output.textures_delta.free {
+            self.renderer.free_texture(id);
+        }
+    }
+
+    /// `true` if egui currently wants pointer or keyboard input (a
+    /// widget is hovered, focused, or accepting text). Apps should
+    /// gate gameplay input on `!ui_has_focus()` so a player typing in
+    /// a settings field doesn't also fire WASD movement.
+    pub fn ui_has_focus(&self) -> bool {
+        self.last_focus
+    }
+}

--- a/crates/rye-egui/src/lib.rs
+++ b/crates/rye-egui/src/lib.rs
@@ -1,0 +1,66 @@
+//! `rye-egui`: integration glue between `rye-app` and the [egui]
+//! immediate-mode UI library.
+//!
+//! Named for what it is, not what it abstracts. The crate wraps egui
+//! and provides a wgpu paint pass + world-anchored label helper; if a
+//! future migration to a different UI framework happens, this crate
+//! gets replaced rather than retargeted.
+//!
+//! ## Surface
+//!
+//! - [`UiIntegration`]: per-app egui state (Context, winit translator,
+//!   wgpu renderer). Owned by `rye_app::Runner`; apps don't construct
+//!   it directly.
+//! - [`world_to_screen`]: project a world-space point to screen pixel
+//!   coordinates via a camera + viewport. The cheap pattern for
+//!   "egui label that follows a 3D object."
+//!
+//! [egui]: https://github.com/emilk/egui
+//!
+//! Apps interact with the UI by overriding `App::ui(&mut self, ctx,
+//! frame)` and writing immediate-mode egui code:
+//!
+//! ```ignore
+//! fn ui(&mut self, ctx: &egui::Context, frame: &mut FrameCtx<'_>) {
+//!     egui::Window::new("Settings").show(ctx, |ui| {
+//!         ui.add(egui::Slider::new(&mut self.fov, 30.0..=120.0).text("FOV"));
+//!         if ui.button("Reset").clicked() {
+//!             self.reset();
+//!         }
+//!     });
+//! }
+//! ```
+//!
+//! ## Input gating
+//!
+//! egui consumes input it cares about (clicks on widgets, typing into
+//! a focused text input). Gameplay code that reads the same WASD keys
+//! or mouse delta should gate on `frame.ui_has_focus()` so a player
+//! typing into a settings field doesn't also fire movement.
+//!
+//! ## Why egui (not iced or a from-scratch UI)
+//!
+//! Immediate mode matches `rye-app`'s "library-style composition, no
+//! ECS" pattern: apps construct and call UI inside `App::ui`. egui
+//! integrates with wgpu directly via `egui-wgpu`; no rendering glue
+//! beyond what this crate provides. Pure-Rust dependency tree.
+//!
+//! ## What's deliberately out of scope
+//!
+//! - **3D-billboard egui** (egui rendered to texture, sampled in the
+//!   3D scene with ray-cast interaction). Possible but unnecessary
+//!   for current use cases; the screen-space-with-world-anchoring
+//!   pattern via [`world_to_screen`] covers labels and HUDs that
+//!   follow 3D objects.
+//! - **Custom widget set on top of egui.** egui's defaults are fine
+//!   for v0; theme tweaks live in the app, not here.
+
+mod integration;
+mod world;
+
+pub use integration::UiIntegration;
+pub use world::world_to_screen;
+
+// Re-export egui so apps depend on `rye-egui` only and the version
+// pin lives in one place.
+pub use egui;

--- a/crates/rye-egui/src/world.rs
+++ b/crates/rye-egui/src/world.rs
@@ -1,0 +1,140 @@
+//! World-space to screen-space projection for anchoring egui widgets
+//! to 3D points.
+//!
+//! References:
+//! - Akenine-Möller, Haines, Hoffman, *Real-Time Rendering* (4th ed,
+//!   2018), §4.7 (view + projection transforms).
+
+use glam::{Mat4, Vec3, Vec4Swizzles};
+use rye_camera::CameraView;
+
+/// Project a world-space point to screen pixel coordinates via the
+/// camera's view + perspective projection.
+///
+/// Returns `None` if the point is behind the camera or outside the
+/// canonical view volume after projection (clipped).
+///
+/// `viewport` is `(width_px, height_px)`. `fov_y_radians` matches the
+/// `Camera::fov_y` field; `aspect` should be `width_px / height_px`.
+/// `near` and `far` should match the renderer's depth setup; for
+/// screen-anchoring purposes `near = 0.05`, `far = 100.0` is fine
+/// since we only care about NDC.
+///
+/// The returned [`egui::Pos2`] is in egui's pixel coordinates (top-left
+/// origin, y-down), ready to pass to `egui::Area::fixed_pos`.
+pub fn world_to_screen(
+    world: Vec3,
+    camera: &CameraView,
+    fov_y_radians: f32,
+    viewport: (u32, u32),
+    near: f32,
+    far: f32,
+) -> Option<egui::Pos2> {
+    let (vw, vh) = (viewport.0 as f32, viewport.1 as f32);
+    if vw <= 0.0 || vh <= 0.0 {
+        return None;
+    }
+    let aspect = vw / vh;
+
+    // Build a right-handed view matrix from the camera's orthonormal
+    // frame: camera looks along `forward`, with `right` and `up` as
+    // the screen axes. `Mat4::look_to_rh` is exactly this.
+    let view = Mat4::look_to_rh(camera.position, camera.forward, camera.up);
+    let proj = Mat4::perspective_rh(fov_y_radians, aspect, near, far);
+    let clip = proj * view * world.extend(1.0);
+
+    // Behind the camera (or on the near plane).
+    if clip.w <= 0.0 {
+        return None;
+    }
+
+    let ndc = clip.xyz() / clip.w;
+    // Outside the canonical NDC cube; the point isn't visible.
+    if ndc.x < -1.0 || ndc.x > 1.0 || ndc.y < -1.0 || ndc.y > 1.0 || ndc.z < 0.0 || ndc.z > 1.0 {
+        return None;
+    }
+
+    // NDC has y-up; egui screen coords are y-down. Flip y here.
+    let screen_x = (ndc.x * 0.5 + 0.5) * vw;
+    let screen_y = (1.0 - (ndc.y * 0.5 + 0.5)) * vh;
+    Some(egui::Pos2::new(screen_x, screen_y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn camera_at(position: Vec3, forward: Vec3, up: Vec3) -> CameraView {
+        let right = forward.cross(up).normalize();
+        CameraView {
+            position,
+            forward: forward.normalize(),
+            right,
+            up: up.normalize(),
+        }
+    }
+
+    /// A point at the camera's gaze direction projects to the centre
+    /// of the viewport.
+    #[test]
+    fn point_in_front_projects_to_centre() {
+        let camera = camera_at(Vec3::ZERO, -Vec3::Z, Vec3::Y);
+        let world = Vec3::new(0.0, 0.0, -5.0);
+        let pos = world_to_screen(world, &camera, 60_f32.to_radians(), (800, 600), 0.05, 100.0)
+            .expect("point in front of camera should project");
+        let cx = 800.0 * 0.5;
+        let cy = 600.0 * 0.5;
+        assert!((pos.x - cx).abs() < 1e-3, "x off centre: {}", pos.x);
+        assert!((pos.y - cy).abs() < 1e-3, "y off centre: {}", pos.y);
+    }
+
+    /// A point behind the camera returns None.
+    #[test]
+    fn point_behind_camera_returns_none() {
+        let camera = camera_at(Vec3::ZERO, -Vec3::Z, Vec3::Y);
+        let world = Vec3::new(0.0, 0.0, 5.0); // behind a -Z-looking camera
+        assert!(
+            world_to_screen(world, &camera, 60_f32.to_radians(), (800, 600), 0.05, 100.0).is_none()
+        );
+    }
+
+    /// Off-axis world points map to the correct screen quadrant.
+    /// A point above-and-right of the gaze direction lands in the
+    /// upper-right of the screen (small x > centre, small y < centre
+    /// because egui is y-down).
+    #[test]
+    fn upper_right_world_lands_upper_right_screen() {
+        let camera = camera_at(Vec3::ZERO, -Vec3::Z, Vec3::Y);
+        let world = Vec3::new(0.5, 0.5, -5.0);
+        let pos = world_to_screen(world, &camera, 60_f32.to_radians(), (800, 600), 0.05, 100.0)
+            .expect("visible point should project");
+        assert!(pos.x > 400.0, "expected right half: x={}", pos.x);
+        assert!(pos.y < 300.0, "expected upper half (y-down): y={}", pos.y);
+    }
+
+    /// A point far outside the frustum's lateral extent is clipped to
+    /// None rather than producing nonsense pixel coordinates.
+    #[test]
+    fn point_outside_frustum_returns_none() {
+        let camera = camera_at(Vec3::ZERO, -Vec3::Z, Vec3::Y);
+        // 100 units off-axis at near distance = far past the FOV cone.
+        let world = Vec3::new(100.0, 0.0, -1.0);
+        assert!(
+            world_to_screen(world, &camera, 60_f32.to_radians(), (800, 600), 0.05, 100.0).is_none()
+        );
+    }
+
+    /// Zero-area viewport returns None rather than panicking on a
+    /// divide.
+    #[test]
+    fn zero_viewport_returns_none() {
+        let camera = camera_at(Vec3::ZERO, -Vec3::Z, Vec3::Y);
+        let world = Vec3::new(0.0, 0.0, -5.0);
+        assert!(
+            world_to_screen(world, &camera, 60_f32.to_radians(), (0, 600), 0.05, 100.0).is_none()
+        );
+        assert!(
+            world_to_screen(world, &camera, 60_f32.to_radians(), (800, 0), 0.05, 100.0).is_none()
+        );
+    }
+}

--- a/crates/rye-render/src/device.rs
+++ b/crates/rye-render/src/device.rs
@@ -54,8 +54,11 @@ impl RenderDevice {
                 label: Some("Rye Device"),
                 required_features: Features::empty(),
                 required_limits: Limits::default(),
-                memory_hints: MemoryHints::default(), // NEW in v26
-                trace: Trace::Off,                    // NEW in v26
+                memory_hints: MemoryHints::default(),
+                trace: Trace::Off,
+                // wgpu v27 requires opting in to experimental features explicitly;
+                // we don't use any.
+                experimental_features: Default::default(),
             })
             .await?;
 

--- a/crates/rye-shader/src/db.rs
+++ b/crates/rye-shader/src/db.rs
@@ -691,6 +691,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                 required_limits: wgpu::Limits::default(),
                 memory_hints: wgpu::MemoryHints::default(),
                 trace: wgpu::Trace::Off,
+                experimental_features: Default::default(),
             })
             .await
             .map_err(|e| format!("request_device failed: {e}"))?;
@@ -803,8 +804,14 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         slice.map_async(wgpu::MapMode::Read, move |res| {
             tx.send(res).expect("map callback receiver should exist");
         });
+        // wgpu v27 made `PollType::Wait` a struct variant. Default
+        // `submission_index = None` waits on the most recent submission;
+        // `timeout = None` waits indefinitely (matches the v26 behaviour).
         device
-            .poll(wgpu::PollType::Wait)
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
             .map_err(|e| e.to_string())?;
         rx.recv()
             .map_err(|e| e.to_string())?

--- a/crates/rye-text/Cargo.toml
+++ b/crates/rye-text/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Rye text rendering: ab_glyph-backed screen-space text overlay for game UIs and HUDs."
+description = "Rye text rendering: minimal-deps ab_glyph-backed screen-space text overlay. For full UI use rye-egui."
 
 [dependencies]
 wgpu      = { workspace = true }

--- a/crates/rye-text/src/lib.rs
+++ b/crates/rye-text/src/lib.rs
@@ -15,9 +15,10 @@
 //! labels); not adequate for typographic-quality text or non-Latin
 //! scripts.
 //!
-//! Eventual upgrade path is glyphon (cosmic-text + complex shaping),
-//! pending the wgpu 28 ecosystem bump. The [`TextRenderer`] surface
-//! is designed to survive that swap.
+//! For richer text (mixed fonts, layout, multiline word wrap, complex
+//! UI), apps should reach for `rye-egui` instead, which uses egui's
+//! own text system. `rye-text` exists for the minimal-deps case where
+//! an app wants screen-space ASCII text without the full egui stack.
 //!
 //! # Example
 //!

--- a/examples/ui_smoke/main.rs
+++ b/examples/ui_smoke/main.rs
@@ -1,0 +1,246 @@
+//! Smoke test for the `rye-egui` egui integration.
+//!
+//! **What this is.** A tiny test that the framework wiring works:
+//! widgets render, input flows in, focus gating works, world-anchored
+//! labels project correctly. The `Space` type is a stub
+//! (`EuclideanR3`) only because `App::Space` is a required associated
+//! type; this app does not use a Space, does not have a player, does
+//! not render a scene, and does not have a floor.
+//!
+//! **What you should see.** A coloured background, an egui window
+//! titled "rye-egui smoke" with a few widgets, and (when enabled) a
+//! small floating label that orbits the centre of the screen.
+//!
+//! **What the widgets do:**
+//!
+//! - **`Window title`** (text input): updates `App::title` so the
+//!   OS window-bar text changes as you type. While focus is on this
+//!   field, `ctx.ui_has_focus` is true and the "gated forward axis"
+//!   readout below stays at zero even if you hold W. That's the
+//!   pattern apps use to keep WASD movement from firing while a
+//!   user types into a settings panel.
+//! - **`Hue`** (slider): drives the clear color via HSV.
+//! - **`Toggle anchor label`** (button): shows/hides the orbiting
+//!   label.
+//! - **`Anchor radius` / `Anchor speed`** (sliders): drive a fictional
+//!   point orbiting the origin in a fixed-camera coordinate system.
+//!   Its world-space position is projected to screen via
+//!   `world_to_screen` each frame; an egui Area is anchored at that
+//!   pixel. There is no 3D rendering of the point, only its label.
+//!
+//! **What this is not.** Not a Space-aware demo. Not a movement
+//! demo. Not an SDF render. The WASD reading is purely for showing
+//! the focus gate; nothing in the world responds to it.
+
+use std::borrow::Cow;
+
+use anyhow::Result;
+use glam::Vec3;
+use rye_app::{egui, run_with_config, world_to_screen, App, FrameCtx, RunConfig, SetupCtx};
+use rye_camera::CameraView;
+use rye_render::device::RenderDevice;
+use winit::window::WindowAttributes;
+
+struct UiSmokeApp {
+    space: rye_math::EuclideanR3,
+
+    // Driven by the UI.
+    title: String,
+    hue: f32,
+    anchor_radius: f32,
+    anchor_speed: f32,
+    show_anchor_label: bool,
+
+    // Driven by the sim tick.
+    anchor_angle: f32,
+    /// Cumulative WASD-forward axis seen this frame, displayed in the
+    /// UI to make the focus-gate behavior visible: while a text edit
+    /// is focused, this should stay at zero even if the user is
+    /// physically holding W.
+    last_forward_axis: f32,
+}
+
+impl App for UiSmokeApp {
+    type Space = rye_math::EuclideanR3;
+
+    fn setup(_ctx: &mut SetupCtx<'_>) -> Result<Self> {
+        Ok(Self {
+            space: rye_math::EuclideanR3,
+            title: "rye-egui smoke".to_string(),
+            hue: 0.55,
+            anchor_radius: 2.0,
+            anchor_speed: 1.0,
+            show_anchor_label: true,
+            anchor_angle: 0.0,
+            last_forward_axis: 0.0,
+        })
+    }
+
+    fn space(&self) -> &Self::Space {
+        &self.space
+    }
+
+    fn tick(&mut self, dt: f32, _ctx: &mut rye_app::TickCtx) {
+        self.anchor_angle += self.anchor_speed * dt;
+    }
+
+    fn update(&mut self, ctx: &mut FrameCtx<'_>) {
+        // Demonstrate the focus gate: only count WASD forward when
+        // the UI isn't claiming keyboard input.
+        if !ctx.ui_has_focus {
+            self.last_forward_axis = ctx.input.move_forward;
+        } else {
+            self.last_forward_axis = 0.0;
+        }
+    }
+
+    fn ui(&mut self, ctx: &egui::Context, frame: &mut FrameCtx<'_>) {
+        egui::Window::new("rye-egui smoke")
+            .default_pos([16.0, 16.0])
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("Window title:");
+                    ui.text_edit_singleline(&mut self.title);
+                });
+
+                ui.add(egui::Slider::new(&mut self.hue, 0.0..=1.0).text("Hue"));
+
+                if ui.button("Toggle anchor label").clicked() {
+                    self.show_anchor_label = !self.show_anchor_label;
+                }
+
+                ui.separator();
+                ui.add(egui::Slider::new(&mut self.anchor_radius, 0.5..=4.0).text("Anchor radius"));
+                ui.add(egui::Slider::new(&mut self.anchor_speed, 0.0..=4.0).text("Anchor speed"));
+
+                ui.separator();
+                ui.label(format!(
+                    "ui_has_focus: {} | gated forward axis: {:.2}",
+                    frame.ui_has_focus, self.last_forward_axis,
+                ));
+                ui.label(
+                    "Press / hold W to make the axis above read +1.0. \
+                     Click into 'Window title' and type, the axis will \
+                     read 0.00 while focus is on the text edit. That's \
+                     the focus gate; nothing in the scene moves either way.",
+                );
+            });
+
+        // World-anchored label. Project the anchor's world position
+        // into screen-space via the framework's `world_to_screen`
+        // helper, then drop an egui Area at that pixel.
+        if self.show_anchor_label {
+            let anchor_world = Vec3::new(
+                self.anchor_radius * self.anchor_angle.cos(),
+                0.0,
+                self.anchor_radius * self.anchor_angle.sin(),
+            );
+            let camera = anchor_demo_camera();
+            let viewport = (
+                frame.rd.surface_bundle.size.width,
+                frame.rd.surface_bundle.size.height,
+            );
+            if let Some(pos) = world_to_screen(
+                anchor_world,
+                &camera,
+                60_f32.to_radians(),
+                viewport,
+                0.05,
+                100.0,
+            ) {
+                egui::Area::new(egui::Id::new("anchor-label"))
+                    .fixed_pos(pos)
+                    .show(ctx, |ui| {
+                        let frame_style = egui::Frame::popup(ui.style());
+                        frame_style.show(ui, |ui| {
+                            ui.label(format!(
+                                "Anchor ({:.2}, {:.2}, {:.2})",
+                                anchor_world.x, anchor_world.y, anchor_world.z,
+                            ));
+                        });
+                    });
+            }
+        }
+    }
+
+    fn render(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> Result<()> {
+        // Single clear pass, hue-controlled. The framework paints the
+        // egui overlay on top after this returns.
+        let (r, g, b) = hsv_to_rgb(self.hue, 0.4, 0.18);
+        let mut encoder = rd
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("ui_smoke::clear"),
+            });
+        {
+            let _pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("ui_smoke::clear-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: r as f64,
+                            g: g as f64,
+                            b: b as f64,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+        }
+        rd.queue.submit(Some(encoder.finish()));
+        Ok(())
+    }
+
+    fn title(&self, fps: f32) -> Cow<'static, str> {
+        Cow::Owned(format!("{} | {fps:.0} fps", self.title))
+    }
+}
+
+/// Fixed camera for the anchor-label demo. At z = 5, looking at the
+/// origin, world-up = +Y. The anchor orbits in the XZ plane at y = 0.
+fn anchor_demo_camera() -> CameraView {
+    CameraView {
+        position: Vec3::new(0.0, 0.0, 5.0),
+        forward: Vec3::new(0.0, 0.0, -1.0),
+        right: Vec3::new(1.0, 0.0, 0.0),
+        up: Vec3::new(0.0, 1.0, 0.0),
+    }
+}
+
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> (f32, f32, f32) {
+    let i = (h * 6.0).floor();
+    let f = h * 6.0 - i;
+    let p = v * (1.0 - s);
+    let q = v * (1.0 - f * s);
+    let t = v * (1.0 - (1.0 - f) * s);
+    match (i as i32) % 6 {
+        0 => (v, t, p),
+        1 => (q, v, p),
+        2 => (p, v, t),
+        3 => (p, q, v),
+        4 => (t, p, v),
+        _ => (v, p, q),
+    }
+}
+
+fn main() -> Result<()> {
+    run_with_config::<UiSmokeApp>(RunConfig {
+        window: WindowAttributes::default()
+            .with_title("rye-egui smoke")
+            .with_visible(false),
+        // Drop wgpu_hal to `error` so the Windows Vulkan loader's noisy
+        // "validation layer not found" + "D3D12 mapping JSON parse"
+        // warnings stay silent. Those are platform-loader chatter, not
+        // anything we can act on. Keep wgpu_core at `warn` so genuine
+        // wgpu issues still surface.
+        log_filter: Some("info,wgpu_core=warn,wgpu_hal=error".to_string()),
+        ..Default::default()
+    })
+}


### PR DESCRIPTION
First-class UI for the rye-app framework. Apps override \`App::ui(&mut self, ctx, frame)\` and write immediate-mode egui code; the framework owns the egui context, the winit input translator, and the wgpu paint pass.

## What lands

- **\`crates/rye-ui\`**: new crate. \`UiIntegration\` owns egui's per-window state (Context, \`egui_winit::State\`, \`egui_wgpu::Renderer\`). \`world_to_screen(world, camera, fov, viewport, near, far) -> Option<egui::Pos2>\` helper for anchoring egui widgets to 3D points. Re-exports \`egui\` so apps depend on \`rye-ui\` only.
- **\`rye-app::App::ui\`**: new trait method with default no-op impl. Called between \`App::update\` and \`App::render\`; egui paints as a \`LoadOp::Load\` overlay after the scene render.
- **\`FrameCtx::ui_has_focus\`**: \`true\` when egui consumes pointer/keyboard input. Apps gate gameplay (\`if !ctx.ui_has_focus { player.advance(...) }\`) so typing into a settings field doesn't fire WASD. Also short-circuits the \`Esc\` exit when a TextEdit is focused so Esc dismisses the edit instead of exiting.
- **\`examples/ui_smoke\`**: button + slider + text input + world-anchored label + \`ui_has_focus\` gate. The "sun" orbits the origin; an egui label tracks it via \`world_to_screen\`. Hold W to read non-zero \`gated forward axis\`; click into the title field, the axis reads zero while the edit has focus.

## Workspace bumps required by egui-wgpu compat

egui-wgpu 0.33 (the latest version compatible with rustc 1.88) wants wgpu 27. The workspace was on wgpu 26. Bumped to wgpu/naga 27 with two API touch-ups:

- \`DeviceDescriptor\` gained \`experimental_features\` (added \`Default::default()\` in two places).
- \`PollType::Wait\` became a struct variant with optional \`submission_index\` and \`timeout\` (updated the GPU-probe path).

All existing tests including the lavapipe GPU probes still pass under wgpu 27.

## What's deliberately out of scope

- **3D-billboard egui** (egui rendered to texture, sampled in the scene with ray-cast interaction). Possible but unnecessary for current use cases; \`world_to_screen\` covers labels and HUDs that follow 3D objects.
- **Custom widget set**. egui's defaults are fine for v0; theme tweaks live in the app, not in \`rye-ui\`.
- **Migrating existing examples to use UI**. \`App::ui\` defaults to no-op; current examples are unchanged. The natural follow-up PR is migrating polytope_smoke's keyboard-toggle UI to egui sliders + checkboxes.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-targets\` (339 passed; 5 \`world_to_screen\` unit tests new in rye-ui)
- [x] \`cargo test gpu_probe -- --include-ignored\` (lavapipe GPU parity probes still green under wgpu 27)
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace\`
- [x] Eyes-on visual verification of \`cargo run --release --example ui_smoke\` (UI renders, button toggles, slider drags, text input gates, sun label tracks)