### PR TITLE
feat(rasterizer): R³ + R⁴ line wireframes alongside the SDF tier

### DIFF
--- a/crates/rye-app/src/capture.rs
+++ b/crates/rye-app/src/capture.rs
@@ -96,7 +96,7 @@ use wgpu::{
     TextureAspect, TextureFormat,
 };
 
-use rye_egui::{cmd, Console, ConsoleWriter};
+use rye_egui::Console;
 
 /// Where in the frame pipeline the capture is taken from.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -1450,39 +1450,18 @@ fn write_png_bytes(path: &Path, rgba: &[u8], width: u32, height: u32) -> Result<
 /// aspect preserved); GIF-only. Args are key-value, not in arg_choices, so tab
 /// completion doesn't surface them (free-form values aren't enumerable).
 pub fn register_commands<Ctx: 'static>(console: &mut Console<Ctx>) {
-    console.register(
-        cmd("capture", capture_help(), |args, _ctx: &mut Ctx, out| {
-            run_capture(args, out)
-        })
-        // Positional arg-choice grammar drives tab-completion + ghost preview.
-        // All kv keys appear at the arg level (`fps=`, `palette=`, `scale=`); the
-        // *values* for `palette=` are declared separately via
-        // `with_value_choices` so the console can do two-step completion: first
-        // Tab lands on `palette=`, then ghost/Tab cycles `global`/`local`.
-        // `fps=` and `scale=` have no value choices (free-form numeric input)
-        // so completion stops at the bare key.
-        .with_args(&[
-            &["png", "frames", "gif", "apng", "toggle", "stop", "panel"],
-            &["both", "fps=", "palette=", "post", "pre", "scale="],
-            &["fps=", "palette=", "scale="],
-            &["fps=", "palette=", "scale="],
-        ])
-        .with_value_choices("palette", &["local", "global"]),
-    );
-}
+    // Each subcommand is its own typed registration. Per-subcommand `arg_choices`
+    // drive context-aware tab completion (the `gif` palette/fps/scale prefixes only
+    // surface after the user types `capture gif `), and `palette=` is the only kv
+    // key with enumerable values. The framework handles dispatch + subcommand-name
+    // completion; the handlers only own arg parsing + enqueue logic.
+    let stage_choices: &[&'static str] = &["pre", "post", "both"];
+    let png_kv: &[&'static str] = &["fps=", "scale="];
+    let gif_kv: &[&'static str] = &["fps=", "palette=", "scale="];
+    let palette_values: &[&'static str] = &["local", "global"];
 
-fn capture_help() -> &'static str {
-    "capture <png|frames|gif|apng|toggle|stop|panel> [pre|post|both] [dir] [fps=N] \
-     [scale=W] [palette=local|global]"
-}
-
-fn run_capture(args: &[&str], out: &mut ConsoleWriter) -> Result<()> {
-    let Some((sub, rest)) = args.split_first() else {
-        out.error(format!("usage: {}", capture_help()));
-        return Ok(());
-    };
-    match *sub {
-        "png" => {
+    let cap = rye_egui::subcommands::<Ctx>("capture", capture_help())
+        .custom("png", "one-shot PNG capture", &[stage_choices], &[], |_, rest, out| {
             let p = parse_capture_args(rest);
             enqueue(CaptureRequest::OneShot {
                 stage: p.stage,
@@ -1490,115 +1469,144 @@ fn run_capture(args: &[&str], out: &mut ConsoleWriter) -> Result<()> {
                 name: None,
             });
             out.line(format!("queued one-shot ({:?})", p.stage));
-        }
-        "frames" => {
-            let p = parse_capture_args(rest);
-            enqueue(CaptureRequest::StartSequence {
-                format: CaptureFormat::Png,
-                stage: p.stage,
-                dir: p.dir,
-                name: None,
-                fps: p.fps,
-                scale: None,
-                palette: PaletteMode::default(),
-            });
-            out.line(format!("started PNG sequence ({:?})", p.stage));
-        }
-        "gif" => {
-            let p = parse_capture_args(rest);
-            // Always surface the GIF quality caveat. Raymarched continuous-tone
-            // content fights the 256-color palette and produces visible flicker.
-            out.error(
-                "GIF: per-frame NeuQuant flickers on raymarched content. Prefer \
-                 `capture apng` for shareable clips, or `capture frames` + ffmpeg \
-                 palettegen for high-quality post-processed GIFs.",
-            );
-            tracing::warn!(
-                "capture: GIF quality is limited for raymarched content (per-frame \
-                 palette regeneration causes flicker); prefer apng or PNG sequence"
-            );
-            // `palette=global` is the more experimental path (warmup buffer, shared
-            // NeuQuant, training-data bias if anything is visible during warmup).
-            // Stack a second warning so the extra caveats are surfaced.
-            if p.palette == PaletteMode::Global {
+            Ok(())
+        })
+        .custom(
+            "frames",
+            "PNG frame sequence (per-frame .png files)",
+            &[stage_choices, png_kv, png_kv],
+            &[],
+            |_, rest, out| {
+                let p = parse_capture_args(rest);
+                enqueue(CaptureRequest::StartSequence {
+                    format: CaptureFormat::Png,
+                    stage: p.stage,
+                    dir: p.dir,
+                    name: None,
+                    fps: p.fps,
+                    scale: None,
+                    palette: PaletteMode::default(),
+                });
+                out.line(format!("started PNG sequence ({:?})", p.stage));
+                Ok(())
+            },
+        )
+        .custom(
+            "gif",
+            "GIF sequence (limited quality on raymarched content)",
+            &[stage_choices, gif_kv, gif_kv, gif_kv],
+            &[("palette", palette_values)],
+            |_, rest, out| {
+                let p = parse_capture_args(rest);
+                // Surface the GIF quality caveat. Raymarched continuous-tone content
+                // fights the 256-color palette and produces visible flicker.
                 out.error(
-                    "GIF palette=global: palette is trained from the first ~1s of \
-                     captures; anything on screen during that window (the console, \
-                     transient overlays) biases the palette toward those colors and \
-                     the rest of the recording looks desaturated. Capture pre-egui \
-                     (`capture gif pre palette=global`) to avoid.",
+                    "GIF: per-frame NeuQuant flickers on raymarched content. Prefer \
+                     `capture apng` for shareable clips, or `capture frames` + ffmpeg \
+                     palettegen for high-quality post-processed GIFs.",
                 );
                 tracing::warn!(
-                    "capture: GIF palette=global trains on the warmup buffer; ensure \
-                     no transient UI is visible during the first ~1s of capture"
+                    "capture: GIF quality is limited for raymarched content (per-frame \
+                     palette regeneration causes flicker); prefer apng or PNG sequence"
                 );
-            }
-            enqueue(CaptureRequest::StartSequence {
-                format: CaptureFormat::Gif,
-                stage: p.stage,
-                dir: p.dir,
-                name: None,
-                fps: p.fps,
-                scale: p.scale,
-                palette: p.palette,
-            });
-            out.line(format!(
-                "started GIF stream ({:?}, fps={}, scale={}, palette={:?})",
-                p.stage,
-                p.fps.map_or("default".into(), |f| f.to_string()),
-                p.scale.map_or("native".into(), |s| s.to_string()),
-                p.palette,
-            ));
-        }
-        "apng" => {
-            let p = parse_capture_args(rest);
-            enqueue(CaptureRequest::StartSequence {
-                format: CaptureFormat::Apng,
-                stage: p.stage,
-                dir: p.dir,
-                name: None,
-                fps: p.fps,
-                scale: p.scale,
-                palette: PaletteMode::default(),
-            });
-            out.line(format!(
-                "started APNG stream ({:?}, fps={}, scale={})",
-                p.stage,
-                p.fps.map_or("default".into(), |f| f.to_string()),
-                p.scale.map_or("native".into(), |s| s.to_string()),
-            ));
-        }
-        "stop" => {
+                if p.palette == PaletteMode::Global {
+                    out.error(
+                        "GIF palette=global: palette is trained from the first ~1s of \
+                         captures; anything on screen during that window (the console, \
+                         transient overlays) biases the palette toward those colors and \
+                         the rest of the recording looks desaturated. Capture pre-egui \
+                         (`capture gif pre palette=global`) to avoid.",
+                    );
+                    tracing::warn!(
+                        "capture: GIF palette=global trains on the warmup buffer; ensure \
+                         no transient UI is visible during the first ~1s of capture"
+                    );
+                }
+                enqueue(CaptureRequest::StartSequence {
+                    format: CaptureFormat::Gif,
+                    stage: p.stage,
+                    dir: p.dir,
+                    name: None,
+                    fps: p.fps,
+                    scale: p.scale,
+                    palette: p.palette,
+                });
+                out.line(format!(
+                    "started GIF stream ({:?}, fps={}, scale={}, palette={:?})",
+                    p.stage,
+                    p.fps.map_or("default".into(), |f| f.to_string()),
+                    p.scale.map_or("native".into(), |s| s.to_string()),
+                    p.palette,
+                ));
+                Ok(())
+            },
+        )
+        .custom(
+            "apng",
+            "APNG sequence (true-color, larger than GIF)",
+            &[stage_choices, png_kv, png_kv],
+            &[],
+            |_, rest, out| {
+                let p = parse_capture_args(rest);
+                enqueue(CaptureRequest::StartSequence {
+                    format: CaptureFormat::Apng,
+                    stage: p.stage,
+                    dir: p.dir,
+                    name: None,
+                    fps: p.fps,
+                    scale: p.scale,
+                    palette: PaletteMode::default(),
+                });
+                out.line(format!(
+                    "started APNG stream ({:?}, fps={}, scale={})",
+                    p.stage,
+                    p.fps.map_or("default".into(), |f| f.to_string()),
+                    p.scale.map_or("native".into(), |s| s.to_string()),
+                ));
+                Ok(())
+            },
+        )
+        .custom(
+            "toggle",
+            "start/stop a sequence in one command (format + args)",
+            &[&["png", "frames", "gif", "apng"], stage_choices, gif_kv, gif_kv],
+            &[("palette", palette_values)],
+            |_, rest, out| {
+                let (format, after_format) = parse_format(rest);
+                let p = parse_capture_args(after_format);
+                enqueue(CaptureRequest::Toggle {
+                    format,
+                    stage: p.stage,
+                    dir: p.dir,
+                    name: None,
+                    fps: p.fps,
+                    scale: p.scale,
+                    palette: p.palette,
+                });
+                out.line(format!("toggle queued ({format:?}, {:?})", p.stage));
+                Ok(())
+            },
+        )
+        .custom("stop", "stop the active sequence", &[], &[], |_, _rest, out| {
             enqueue(CaptureRequest::Stop);
             out.line("stop queued");
-        }
-        "panel" => {
+            Ok(())
+        })
+        .custom("panel", "toggle the capture parameters panel", &[], &[], |_, _rest, out| {
             let now_open = toggle_panel_global();
             out.line(if now_open {
                 "panel opened"
             } else {
                 "panel closed"
             });
-        }
-        "toggle" => {
-            let (format, after_format) = parse_format(rest);
-            let p = parse_capture_args(after_format);
-            enqueue(CaptureRequest::Toggle {
-                format,
-                stage: p.stage,
-                dir: p.dir,
-                name: None,
-                fps: p.fps,
-                scale: p.scale,
-                palette: p.palette,
-            });
-            out.line(format!("toggle queued ({format:?}, {:?})", p.stage));
-        }
-        other => {
-            out.error(format!("unknown sub-command `{other}`. {}", capture_help()));
-        }
-    }
-    Ok(())
+            Ok(())
+        });
+    console.register(cap);
+}
+
+fn capture_help() -> &'static str {
+    "capture <png|frames|gif|apng|toggle|stop|panel> [pre|post|both] [dir] [fps=N] \
+     [scale=W] [palette=local|global]"
 }
 
 struct ParsedCaptureArgs {

--- a/crates/rye-app/src/capture.rs
+++ b/crates/rye-app/src/capture.rs
@@ -1461,16 +1461,22 @@ pub fn register_commands<Ctx: 'static>(console: &mut Console<Ctx>) {
     let palette_values: &[&'static str] = &["local", "global"];
 
     let cap = rye_egui::subcommands::<Ctx>("capture", capture_help())
-        .custom("png", "one-shot PNG capture", &[stage_choices], &[], |_, rest, out| {
-            let p = parse_capture_args(rest);
-            enqueue(CaptureRequest::OneShot {
-                stage: p.stage,
-                dir: p.dir,
-                name: None,
-            });
-            out.line(format!("queued one-shot ({:?})", p.stage));
-            Ok(())
-        })
+        .custom(
+            "png",
+            "one-shot PNG capture",
+            &[stage_choices],
+            &[],
+            |_, rest, out| {
+                let p = parse_capture_args(rest);
+                enqueue(CaptureRequest::OneShot {
+                    stage: p.stage,
+                    dir: p.dir,
+                    name: None,
+                });
+                out.line(format!("queued one-shot ({:?})", p.stage));
+                Ok(())
+            },
+        )
         .custom(
             "frames",
             "PNG frame sequence (per-frame .png files)",
@@ -1569,7 +1575,12 @@ pub fn register_commands<Ctx: 'static>(console: &mut Console<Ctx>) {
         .custom(
             "toggle",
             "start/stop a sequence in one command (format + args)",
-            &[&["png", "frames", "gif", "apng"], stage_choices, gif_kv, gif_kv],
+            &[
+                &["png", "frames", "gif", "apng"],
+                stage_choices,
+                gif_kv,
+                gif_kv,
+            ],
             &[("palette", palette_values)],
             |_, rest, out| {
                 let (format, after_format) = parse_format(rest);
@@ -1587,20 +1598,32 @@ pub fn register_commands<Ctx: 'static>(console: &mut Console<Ctx>) {
                 Ok(())
             },
         )
-        .custom("stop", "stop the active sequence", &[], &[], |_, _rest, out| {
-            enqueue(CaptureRequest::Stop);
-            out.line("stop queued");
-            Ok(())
-        })
-        .custom("panel", "toggle the capture parameters panel", &[], &[], |_, _rest, out| {
-            let now_open = toggle_panel_global();
-            out.line(if now_open {
-                "panel opened"
-            } else {
-                "panel closed"
-            });
-            Ok(())
-        });
+        .custom(
+            "stop",
+            "stop the active sequence",
+            &[],
+            &[],
+            |_, _rest, out| {
+                enqueue(CaptureRequest::Stop);
+                out.line("stop queued");
+                Ok(())
+            },
+        )
+        .custom(
+            "panel",
+            "toggle the capture parameters panel",
+            &[],
+            &[],
+            |_, _rest, out| {
+                let now_open = toggle_panel_global();
+                out.line(if now_open {
+                    "panel opened"
+                } else {
+                    "panel closed"
+                });
+                Ok(())
+            },
+        );
     console.register(cap);
 }
 

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -505,10 +505,7 @@ impl<Ctx: 'static> SubcommandSet<Ctx> {
 
 /// Build a [`SubcommandSet`] for a multi-subcommand console command. See the
 /// [`SubcommandSet`] docs for the full builder pattern.
-pub fn subcommands<Ctx: 'static>(
-    name: &'static str,
-    help: &'static str,
-) -> SubcommandSet<Ctx> {
+pub fn subcommands<Ctx: 'static>(name: &'static str, help: &'static str) -> SubcommandSet<Ctx> {
     SubcommandSet {
         name,
         help,
@@ -581,10 +578,9 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
             return &[];
         };
         match &entry.kind {
-            SubcommandKind::Custom { value_choices, .. } => value_choices
-                .get(key)
-                .map(|v| v.as_slice())
-                .unwrap_or(&[]),
+            SubcommandKind::Custom { value_choices, .. } => {
+                value_choices.get(key).map(|v| v.as_slice()).unwrap_or(&[])
+            }
             _ => &[],
         }
     }
@@ -609,9 +605,9 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
         };
         match &mut entry.kind {
             SubcommandKind::Toggle { handler } => {
-                let value = rest.first().ok_or_else(|| {
-                    anyhow::anyhow!("usage: {} {sub_name} <on|off>", self.name)
-                })?;
+                let value = rest
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("usage: {} {sub_name} <on|off>", self.name))?;
                 let v = match value.to_ascii_lowercase().as_str() {
                     "on" | "true" | "1" => true,
                     "off" | "false" | "0" => false,
@@ -626,9 +622,9 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
                 handler(ctx, v)
             }
             SubcommandKind::Choice { handler, .. } => {
-                let value = rest.first().ok_or_else(|| {
-                    anyhow::anyhow!("usage: {} {sub_name} <value>", self.name)
-                })?;
+                let value = rest
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("usage: {} {sub_name} <value>", self.name))?;
                 let _ = out;
                 handler(ctx, value)
             }
@@ -1969,7 +1965,11 @@ mod tests {
         let m = con.completion_matches(&ctx);
         assert_eq!(
             m,
-            vec!["5cell".to_string(), "off".to_string(), "tesseract".to_string()]
+            vec![
+                "5cell".to_string(),
+                "off".to_string(),
+                "tesseract".to_string()
+            ]
         );
         assert!(!m.contains(&"on".into()));
     }
@@ -1985,7 +1985,11 @@ mod tests {
         let m = con.completion_matches(&ctx);
         assert_eq!(
             m,
-            vec!["axes".to_string(), "cube".to_string(), "polytope".to_string()]
+            vec![
+                "axes".to_string(),
+                "cube".to_string(),
+                "polytope".to_string()
+            ]
         );
     }
 
@@ -2117,7 +2121,10 @@ mod tests {
 
     #[test]
     fn tokenize_preserves_spaces_in_double_quotes() {
-        assert_eq!(tokenize(r#"foo "bar baz" qux"#), vec!["foo", "bar baz", "qux"]);
+        assert_eq!(
+            tokenize(r#"foo "bar baz" qux"#),
+            vec!["foo", "bar baz", "qux"]
+        );
     }
 
     #[test]
@@ -2145,7 +2152,10 @@ mod tests {
     fn tokenize_unterminated_quote_consumes_to_end() {
         // For interactive ergonomics: don't error on unterminated quotes; treat
         // trailing content as one token.
-        assert_eq!(tokenize(r#"foo "unterminated"#), vec!["foo", "unterminated"]);
+        assert_eq!(
+            tokenize(r#"foo "unterminated"#),
+            vec!["foo", "unterminated"]
+        );
     }
 
     #[test]

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -191,6 +191,20 @@ pub trait Command<Ctx>: 'static {
         &[]
     }
 
+    /// Context-aware variant of [`Command::arg_value_choices`]. Receives the arg
+    /// tokens parsed BEFORE the current completion position; subcommand-dispatching
+    /// commands route kv-value lookups to the active subcommand's value table
+    /// using this. Default delegates to [`Command::arg_value_choices`].
+    fn arg_value_choices_ctx<'a>(
+        &'a self,
+        arg_index: usize,
+        key: &str,
+        prior: &[&str],
+    ) -> &'a [&'static str] {
+        let _ = prior;
+        self.arg_value_choices(arg_index, key)
+    }
+
     /// Run the command. `args` are whitespace-split tokens after the command name.
     /// Output goes to `out`; recoverable issues get `out.error(..)`; unrecoverable
     /// ones return `Err`.
@@ -310,6 +324,14 @@ type ToggleHandler<Ctx> = Box<dyn FnMut(&mut Ctx, bool) -> anyhow::Result<()>>;
 /// to handle case-insensitivity / aliases if those are wanted).
 type ChoiceHandler<Ctx> = Box<dyn FnMut(&mut Ctx, &str) -> anyhow::Result<()>>;
 
+/// Boxed handler for a custom-grammar subcommand. Receives the user's context, the
+/// raw args slice AFTER the subcommand name (positional + key-value tokens, framework
+/// does not parse them), and the writer. Used for subcommands whose grammar doesn't
+/// fit the simpler `.toggle` / `.choice` shapes (e.g. `capture gif post fps=30
+/// scale=720 palette=global`).
+type CustomHandler<Ctx> =
+    Box<dyn FnMut(&mut Ctx, &[&str], &mut ConsoleWriter) -> anyhow::Result<()>>;
+
 /// One entry in a [`SubcommandSet`]. The dispatch kind decides how the framework
 /// parses the value slot and what's offered for tab completion.
 enum SubcommandKind<Ctx> {
@@ -322,6 +344,16 @@ enum SubcommandKind<Ctx> {
     Choice {
         choices: Vec<&'static str>,
         handler: ChoiceHandler<Ctx>,
+    },
+    /// Custom-grammar subcommand. Per-slot positional choices drive tab completion
+    /// (slot 0 is the first arg AFTER the subcommand name); per-key value enumerables
+    /// drive two-step kv completion. The framework dispatches by subcommand name and
+    /// then hands the raw args + writer to the handler; arg parsing is the
+    /// handler's responsibility.
+    Custom {
+        arg_choices: Vec<Vec<&'static str>>,
+        value_choices: HashMap<&'static str, Vec<&'static str>>,
+        handler: CustomHandler<Ctx>,
     },
 }
 
@@ -411,6 +443,60 @@ impl<Ctx: 'static> SubcommandSet<Ctx> {
         self
     }
 
+    /// Register a custom-grammar subcommand. Use when `.toggle` / `.choice` are too
+    /// rigid: subcommands with multiple positional args, key-value pairs, or both.
+    ///
+    /// - `arg_choices[i]` lists tab-completion choices for the i-th positional arg
+    ///   AFTER the subcommand name. Include `key=` entries for kv-pair prefixes.
+    /// - `value_choices[k]` lists enumerable values for the `key=value` arg whose
+    ///   bare key is `k` (the framework looks this up when the user types `k=` and
+    ///   hits Tab).
+    /// - `handler` receives the raw args after the subcommand name plus the writer;
+    ///   it owns the parsing of positionals and kv tokens.
+    ///
+    /// ```ignore
+    /// subcommands::<Ctx>("capture", "...")
+    ///     .custom(
+    ///         "gif",
+    ///         "gif sequence (with fps/scale/palette knobs)",
+    ///         &[
+    ///             &["pre", "post", "both"],
+    ///             &["fps=", "palette=", "scale="],
+    ///             &["fps=", "palette=", "scale="],
+    ///         ],
+    ///         &[("palette", &["local", "global"])],
+    ///         |ctx, args, out| { /* parse and act */ Ok(()) },
+    ///     )
+    /// ```
+    pub fn custom<F>(
+        mut self,
+        name: &'static str,
+        help: &'static str,
+        arg_choices: &[&[&'static str]],
+        value_choices: &[(&'static str, &[&'static str])],
+        handler: F,
+    ) -> Self
+    where
+        F: FnMut(&mut Ctx, &[&str], &mut ConsoleWriter) -> anyhow::Result<()> + 'static,
+    {
+        let mut vc = HashMap::new();
+        for (k, vs) in value_choices {
+            vc.insert(*k, vs.to_vec());
+        }
+        self.subs.insert(
+            name,
+            SubcommandEntry {
+                help,
+                kind: SubcommandKind::Custom {
+                    arg_choices: arg_choices.iter().map(|slot| slot.to_vec()).collect(),
+                    value_choices: vc,
+                    handler: Box::new(handler),
+                },
+            },
+        );
+        self
+    }
+
     fn cached_names(&self) -> &[&'static str] {
         self.name_cache
             .get_or_init(|| self.subs.keys().copied().collect())
@@ -451,12 +537,43 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
         if arg_index == 0 {
             return self.cached_names();
         }
-        if arg_index != 1 {
+        let Some(&sub_name) = prior.first() else {
             return &[];
+        };
+        let Some(entry) = self.subs.get(sub_name) else {
+            return &[];
+        };
+        // Within-subcommand slot index: arg_index 1 is the first arg AFTER the
+        // subcommand name, which is slot 0 of the subcommand's own grammar.
+        let sub_slot = arg_index - 1;
+        match &entry.kind {
+            SubcommandKind::Toggle { .. } => {
+                if sub_slot == 0 {
+                    ON_OFF_CHOICES
+                } else {
+                    &[]
+                }
+            }
+            SubcommandKind::Choice { choices, .. } => {
+                if sub_slot == 0 {
+                    choices.as_slice()
+                } else {
+                    &[]
+                }
+            }
+            SubcommandKind::Custom { arg_choices, .. } => arg_choices
+                .get(sub_slot)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]),
         }
-        // `&sub_name` pattern peels one reference off the `&&str` returned by
-        // `prior.first()`, leaving `sub_name: &str` whose lifetime is tied to `prior`
-        // (which is fine: we only use it to look up in `subs` and don't return it).
+    }
+
+    fn arg_value_choices_ctx<'a>(
+        &'a self,
+        _arg_index: usize,
+        key: &str,
+        prior: &[&str],
+    ) -> &'a [&'static str] {
         let Some(&sub_name) = prior.first() else {
             return &[];
         };
@@ -464,8 +581,11 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
             return &[];
         };
         match &entry.kind {
-            SubcommandKind::Toggle { .. } => ON_OFF_CHOICES,
-            SubcommandKind::Choice { choices, .. } => choices.as_slice(),
+            SubcommandKind::Custom { value_choices, .. } => value_choices
+                .get(key)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]),
+            _ => &[],
         }
     }
 
@@ -487,7 +607,6 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
                 names.join(", ")
             ));
         };
-        let _ = out;
         match &mut entry.kind {
             SubcommandKind::Toggle { handler } => {
                 let value = rest.first().ok_or_else(|| {
@@ -503,14 +622,17 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
                         ))
                     }
                 };
+                let _ = out;
                 handler(ctx, v)
             }
             SubcommandKind::Choice { handler, .. } => {
                 let value = rest.first().ok_or_else(|| {
                     anyhow::anyhow!("usage: {} {sub_name} <value>", self.name)
                 })?;
+                let _ = out;
                 handler(ctx, value)
             }
+            SubcommandKind::Custom { handler, .. } => handler(ctx, rest, out),
         }
     }
 }
@@ -971,12 +1093,13 @@ impl<Ctx: 'static> Console<Ctx> {
                 // Mid-`key=` value completion: if the partial token already
                 // contains an `=`, we're past the key and completing its value.
                 // Look up the enumerable values declared via `with_value_choices`
+                // (or the context-aware variant for subcommand-dispatching commands)
                 // and return them prefixed with `key=`.
                 if let Some(eq) = prefix.find('=') {
                     let key = &prefix[..eq];
                     let value_prefix = &prefix[eq + 1..];
                     let mut matches: Vec<String> = cmd
-                        .arg_value_choices(*arg_index, key)
+                        .arg_value_choices_ctx(*arg_index, key, &prior_refs)
                         .iter()
                         .filter(|v| v.starts_with(value_prefix))
                         .map(|v| format!("{key}={v}"))
@@ -1767,6 +1890,123 @@ mod tests {
         assert_eq!(
             m,
             vec!["axes".to_string(), "cube".to_string(), "polytope".to_string()]
+        );
+    }
+
+    // ----------------- SubcommandSet::Custom -----------------
+
+    type CustomCtx = Vec<String>;
+
+    fn custom_subset() -> SubcommandSet<CustomCtx> {
+        subcommands::<CustomCtx>("capture", "umbrella")
+            // No-arg subcommand.
+            .custom("stop", "stop running capture", &[], &[], |c, rest, _out| {
+                c.push(format!("stop;rest={}", rest.join(",")));
+                Ok(())
+            })
+            // Single-slot positional subcommand.
+            .custom(
+                "png",
+                "one-shot png",
+                &[&["pre", "post", "both"]],
+                &[],
+                |c, rest, _out| {
+                    c.push(format!("png;rest={}", rest.join(",")));
+                    Ok(())
+                },
+            )
+            // Multi-slot with kv pairs + enumerable value for one of them.
+            .custom(
+                "gif",
+                "gif sequence",
+                &[
+                    &["pre", "post", "both"],
+                    &["fps=", "palette=", "scale="],
+                    &["fps=", "palette=", "scale="],
+                ],
+                &[("palette", &["local", "global"])],
+                |c, rest, _out| {
+                    c.push(format!("gif;rest={}", rest.join(",")));
+                    Ok(())
+                },
+            )
+    }
+
+    #[test]
+    fn custom_subcommand_dispatch_receives_full_rest() {
+        let mut con = Console::<CustomCtx>::new();
+        con.register(custom_subset());
+        let mut ctx: CustomCtx = Vec::new();
+
+        con.execute("capture png post", &mut ctx);
+        con.execute("capture gif both fps=30 palette=global", &mut ctx);
+        con.execute("capture stop", &mut ctx);
+
+        assert_eq!(
+            ctx,
+            vec![
+                "png;rest=post".to_string(),
+                "gif;rest=both,fps=30,palette=global".to_string(),
+                "stop;rest=".to_string(),
+            ]
+        );
+    }
+
+    /// Multi-slot tab completion: each positional slot AFTER the subcommand name
+    /// returns the slot-specific arg_choices. Slot 0 of `gif` is the stage; slot 1
+    /// is the first kv key.
+    #[test]
+    fn custom_multi_slot_completion_per_slot() {
+        let mut con = Console::<CustomCtx>::new();
+        con.register(custom_subset());
+
+        // `capture gif ` -> slot 0 of `gif`: stages.
+        con.input = "capture gif ".into();
+        let ctx = con.completion_context().unwrap();
+        let m = con.completion_matches(&ctx);
+        assert_eq!(
+            m,
+            vec!["both".to_string(), "post".to_string(), "pre".to_string()]
+        );
+
+        // `capture gif post ` -> slot 1 of `gif`: kv prefixes.
+        con.input = "capture gif post ".into();
+        let ctx = con.completion_context().unwrap();
+        let m = con.completion_matches(&ctx);
+        assert!(m.contains(&"fps=".into()));
+        assert!(m.contains(&"palette=".into()));
+        assert!(m.contains(&"scale=".into()));
+
+        // `capture png ` -> slot 0 of `png`: stages, NOT kv prefixes (those belong
+        // to gif).
+        con.input = "capture png ".into();
+        let ctx = con.completion_context().unwrap();
+        let m = con.completion_matches(&ctx);
+        assert!(m.contains(&"post".into()));
+        assert!(!m.contains(&"fps=".into()), "got: {m:?}");
+
+        // `capture stop ` -> no choices (zero-slot subcommand).
+        con.input = "capture stop ".into();
+        let ctx = con.completion_context().unwrap();
+        let m = con.completion_matches(&ctx);
+        assert!(m.is_empty(), "got: {m:?}");
+    }
+
+    /// Two-step kv-value completion: after the user types `palette=`, ghost/Tab
+    /// should cycle the declared values. This is the context-aware kv path -- the
+    /// same `palette=` prefix in a hypothetical non-gif subcommand wouldn't produce
+    /// these (gif is the only subcommand that declares `palette` value-choices).
+    #[test]
+    fn custom_subcommand_kv_value_completion_is_context_aware() {
+        let mut con = Console::<CustomCtx>::new();
+        con.register(custom_subset());
+
+        con.input = "capture gif post palette=".into();
+        let ctx = con.completion_context().unwrap();
+        let m = con.completion_matches(&ctx);
+        assert_eq!(
+            m,
+            vec!["palette=global".to_string(), "palette=local".to_string()]
         );
     }
 }

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -150,14 +150,36 @@ pub trait Command<Ctx>: 'static {
     /// One-line description shown by `help`.
     fn help(&self) -> &str;
 
-    /// Tab-completion choices for the `arg_index`-th positional argument. Default is
-    /// empty (no completion / free-form arg like a path or number). Override via
-    /// [`FnCommand::with_args`] when an arg is a fixed enum like `pre|post|both`,
-    /// or include a `key=` entry to declare a key-value arg whose values are
-    /// supplied separately by [`Command::arg_value_choices`].
+    /// Tab-completion choices for the `arg_index`-th positional argument, without
+    /// awareness of values typed in prior slots. Default is empty (no completion /
+    /// free-form arg like a path or number). Override via [`FnCommand::with_args`]
+    /// when an arg is a fixed enum like `pre|post|both`, or include a `key=` entry
+    /// to declare a key-value arg whose values are supplied separately by
+    /// [`Command::arg_value_choices`].
+    ///
+    /// Most commands should override this. Subcommand-style commands whose value
+    /// slot depends on what subcommand was picked should override
+    /// [`Command::arg_choices_ctx`] instead (this method's default returns `&[]`,
+    /// and `arg_choices_ctx`'s default delegates back here).
     fn arg_choices(&self, arg_index: usize) -> &[&'static str] {
         let _ = arg_index;
         &[]
+    }
+
+    /// Context-aware variant of [`Command::arg_choices`]. Receives the arg tokens
+    /// parsed BEFORE the current completion position (`prior.len() == arg_index`),
+    /// so completion can branch on prior choices.
+    ///
+    /// Default delegates to [`Command::arg_choices`], so commands that don't need
+    /// context don't have to override this. Subcommand dispatch (e.g.
+    /// [`SubcommandSet`]) overrides this to gate the value-slot choices on the
+    /// selected subcommand.
+    ///
+    /// The explicit `'a` lifetime ties the returned slice to `&self`; the nested
+    /// `&[&str]` in `prior` would otherwise confuse lifetime elision.
+    fn arg_choices_ctx<'a>(&'a self, arg_index: usize, prior: &[&str]) -> &'a [&'static str] {
+        let _ = prior;
+        self.arg_choices(arg_index)
     }
 
     /// Enumerable values for a `key=value` arg at `arg_index` whose key is `key`
@@ -271,6 +293,229 @@ where
 }
 
 // ---------------------------------------------------------------------------
+// Subcommand dispatch
+// ---------------------------------------------------------------------------
+
+/// Static on/off completion list used by every `Toggle` subcommand. Lives here so the
+/// `arg_choices_ctx` impl can hand back a `&'static [&'static str]` without owning a
+/// per-instance Vec.
+const ON_OFF_CHOICES: &[&str] = &["off", "on"];
+
+/// Boxed handler for an on/off toggle subcommand. Receives the user's context and the
+/// parsed bool; returns a `Result` so handlers can fail with usage / validation errors.
+type ToggleHandler<Ctx> = Box<dyn FnMut(&mut Ctx, bool) -> anyhow::Result<()>>;
+
+/// Boxed handler for a fixed-choice subcommand. Receives the user's context and the
+/// raw value string (one of the declared choices in normal use; the handler still has
+/// to handle case-insensitivity / aliases if those are wanted).
+type ChoiceHandler<Ctx> = Box<dyn FnMut(&mut Ctx, &str) -> anyhow::Result<()>>;
+
+/// One entry in a [`SubcommandSet`]. The dispatch kind decides how the framework
+/// parses the value slot and what's offered for tab completion.
+enum SubcommandKind<Ctx> {
+    /// On/off subcommand. The framework parses `args[1]` as `on|off` and passes the
+    /// resulting bool to `handler`. Completion at the value slot is the static
+    /// `["off", "on"]` list.
+    Toggle { handler: ToggleHandler<Ctx> },
+    /// Fixed-choice subcommand. The framework completes the value slot from `choices`;
+    /// the handler receives the raw value string and decides what to do.
+    Choice {
+        choices: Vec<&'static str>,
+        handler: ChoiceHandler<Ctx>,
+    },
+}
+
+struct SubcommandEntry<Ctx> {
+    help: &'static str,
+    kind: SubcommandKind<Ctx>,
+}
+
+/// A command that dispatches to one of several named subcommands based on the first
+/// positional arg. Provides typed dispatch (no `match arg.to_lowercase()` boilerplate
+/// per command) and context-aware tab completion (the value-slot list narrows to the
+/// chosen subcommand's allowed values).
+///
+/// Build with [`subcommands`] and chain [`SubcommandSet::toggle`] /
+/// [`SubcommandSet::choice`] to register subcommands. Register the whole set as a
+/// single command via `console.register(set)`.
+///
+/// ```ignore
+/// let tests = subcommands::<MyCtx>("tests", "select what renders")
+///     .toggle("axes", "toggle world-axes", |ctx, on| {
+///         ctx.show_axes = on;
+///         Ok(())
+///     })
+///     .choice(
+///         "polytope",
+///         "set R⁴ polytope overlay",
+///         &["5cell", "tesseract", "16cell", "off"],
+///         |ctx, name| { ctx.polytope = parse_polytope(name)?; Ok(()) },
+///     );
+/// console.register(tests);
+/// ```
+pub struct SubcommandSet<Ctx> {
+    name: &'static str,
+    help: &'static str,
+    /// Insertion-ordered subcommands. BTreeMap so iteration is deterministic and Tab
+    /// cycling order is alphabetical, matching the rest of the console.
+    subs: BTreeMap<&'static str, SubcommandEntry<Ctx>>,
+    /// Cached sorted slice of subcommand names. Populated lazily on first
+    /// [`Command::arg_choices`] / [`Command::arg_choices_ctx`] call so [`Self::toggle`]
+    /// and [`Self::choice`] can stay infallible chainable builders.
+    name_cache: std::cell::OnceCell<Vec<&'static str>>,
+}
+
+impl<Ctx: 'static> SubcommandSet<Ctx> {
+    /// Register an on/off subcommand. The framework parses the value slot as
+    /// `on | off | true | false | 1 | 0`; the handler receives the parsed bool.
+    pub fn toggle<F>(mut self, name: &'static str, help: &'static str, handler: F) -> Self
+    where
+        F: FnMut(&mut Ctx, bool) -> anyhow::Result<()> + 'static,
+    {
+        self.subs.insert(
+            name,
+            SubcommandEntry {
+                help,
+                kind: SubcommandKind::Toggle {
+                    handler: Box::new(handler),
+                },
+            },
+        );
+        self
+    }
+
+    /// Register a fixed-choice subcommand. The framework completes the value slot from
+    /// `choices`; the handler receives the raw value string (which is one of `choices`
+    /// only after Tab-completion or exact match, since the framework does not validate
+    /// the value against `choices` before dispatch).
+    pub fn choice<F>(
+        mut self,
+        name: &'static str,
+        help: &'static str,
+        choices: &[&'static str],
+        handler: F,
+    ) -> Self
+    where
+        F: FnMut(&mut Ctx, &str) -> anyhow::Result<()> + 'static,
+    {
+        self.subs.insert(
+            name,
+            SubcommandEntry {
+                help,
+                kind: SubcommandKind::Choice {
+                    choices: choices.to_vec(),
+                    handler: Box::new(handler),
+                },
+            },
+        );
+        self
+    }
+
+    fn cached_names(&self) -> &[&'static str] {
+        self.name_cache
+            .get_or_init(|| self.subs.keys().copied().collect())
+    }
+}
+
+/// Build a [`SubcommandSet`] for a multi-subcommand console command. See the
+/// [`SubcommandSet`] docs for the full builder pattern.
+pub fn subcommands<Ctx: 'static>(
+    name: &'static str,
+    help: &'static str,
+) -> SubcommandSet<Ctx> {
+    SubcommandSet {
+        name,
+        help,
+        subs: BTreeMap::new(),
+        name_cache: std::cell::OnceCell::new(),
+    }
+}
+
+impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn help(&self) -> &str {
+        self.help
+    }
+
+    fn arg_choices(&self, arg_index: usize) -> &[&'static str] {
+        if arg_index == 0 {
+            self.cached_names()
+        } else {
+            &[]
+        }
+    }
+
+    fn arg_choices_ctx<'a>(&'a self, arg_index: usize, prior: &[&str]) -> &'a [&'static str] {
+        if arg_index == 0 {
+            return self.cached_names();
+        }
+        if arg_index != 1 {
+            return &[];
+        }
+        // `&sub_name` pattern peels one reference off the `&&str` returned by
+        // `prior.first()`, leaving `sub_name: &str` whose lifetime is tied to `prior`
+        // (which is fine: we only use it to look up in `subs` and don't return it).
+        let Some(&sub_name) = prior.first() else {
+            return &[];
+        };
+        let Some(entry) = self.subs.get(sub_name) else {
+            return &[];
+        };
+        match &entry.kind {
+            SubcommandKind::Toggle { .. } => ON_OFF_CHOICES,
+            SubcommandKind::Choice { choices, .. } => choices.as_slice(),
+        }
+    }
+
+    fn run(&mut self, args: &[&str], ctx: &mut Ctx, out: &mut ConsoleWriter) -> anyhow::Result<()> {
+        let Some((sub_name, rest)) = args.split_first() else {
+            // Usage block lists subcommands with their one-line help so `tests` with no
+            // args is self-documenting instead of dumping a bare grammar.
+            let mut msg = format!("usage: {} <subcommand> <value>; subcommands:", self.name);
+            for (name, entry) in &self.subs {
+                msg.push_str(&format!("\n  {name:12} {}", entry.help));
+            }
+            return Err(anyhow::anyhow!(msg));
+        };
+        let Some(entry) = self.subs.get_mut(*sub_name) else {
+            let names: Vec<&str> = self.subs.keys().copied().collect();
+            return Err(anyhow::anyhow!(
+                "unknown subcommand `{sub_name}` for `{}` (try {})",
+                self.name,
+                names.join(", ")
+            ));
+        };
+        let _ = out;
+        match &mut entry.kind {
+            SubcommandKind::Toggle { handler } => {
+                let value = rest.first().ok_or_else(|| {
+                    anyhow::anyhow!("usage: {} {sub_name} <on|off>", self.name)
+                })?;
+                let v = match value.to_ascii_lowercase().as_str() {
+                    "on" | "true" | "1" => true,
+                    "off" | "false" | "0" => false,
+                    other => {
+                        return Err(anyhow::anyhow!(
+                            "unknown value `{other}` for `{} {sub_name}` (try on|off)",
+                            self.name
+                        ))
+                    }
+                };
+                handler(ctx, v)
+            }
+            SubcommandKind::Choice { handler, .. } => {
+                let value = rest.first().ok_or_else(|| {
+                    anyhow::anyhow!("usage: {} {sub_name} <value>", self.name)
+                })?;
+                handler(ctx, value)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Console
 // ---------------------------------------------------------------------------
 
@@ -341,10 +586,14 @@ struct TabState {
 enum CompletionContext {
     /// Completing the command name (no whitespace yet, or whitespace-leading input).
     Command { prefix: String },
-    /// Completing positional argument `arg_index` of `cmd_name`.
+    /// Completing positional argument `arg_index` of `cmd_name`. `prior` carries the
+    /// fully-typed arg tokens BEFORE the cursor (`prior.len() == arg_index`); commands
+    /// that branch their value-slot completion on prior choices (subcommand dispatch)
+    /// read it via [`Command::arg_choices_ctx`].
     Arg {
         cmd_name: String,
         arg_index: usize,
+        prior: Vec<String>,
         prefix: String,
     },
 }
@@ -675,19 +924,28 @@ impl<Ctx: 'static> Console<Ctx> {
         // The `else` arm is reached only when `parsed.len() >= 2` (the `len() == 1 &&
         // !trailing_ws` case returned above), so `parsed.last()` is always `Some`;
         // `unwrap_or_default` returns the empty-string fallback only in the impossible
-        // path, keeping library code free of `unwrap()`.
+        // path, keeping library code free of `unwrap()`. `prior` captures the fully-
+        // typed arg tokens before the cursor so subcommand-dispatching commands can
+        // gate their value-slot completion on what came earlier.
         let cmd_name = parsed[0].to_string();
-        let (arg_index, prefix) = if trailing_ws {
-            (parsed.len() - 1, String::new())
+        let (arg_index, prefix, prior) = if trailing_ws {
+            let prior: Vec<String> = parsed[1..].iter().map(|s| (*s).to_string()).collect();
+            (parsed.len() - 1, String::new(), prior)
         } else {
+            let prior: Vec<String> = parsed[1..parsed.len() - 1]
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect();
             (
                 parsed.len() - 2,
                 parsed.last().copied().unwrap_or_default().to_string(),
+                prior,
             )
         };
         Some(CompletionContext::Arg {
             cmd_name,
             arg_index,
+            prior,
             prefix,
         })
     }
@@ -702,11 +960,13 @@ impl<Ctx: 'static> Console<Ctx> {
             CompletionContext::Arg {
                 cmd_name,
                 arg_index,
+                prior,
                 prefix,
             } => {
                 let Some(cmd) = self.commands.get(cmd_name) else {
                     return Vec::new();
                 };
+                let prior_refs: Vec<&str> = prior.iter().map(String::as_str).collect();
 
                 // Mid-`key=` value completion: if the partial token already
                 // contains an `=`, we're past the key and completing its value.
@@ -747,8 +1007,10 @@ impl<Ctx: 'static> Console<Ctx> {
                 // Sort matches alphabetically so command authors can declare choices
                 // in any order (workflow, frequency, narrative) without affecting Tab
                 // cycling order. Matches the command-name path, which is also sorted.
+                // Uses the context-aware variant so subcommand-dispatching commands
+                // can gate value-slot choices on the prior subcommand pick.
                 let mut matches: Vec<String> = cmd
-                    .arg_choices(*arg_index)
+                    .arg_choices_ctx(*arg_index, &prior_refs)
                     .iter()
                     .filter(|choice| choice.starts_with(prefix.as_str()))
                     .filter(|choice| {
@@ -1380,5 +1642,131 @@ mod tests {
         let last = c.history.back().unwrap();
         assert_eq!(last.kind, LineKind::Error);
         assert!(last.text.contains("nope"));
+    }
+
+    // ----------------- SubcommandSet -----------------
+
+    /// Holds a single `Ctx: u32` slot plus a `last_choice` string so tests can verify
+    /// which branch ran.
+    type SubCtx = (u32, String);
+
+    fn sample_subset() -> SubcommandSet<SubCtx> {
+        subcommands::<SubCtx>("tests", "umbrella")
+            .toggle("axes", "toggle axes", |c, v| {
+                c.0 = if v { 1 } else { 0 };
+                c.1 = format!("axes={v}");
+                Ok(())
+            })
+            .toggle("cube", "toggle cube", |c, v| {
+                c.0 = if v { 2 } else { 0 };
+                c.1 = format!("cube={v}");
+                Ok(())
+            })
+            .choice(
+                "polytope",
+                "set polytope",
+                &["5cell", "tesseract", "off"],
+                |c, name| {
+                    c.1 = format!("polytope={name}");
+                    Ok(())
+                },
+            )
+    }
+
+    #[test]
+    fn subcommand_dispatch_runs_correct_handler() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset());
+        let mut ctx: SubCtx = (0, String::new());
+
+        con.execute("tests axes on", &mut ctx);
+        assert_eq!(ctx, (1, "axes=true".into()));
+
+        con.execute("tests cube off", &mut ctx);
+        assert_eq!(ctx, (0, "cube=false".into()));
+
+        con.execute("tests polytope tesseract", &mut ctx);
+        assert_eq!(ctx.1, "polytope=tesseract");
+    }
+
+    #[test]
+    fn subcommand_toggle_accepts_aliases() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset());
+        let mut ctx: SubCtx = (0, String::new());
+        for alias in &["on", "true", "1"] {
+            con.execute(&format!("tests axes {alias}"), &mut ctx);
+            assert_eq!(ctx.1, "axes=true", "alias `{alias}`");
+        }
+        for alias in &["off", "false", "0"] {
+            con.execute(&format!("tests axes {alias}"), &mut ctx);
+            assert_eq!(ctx.1, "axes=false", "alias `{alias}`");
+        }
+    }
+
+    #[test]
+    fn subcommand_unknown_subcommand_errors() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset());
+        let mut ctx: SubCtx = (0, String::new());
+        con.execute("tests xyzzy on", &mut ctx);
+        let last = con.history.back().unwrap();
+        assert_eq!(last.kind, LineKind::Error);
+        assert!(
+            last.text.contains("unknown subcommand"),
+            "got: {}",
+            last.text
+        );
+    }
+
+    #[test]
+    fn subcommand_missing_value_errors() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset());
+        let mut ctx: SubCtx = (0, String::new());
+        con.execute("tests axes", &mut ctx);
+        let last = con.history.back().unwrap();
+        assert_eq!(last.kind, LineKind::Error);
+        assert!(last.text.contains("usage"), "got: {}", last.text);
+    }
+
+    /// Tab completion at the value slot narrows to ONLY the chosen subcommand's choices.
+    /// This is the load-bearing context-aware-completion test: previously the second-arg
+    /// completion list would have to be the union (`on, off, 5cell, ...`).
+    #[test]
+    fn subcommand_value_completion_is_context_aware() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset());
+
+        // `tests axes ` -> only on/off in the cycle.
+        con.input = "tests axes ".into();
+        let ctx = con.completion_context().unwrap();
+        let m = con.completion_matches(&ctx);
+        assert_eq!(m, vec!["off".to_string(), "on".to_string()]);
+
+        // `tests polytope ` -> only polytope names in the cycle, no on/off.
+        con.input = "tests polytope ".into();
+        let ctx = con.completion_context().unwrap();
+        let m = con.completion_matches(&ctx);
+        assert_eq!(
+            m,
+            vec!["5cell".to_string(), "off".to_string(), "tesseract".to_string()]
+        );
+        assert!(!m.contains(&"on".into()));
+    }
+
+    /// Tab completion at the subcommand slot lists every registered subcommand,
+    /// sorted alphabetically (matches the rest of the console's completion convention).
+    #[test]
+    fn subcommand_first_slot_completion_lists_subcommands() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset());
+        con.input = "tests ".into();
+        let ctx = con.completion_context().unwrap();
+        let m = con.completion_matches(&ctx);
+        assert_eq!(
+            m,
+            vec!["axes".to_string(), "cube".to_string(), "polytope".to_string()]
+        );
     }
 }

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -1014,22 +1014,20 @@ impl<Ctx: 'static> Console<Ctx> {
 
     fn all_command_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self.commands.keys().cloned().collect();
-        names.push("help".into());
-        names.push("clear".into());
-        names.push("detach".into());
-        names.push("dock".into());
+        names.extend(Builtin::ALL.iter().map(|b| b.name().to_string()));
         names.sort();
         names
     }
 
     /// Inspect [`Console::input`] to decide what the user is currently completing: the
     /// command name, or the n-th positional argument of a known command. Returns `None`
-    /// for empty input.
+    /// for empty input. Uses the quote-aware [`tokenize`] so `tests "5 cell" o<Tab>`
+    /// completes on arg 1 with prefix `o`, not on a garbage `cell"` token.
     fn completion_context(&self) -> Option<CompletionContext> {
         if self.input.is_empty() {
             return None;
         }
-        let parsed: Vec<&str> = self.input.split_whitespace().collect();
+        let parsed = tokenize(&self.input);
         if parsed.is_empty() {
             return None;
         }
@@ -1038,31 +1036,23 @@ impl<Ctx: 'static> Console<Ctx> {
         // No whitespace yet: still typing the command name.
         if parsed.len() == 1 && !trailing_ws {
             return Some(CompletionContext::Command {
-                prefix: parsed[0].to_string(),
+                prefix: parsed.into_iter().next().unwrap(),
             });
         }
 
         // After whitespace: we're on an argument. `arg_index` is 0-based positional.
         // The `else` arm is reached only when `parsed.len() >= 2` (the `len() == 1 &&
-        // !trailing_ws` case returned above), so `parsed.last()` is always `Some`;
-        // `unwrap_or_default` returns the empty-string fallback only in the impossible
-        // path, keeping library code free of `unwrap()`. `prior` captures the fully-
-        // typed arg tokens before the cursor so subcommand-dispatching commands can
-        // gate their value-slot completion on what came earlier.
-        let cmd_name = parsed[0].to_string();
+        // !trailing_ws` case returned above), so the partial-token pop is safe. `prior`
+        // captures the fully-typed arg tokens before the cursor so subcommand-dispatching
+        // commands can gate their value-slot completion on what came earlier.
+        let mut parts = parsed;
+        let cmd_name = parts.remove(0);
         let (arg_index, prefix, prior) = if trailing_ws {
-            let prior: Vec<String> = parsed[1..].iter().map(|s| (*s).to_string()).collect();
-            (parsed.len() - 1, String::new(), prior)
+            let idx = parts.len();
+            (idx, String::new(), parts)
         } else {
-            let prior: Vec<String> = parsed[1..parsed.len() - 1]
-                .iter()
-                .map(|s| (*s).to_string())
-                .collect();
-            (
-                parsed.len() - 2,
-                parsed.last().copied().unwrap_or_default().to_string(),
-                prior,
-            )
+            let partial = parts.pop().unwrap_or_default();
+            (parts.len(), partial, parts)
         };
         Some(CompletionContext::Arg {
             cmd_name,
@@ -1198,23 +1188,11 @@ impl<Ctx: 'static> Console<Ctx> {
             return;
         };
 
-        // Built-ins first.
-        if name == "help" {
-            self.builtin_help(args.first().map(String::as_str));
-            return;
-        }
-        if name == "clear" {
-            self.history.clear();
-            return;
-        }
-        if name == "detach" {
-            self.detached = true;
-            self.push_history(HistoryLine::system("console detached"));
-            return;
-        }
-        if name == "dock" {
-            self.detached = false;
-            self.push_history(HistoryLine::system("console docked"));
+        // Built-ins first. Framework-owned, dispatched off the `Builtin` enum so the
+        // name + help info isn't duplicated across `execute`, `builtin_help`, and
+        // `all_command_names` (single source of truth for the four primitives).
+        if let Some(builtin) = Builtin::from_name(&name) {
+            self.run_builtin(builtin, args.first().map(String::as_str));
             return;
         }
 
@@ -1239,33 +1217,34 @@ impl<Ctx: 'static> Console<Ctx> {
         }
     }
 
+    /// Dispatch one of the framework built-ins. `target` is the optional first-arg
+    /// token (only used by `help` to look up a specific command).
+    fn run_builtin(&mut self, builtin: Builtin, target: Option<&str>) {
+        match builtin {
+            Builtin::Help => self.builtin_help(target),
+            Builtin::Clear => self.history.clear(),
+            Builtin::Detach => {
+                self.detached = true;
+                self.push_history(HistoryLine::system("console detached"));
+            }
+            Builtin::Dock => {
+                self.detached = false;
+                self.push_history(HistoryLine::system("console docked"));
+            }
+        }
+    }
+
     fn builtin_help(&mut self, target: Option<&str>) {
         match target {
-            Some("help") => {
-                self.push_history(HistoryLine::output(
-                    "help: list commands, or 'help <name>' for one",
-                ));
-            }
-            Some("clear") => {
-                self.push_history(HistoryLine::output("clear: clear the scrollback buffer"));
-            }
-            Some("detach") => {
-                self.push_history(HistoryLine::output(
-                    "detach: render console as a draggable window",
-                ));
-            }
-            Some("dock") => {
-                self.push_history(HistoryLine::output(
-                    "dock: render console as a half-screen drop-down (default)",
-                ));
-            }
-            Some(name) => match self.commands.get(name) {
-                Some(c) => {
-                    let line = format!("{}: {}", c.name(), c.help());
-                    self.push_history(HistoryLine::output(line));
+            Some(name) => {
+                if let Some(b) = Builtin::from_name(name) {
+                    self.push_history(HistoryLine::output(format!("{}: {}", b.name(), b.help())));
+                } else if let Some(c) = self.commands.get(name) {
+                    self.push_history(HistoryLine::output(format!("{}: {}", c.name(), c.help())));
+                } else {
+                    self.push_history(HistoryLine::error(format!("no command '{name}'")));
                 }
-                None => self.push_history(HistoryLine::error(format!("no command '{name}'"))),
-            },
+            }
             None => {
                 self.push_history(HistoryLine::output("commands:"));
                 let mut entries: Vec<(String, String)> = self
@@ -1273,15 +1252,72 @@ impl<Ctx: 'static> Console<Ctx> {
                     .values()
                     .map(|c| (c.name().to_string(), c.help().to_string()))
                     .collect();
-                entries.push(("help".into(), "list commands or describe one".into()));
-                entries.push(("clear".into(), "clear the scrollback buffer".into()));
-                entries.push(("detach".into(), "render as a draggable window".into()));
-                entries.push(("dock".into(), "render as a half-screen drop-down".into()));
+                for b in Builtin::ALL {
+                    entries.push((b.name().to_string(), b.help().to_string()));
+                }
                 entries.sort_by(|a, b| a.0.cmp(&b.0));
                 for (name, help) in entries {
                     self.push_history(HistoryLine::output(format!("  {name:16} {help}")));
                 }
             }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Built-in commands
+// ---------------------------------------------------------------------------
+
+/// Framework-owned commands that mutate [`Console`] internal state directly: history,
+/// detached flag, etc. They can't go through [`Command<Ctx>`] cleanly because that
+/// trait only sees `&mut Ctx` (the user's context), not `&mut Console<Ctx>`. Storing
+/// their name + help in one enum centralizes what was previously duplicated across
+/// [`Console::execute`], [`Console::builtin_help`], and [`Console::all_command_names`].
+///
+/// User crates cannot add new built-ins; framework primitives only.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Builtin {
+    Help,
+    Clear,
+    Detach,
+    Dock,
+}
+
+impl Builtin {
+    /// Iteration order is alphabetical, matching the rest of the console's sort
+    /// conventions (Tab cycling, help listing). Keep this slice sorted by `name()`.
+    const ALL: &'static [Builtin] = &[
+        Builtin::Clear,
+        Builtin::Detach,
+        Builtin::Dock,
+        Builtin::Help,
+    ];
+
+    fn from_name(name: &str) -> Option<Builtin> {
+        match name {
+            "help" => Some(Builtin::Help),
+            "clear" => Some(Builtin::Clear),
+            "detach" => Some(Builtin::Detach),
+            "dock" => Some(Builtin::Dock),
+            _ => None,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Builtin::Help => "help",
+            Builtin::Clear => "clear",
+            Builtin::Detach => "detach",
+            Builtin::Dock => "dock",
+        }
+    }
+
+    fn help(self) -> &'static str {
+        match self {
+            Builtin::Help => "list commands or describe one",
+            Builtin::Clear => "clear the scrollback buffer",
+            Builtin::Detach => "render as a draggable window",
+            Builtin::Dock => "render as a half-screen drop-down (default)",
         }
     }
 }
@@ -1306,14 +1342,78 @@ fn key_text(key: egui::Key) -> Option<&'static str> {
     }
 }
 
-/// Whitespace-split parser. Returns `(command_name, args)` or `None` for an
-/// empty/whitespace-only line. No quoting in v0; commands that need spaces in args
-/// should split on something else or wait for the quoted-arg upgrade.
+/// Quote-aware tokenizer. Returns `(command_name, args)` or `None` for an
+/// empty/whitespace-only line. Tokens are whitespace-separated; double-quoted
+/// (`"..."`) and single-quoted (`'...'`) strings preserve internal whitespace.
+/// Inside double quotes, `\"` and `\\` are escapes; inside single quotes, the
+/// content is literal (no escapes, matching shell convention).
+///
+/// Unterminated quotes are tolerated for interactive ergonomics: trailing content
+/// after an opening quote with no matching close becomes one token through end of
+/// line. This lets mid-typing tab completion work without erroring on the partial
+/// quote state.
 fn parse_line(line: &str) -> Option<(String, Vec<String>)> {
-    let mut parts = line.split_whitespace();
-    let name = parts.next()?.to_string();
-    let args = parts.map(String::from).collect();
-    Some((name, args))
+    let mut tokens = tokenize(line);
+    if tokens.is_empty() {
+        return None;
+    }
+    let name = tokens.remove(0);
+    Some((name, tokens))
+}
+
+/// Quote-aware token splitter. See [`parse_line`] for the grammar.
+fn tokenize(line: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut in_token = false;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '"' => {
+                in_token = true;
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if next == '"' {
+                        break;
+                    }
+                    if next == '\\' {
+                        if let Some(&escaped) = chars.peek() {
+                            if matches!(escaped, '"' | '\\') {
+                                cur.push(escaped);
+                                chars.next();
+                                continue;
+                            }
+                        }
+                    }
+                    cur.push(next);
+                }
+            }
+            '\'' => {
+                in_token = true;
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if next == '\'' {
+                        break;
+                    }
+                    cur.push(next);
+                }
+            }
+            c if c.is_whitespace() => {
+                if in_token {
+                    out.push(std::mem::take(&mut cur));
+                    in_token = false;
+                }
+            }
+            c => {
+                in_token = true;
+                cur.push(c);
+            }
+        }
+    }
+    if in_token {
+        out.push(cur);
+    }
+    out
 }
 
 /// Splice `choice` into `input` at the position the user is completing, preserving
@@ -1324,19 +1424,15 @@ fn apply_completion(input: &str, ctx: &CompletionContext, choice: &str) -> Strin
     match ctx {
         CompletionContext::Command { .. } => choice.to_string(),
         CompletionContext::Arg { .. } => {
-            let parsed: Vec<&str> = input.split_whitespace().collect();
-            let trailing_ws = input.ends_with(char::is_whitespace);
-            let kept = if trailing_ws {
-                &parsed[..]
-            } else {
-                &parsed[..parsed.len() - 1]
-            };
-            let mut result = kept.join(" ");
-            if !result.is_empty() {
-                result.push(' ');
+            // Preserve the input string verbatim up to the start of the partial token
+            // under the cursor, then append the completion choice. Verbatim
+            // preservation is important for quoted args -- a re-tokenize-and-rejoin
+            // would mangle `tests "5 cell"` into `tests 5 cell` on the rejoin step.
+            if input.ends_with(char::is_whitespace) {
+                return format!("{input}{choice}");
             }
-            result.push_str(choice);
-            result
+            let prefix_end = input.rfind(char::is_whitespace).map_or(0, |i| i + 1);
+            format!("{}{choice}", &input[..prefix_end])
         }
     }
 }
@@ -2008,5 +2104,112 @@ mod tests {
             m,
             vec!["palette=global".to_string(), "palette=local".to_string()]
         );
+    }
+
+    // ----------------- Quoted-string tokenizer -----------------
+
+    #[test]
+    fn tokenize_handles_bare_words() {
+        assert_eq!(tokenize("foo bar baz"), vec!["foo", "bar", "baz"]);
+        assert_eq!(tokenize("   foo    bar  "), vec!["foo", "bar"]);
+        assert_eq!(tokenize(""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn tokenize_preserves_spaces_in_double_quotes() {
+        assert_eq!(tokenize(r#"foo "bar baz" qux"#), vec!["foo", "bar baz", "qux"]);
+    }
+
+    #[test]
+    fn tokenize_preserves_spaces_in_single_quotes() {
+        assert_eq!(tokenize("foo 'bar baz' qux"), vec!["foo", "bar baz", "qux"]);
+    }
+
+    #[test]
+    fn tokenize_handles_double_quote_escapes() {
+        // `\"` -> literal `"`; `\\` -> literal `\`; other `\x` keeps the backslash.
+        assert_eq!(
+            tokenize(r#"a "he said \"hi\"" b"#),
+            vec!["a", r#"he said "hi""#, "b"]
+        );
+        assert_eq!(tokenize(r#""back\\slash""#), vec![r"back\slash"]);
+    }
+
+    #[test]
+    fn tokenize_single_quotes_are_literal() {
+        // Backslashes inside single quotes are literal (matches shell convention).
+        assert_eq!(tokenize(r"'a \n b'"), vec![r"a \n b"]);
+    }
+
+    #[test]
+    fn tokenize_unterminated_quote_consumes_to_end() {
+        // For interactive ergonomics: don't error on unterminated quotes; treat
+        // trailing content as one token.
+        assert_eq!(tokenize(r#"foo "unterminated"#), vec!["foo", "unterminated"]);
+    }
+
+    #[test]
+    fn parse_line_routes_quoted_args_to_handler() {
+        type Ctx = Vec<String>;
+        let mut con = Console::<Ctx>::new();
+        con.register(cmd("echoargs", "record args", |args, c: &mut Ctx, _out| {
+            for a in args {
+                c.push((*a).to_string());
+            }
+            Ok(())
+        }));
+        let mut ctx: Ctx = Vec::new();
+        con.execute(r#"echoargs "5 cell" off"#, &mut ctx);
+        assert_eq!(ctx, vec!["5 cell".to_string(), "off".to_string()]);
+    }
+
+    // ----------------- Unified built-ins -----------------
+
+    #[test]
+    fn builtin_from_name_round_trips() {
+        for b in Builtin::ALL {
+            assert_eq!(Builtin::from_name(b.name()), Some(*b));
+        }
+        assert_eq!(Builtin::from_name("nope"), None);
+    }
+
+    #[test]
+    fn help_lists_user_commands_and_builtins_sorted() {
+        type Ctx = u32;
+        let mut con = Console::<Ctx>::new();
+        con.register(cmd("zebra", "fast horse", |_, _, _| Ok(())));
+        con.register(cmd("alpha", "first letter", |_, _, _| Ok(())));
+        let mut ctx: Ctx = 0;
+        con.execute("help", &mut ctx);
+        let texts: Vec<&str> = con.history.iter().map(|h| h.text.as_str()).collect();
+        let i_alpha = texts.iter().position(|t| t.contains("alpha")).unwrap();
+        let i_clear = texts.iter().position(|t| t.contains("clear")).unwrap();
+        let i_zebra = texts.iter().position(|t| t.contains("zebra")).unwrap();
+        // Alphabetical: alpha < clear < zebra.
+        assert!(i_alpha < i_clear);
+        assert!(i_clear < i_zebra);
+    }
+
+    #[test]
+    fn clear_builtin_empties_history() {
+        type Ctx = u32;
+        let mut con = Console::<Ctx>::new();
+        let mut ctx: Ctx = 0;
+        con.push_history(HistoryLine::output("first"));
+        con.push_history(HistoryLine::output("second"));
+        con.execute("clear", &mut ctx);
+        assert!(con.history.is_empty());
+    }
+
+    #[test]
+    fn detach_dock_builtins_flip_flag() {
+        type Ctx = u32;
+        let mut con = Console::<Ctx>::new();
+        let mut ctx: Ctx = 0;
+        assert!(!con.detached);
+        con.execute("detach", &mut ctx);
+        assert!(con.detached);
+        con.execute("dock", &mut ctx);
+        assert!(!con.detached);
     }
 }

--- a/crates/rye-egui/src/lib.rs
+++ b/crates/rye-egui/src/lib.rs
@@ -73,7 +73,9 @@ mod slider_edit;
 mod world;
 
 pub use bivector_matrix::{bivector_matrix, cell_text as bivector_matrix_cell_text};
-pub use console::{cmd, Command, Console, ConsoleWriter, HistoryLine, LineKind};
+pub use console::{
+    cmd, subcommands, Command, Console, ConsoleWriter, HistoryLine, LineKind, SubcommandSet,
+};
 pub use integration::UiIntegration;
 pub use linear_indicator::LinearIndicator;
 pub use overlay::BottomOverlay;

--- a/crates/rye-math/src/rasterizable.rs
+++ b/crates/rye-math/src/rasterizable.rs
@@ -26,10 +26,10 @@
 //! rasterizer-pipeline changes required. The [`Projection<N>`] enum starts with
 //! [`Projection::Identity`] only; more variants land alongside their consuming impls.
 
-use glam::Vec3;
+use glam::{Vec3, Vec4};
 
 use crate::space::Space;
-use crate::EuclideanR3;
+use crate::{EuclideanR3, EuclideanR4};
 
 /// Projection from R^N to R³ for the rasterizer's screen-space transform.
 ///
@@ -38,20 +38,31 @@ use crate::EuclideanR3;
 /// a variant they don't support; new variants are added alongside their first consuming impl
 /// rather than speculatively.
 ///
-/// - [`Identity`](Self::Identity): "use the first 3 components, zero-pad if `N < 3`." Only
-///   sensible for `N == 3` today; R² and R⁴ extensions land with their respective
-///   `RasterizableSpace<N>` impls.
+/// - [`Identity`](Self::Identity): "use the first 3 components, zero-pad if `N < 3`, truncate
+///   if `N > 3`." Default; works for `N == 3` (bitwise identity) and as a "natural" R⁴ to R³
+///   view (drops `w`).
+/// - [`Orthographic`](Self::Orthographic): drop one axis by index. The natural R⁴ wireframe
+///   view is `Orthographic { drop_axis: 3 }` (drop `w`); other axis choices show alternative
+///   3-flat slices. For `N == 3` this can drop one axis to produce a 2D-looking projection
+///   (used later for Flatland-style reveals).
 ///
-/// Future variants under consideration: `Orthographic { drop_axis }` (used for "drop one axis"
-/// views like a Flatland-style 2D projection of R³ content), and the R⁴-specific `Schlegel`,
-/// `Stereographic`, and `Hyperslice` projections.
+/// Future variants under consideration: R⁴-specific `Schlegel`, `Stereographic`, `Hyperslice`.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Projection<const N: usize> {
     /// Pass through: take the first 3 components, zero-pad if `N < 3`, truncate if `N > 3`.
-    /// For `N == 3` this is bitwise identity. Default variant; the only one the current
-    /// line-rasterizer pipeline actually exercises.
+    /// For `N == 3` this is bitwise identity. Default variant.
     #[default]
     Identity,
+
+    /// Drop one axis by index (0-based). The remaining `N - 1` components fill R³ in their
+    /// natural order, zero-padding if `N - 1 < 3`. For R⁴ with `drop_axis: 3` (the "drop-w"
+    /// case) this produces `(x, y, z)`, the standard R⁴-into-R³ viewing convention. For R³
+    /// with `drop_axis: 1` it produces `(x, z, 0)`, a 2D-looking projection in the XZ plane.
+    ///
+    /// Out-of-range `drop_axis` (>= `N`) returns `Vec3::ZERO`.
+    Orthographic {
+        drop_axis: usize,
+    },
 }
 
 /// A flat or curved space that can drive the rasterizer pipeline: provides projection from its
@@ -105,10 +116,49 @@ impl RasterizableSpace<3> for EuclideanR3 {
     fn project_point(point: Vec3, projection: &Projection<3>) -> Vec3 {
         match projection {
             Projection::Identity => point,
+            Projection::Orthographic { drop_axis } => match *drop_axis {
+                0 => Vec3::new(point.y, point.z, 0.0),
+                1 => Vec3::new(point.x, point.z, 0.0),
+                2 => Vec3::new(point.x, point.y, 0.0),
+                _ => Vec3::ZERO,
+            },
         }
     }
 
     fn tessellate_segment(p0: Vec3, p1: Vec3, samples: usize, out: &mut Vec<Vec3>) {
+        out.push(p0);
+        for i in 1..samples {
+            let t = i as f32 / samples as f32;
+            out.push(p0.lerp(p1, t));
+        }
+        out.push(p1);
+    }
+}
+
+impl RasterizableSpace<4> for EuclideanR4 {
+    fn point_to_array(p: Vec4) -> [f32; 4] {
+        p.to_array()
+    }
+
+    fn array_to_point(arr: [f32; 4]) -> Vec4 {
+        Vec4::from_array(arr)
+    }
+
+    fn project_point(point: Vec4, projection: &Projection<4>) -> Vec3 {
+        match projection {
+            // Identity on R⁴: truncate to the first three components. Equivalent to drop-w.
+            Projection::Identity => Vec3::new(point.x, point.y, point.z),
+            Projection::Orthographic { drop_axis } => match *drop_axis {
+                0 => Vec3::new(point.y, point.z, point.w),
+                1 => Vec3::new(point.x, point.z, point.w),
+                2 => Vec3::new(point.x, point.y, point.w),
+                3 => Vec3::new(point.x, point.y, point.z),
+                _ => Vec3::ZERO,
+            },
+        }
+    }
+
+    fn tessellate_segment(p0: Vec4, p1: Vec4, samples: usize, out: &mut Vec<Vec4>) {
         out.push(p0);
         for i in 1..samples {
             let t = i as f32 / samples as f32;
@@ -191,5 +241,77 @@ mod tests {
         assert_eq!(p3, Projection::Identity);
         let p4: Projection<4> = Projection::default();
         assert_eq!(p4, Projection::Identity);
+    }
+
+    /// `Orthographic { drop_axis: 1 }` on R³ produces the XZ plane embedded in R³ with Y
+    /// zeroed. The 2D-looking projection used by camera tweens that want to dramatize a
+    /// "flat to depth" reveal.
+    #[test]
+    fn r3_orthographic_drops_named_axis() {
+        let p = Vec3::new(1.0, 2.0, 3.0);
+        let pj = |drop_axis| {
+            <EuclideanR3 as RasterizableSpace<3>>::project_point(
+                p,
+                &Projection::Orthographic { drop_axis },
+            )
+        };
+        assert_eq!(pj(0), Vec3::new(2.0, 3.0, 0.0));
+        assert_eq!(pj(1), Vec3::new(1.0, 3.0, 0.0));
+        assert_eq!(pj(2), Vec3::new(1.0, 2.0, 0.0));
+        // Out-of-range falls back to zero per the doc contract.
+        assert_eq!(pj(3), Vec3::ZERO);
+        assert_eq!(pj(99), Vec3::ZERO);
+    }
+
+    /// `EuclideanR4` round-trips through point/array conversion for any input.
+    #[test]
+    fn r4_array_round_trip() {
+        let p = Vec4::new(1.0, -2.5, 0.7, 4.2);
+        let arr = <EuclideanR4 as RasterizableSpace<4>>::point_to_array(p);
+        let back = <EuclideanR4 as RasterizableSpace<4>>::array_to_point(arr);
+        assert_eq!(p, back);
+    }
+
+    /// `Projection::Identity` on R⁴ truncates `w` (equivalent to `Orthographic` with
+    /// `drop_axis = 3`). This is the "natural" 4D-to-3D viewing convention.
+    #[test]
+    fn r4_identity_drops_w() {
+        let p = Vec4::new(1.0, 2.0, 3.0, 4.0);
+        let projected =
+            <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &Projection::Identity);
+        assert_eq!(projected, Vec3::new(1.0, 2.0, 3.0));
+    }
+
+    /// `Orthographic { drop_axis }` on R⁴ for each of the four axis choices produces the
+    /// expected 3-flat view. drop_axis=3 (drop w) is the canonical wireframe-rendering case.
+    #[test]
+    fn r4_orthographic_drops_each_axis() {
+        let p = Vec4::new(1.0, 2.0, 3.0, 4.0);
+        let pj = |drop_axis| {
+            <EuclideanR4 as RasterizableSpace<4>>::project_point(
+                p,
+                &Projection::Orthographic { drop_axis },
+            )
+        };
+        assert_eq!(pj(0), Vec3::new(2.0, 3.0, 4.0));
+        assert_eq!(pj(1), Vec3::new(1.0, 3.0, 4.0));
+        assert_eq!(pj(2), Vec3::new(1.0, 2.0, 4.0));
+        assert_eq!(pj(3), Vec3::new(1.0, 2.0, 3.0));
+        // Out-of-range falls back to zero per the doc contract.
+        assert_eq!(pj(4), Vec3::ZERO);
+    }
+
+    /// `tessellate_segment` on R⁴ is plain lerp (since `EuclideanR4` is flat). Each sample
+    /// gives the expected linear interpolation across all four components.
+    #[test]
+    fn r4_tessellate_lerps_all_components() {
+        let p0 = Vec4::new(0.0, 0.0, 0.0, 0.0);
+        let p1 = Vec4::new(4.0, 8.0, 12.0, 16.0);
+        let mut out = Vec::new();
+        <EuclideanR4 as RasterizableSpace<4>>::tessellate_segment(p0, p1, 2, &mut out);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0], p0);
+        assert_eq!(out[1], Vec4::new(2.0, 4.0, 6.0, 8.0));
+        assert_eq!(out[2], p1);
     }
 }

--- a/crates/rye-math/src/rasterizable.rs
+++ b/crates/rye-math/src/rasterizable.rs
@@ -61,9 +61,7 @@ pub enum Projection<const N: usize> {
     /// with `drop_axis: 1` it produces `(x, z, 0)`, a 2D-looking projection in the XZ plane.
     ///
     /// Out-of-range `drop_axis` (>= `N`) returns `Vec3::ZERO`.
-    Orthographic {
-        drop_axis: usize,
-    },
+    Orthographic { drop_axis: usize },
 }
 
 /// A flat or curved space that can drive the rasterizer pipeline: provides projection from its

--- a/crates/rye-math/src/rasterizable.rs
+++ b/crates/rye-math/src/rasterizable.rs
@@ -1,9 +1,9 @@
 //! [`RasterizableSpace<N>`] trait + [`Projection<N>`] enum + flat-Euclidean impls.
 //!
 //! Pairs with the `Visualizable<N>` trait in `rye-shape`. `Visualizable` answers "what mesh
-//! data does this shape produce in R^N?"; `RasterizableSpace` answers "given that mesh data in
-//! space `S`, how do we get screen-ready R³ vertices?". The rasterizer pipeline in `rye-render`
-//! composes them.
+//! data does this shape produce in R^N?"; `RasterizableSpace` answers "given that mesh data
+//! in space `S`, how do we get screen-ready R³ vertices?". The rasterizer pipeline in
+//! `rye-render` composes them.
 //!
 //! ## Unified for flat and curved spaces
 //!
@@ -46,7 +46,8 @@ use crate::{EuclideanR3, EuclideanR4};
 ///   3-flat slices. For `N == 3` this can drop one axis to produce a 2D-looking projection
 ///   (used later for Flatland-style reveals).
 ///
-/// Future variants under consideration: R⁴-specific `Schlegel`, `Stereographic`, `Hyperslice`.
+/// Future variants under consideration: R⁴-specific `Schlegel`, `Stereographic`,
+/// `Hyperslice`, and 4D `Perspective`.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Projection<const N: usize> {
     /// Pass through: take the first 3 components, zero-pad if `N < 3`, truncate if `N > 3`.

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -143,6 +143,85 @@ impl Polytope4 {
 }
 
 // ---------------------------------------------------------------------------
+// Visualizable<4> impl
+// ---------------------------------------------------------------------------
+
+/// Default styling for [`Polytope4::to_lines`]: white at 1.5 px width. The trait method
+/// returns geometry with a uniform style; consumers that want per-cell coloring, depth
+/// dimming, hover highlights, etc., should mutate the returned mesh or call a dedicated
+/// helper (see [`Polytope4::lines_colored_by_cell`]).
+const DEFAULT_LINE_COLOR: [f32; 4] = [0.9, 0.9, 0.9, 1.0];
+const DEFAULT_LINE_WIDTH: f32 = 1.5;
+
+impl rye_shape::Visualizable<4> for Polytope4 {
+    fn to_lines(&self) -> Result<rye_shape::LineMesh<4>, rye_shape::NotVisualizable> {
+        let topo = self.topology();
+        let mut mesh = rye_shape::LineMesh::<4>::default();
+        mesh.segments.reserve(topo.edges.len());
+        mesh.colors.reserve(topo.edges.len());
+        mesh.widths.reserve(topo.edges.len());
+        for &[i, j] in topo.edges {
+            let a = topo.vertices[i as usize].to_array();
+            let b = topo.vertices[j as usize].to_array();
+            mesh.segments.push((a, b));
+            mesh.colors.push((DEFAULT_LINE_COLOR, DEFAULT_LINE_COLOR));
+            mesh.widths.push(DEFAULT_LINE_WIDTH);
+        }
+        Ok(mesh)
+    }
+
+    fn to_triangles(&self) -> Result<rye_shape::TriangleMesh<4>, rye_shape::NotVisualizable> {
+        // 2-face triangulation requires the 2-face topology we deliberately don't ship in
+        // the polytope module (Coxeter table I lists the counts but the incidence data
+        // hasn't been derived). When a real consumer needs filled-face polytope rendering
+        // we'll add it; until then there's nothing to draw.
+        Err(rye_shape::NotVisualizable::Degenerate)
+    }
+
+    fn to_points(&self) -> Result<rye_shape::PointMesh<4>, rye_shape::NotVisualizable> {
+        let topo = self.topology();
+        let mut mesh = rye_shape::PointMesh::<4>::default();
+        mesh.positions.reserve(topo.vertices.len());
+        mesh.colors.reserve(topo.vertices.len());
+        mesh.sizes.reserve(topo.vertices.len());
+        for v in topo.vertices {
+            mesh.positions.push(v.to_array());
+            mesh.colors.push(DEFAULT_LINE_COLOR);
+            mesh.sizes.push(4.0);
+        }
+        Ok(mesh)
+    }
+}
+
+impl Polytope4 {
+    /// Color each edge by the cell its endpoints share. `palette[k]` is the color used for
+    /// edges whose lower-index incident cell is cell `k`. Cells that exceed the palette wrap
+    /// around (`palette.len()` is mod'd against). Width stays at the default; mutate the
+    /// returned mesh directly if you need different per-segment styling.
+    pub fn lines_colored_by_cell(self, palette: &[[f32; 4]]) -> rye_shape::LineMesh<4> {
+        let topo = self.topology();
+        let mut mesh = rye_shape::LineMesh::<4>::default();
+        let n_palette = palette.len().max(1);
+        for &[i, j] in topo.edges {
+            // Find the lowest cell index that contains both vertices.
+            let cell_idx = topo
+                .cells
+                .iter()
+                .position(|cell| cell.contains(&i) && cell.contains(&j))
+                .unwrap_or(0);
+            let color = palette[cell_idx % n_palette];
+            mesh.segments.push((
+                topo.vertices[i as usize].to_array(),
+                topo.vertices[j as usize].to_array(),
+            ));
+            mesh.colors.push((color, color));
+            mesh.widths.push(DEFAULT_LINE_WIDTH);
+        }
+        mesh
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Per-polytope vertex caches
 // ---------------------------------------------------------------------------
 //
@@ -801,6 +880,88 @@ mod tests {
                 0,
                 "{p:?} Euler-Poincaré: V({v}) - E({e}) + F({f}) - C({c}) != 0"
             );
+        }
+    }
+
+    /// [`Visualizable<4>::to_lines`] returns one segment per topology edge, matching the
+    /// edge count for every regular polytope. Catches a future regression where the impl
+    /// accidentally drops edges (e.g., during a refactor that skips disconnected cells).
+    #[test]
+    fn visualizable_line_count_matches_edge_count() {
+        use rye_shape::Visualizable;
+        for p in Polytope4::ALL {
+            let mesh = <Polytope4 as Visualizable<4>>::to_lines(&p)
+                .expect("polytopes always produce line meshes");
+            assert_eq!(
+                mesh.segments.len(),
+                p.edge_count(),
+                "{p:?} line mesh has {} segments, expected {}",
+                mesh.segments.len(),
+                p.edge_count()
+            );
+            // Color + width arrays match segment count, per the LineMesh invariant.
+            assert_eq!(mesh.colors.len(), mesh.segments.len());
+            assert_eq!(mesh.widths.len(), mesh.segments.len());
+        }
+    }
+
+    /// [`Visualizable<4>::to_lines`] segments hit the actual polytope vertex coordinates.
+    /// Pins that the impl reads topology vertices directly, not some other vertex source.
+    #[test]
+    fn visualizable_line_endpoints_are_polytope_vertices() {
+        use rye_shape::Visualizable;
+        let topo = Polytope4::Tesseract.topology();
+        let mesh = <Polytope4 as Visualizable<4>>::to_lines(&Polytope4::Tesseract).unwrap();
+        for (i, &[vi, vj]) in topo.edges.iter().enumerate() {
+            let (a, b) = mesh.segments[i];
+            assert_eq!(a, topo.vertices[vi as usize].to_array());
+            assert_eq!(b, topo.vertices[vj as usize].to_array());
+        }
+    }
+
+    /// [`Visualizable<4>::to_points`] returns one point per topology vertex.
+    #[test]
+    fn visualizable_point_count_matches_vertex_count() {
+        use rye_shape::Visualizable;
+        for p in Polytope4::ALL {
+            let mesh = <Polytope4 as Visualizable<4>>::to_points(&p)
+                .expect("polytopes always produce point meshes");
+            assert_eq!(mesh.positions.len(), p.vertex_count());
+            assert_eq!(mesh.colors.len(), mesh.positions.len());
+            assert_eq!(mesh.sizes.len(), mesh.positions.len());
+        }
+    }
+
+    /// [`Visualizable<4>::to_triangles`] returns `Degenerate` until 2-face topology is
+    /// shipped. Pinned so a future "we have 2-faces now" change updates this test alongside
+    /// the impl rather than silently changing the visible behavior.
+    #[test]
+    fn visualizable_triangles_currently_not_visualizable() {
+        use rye_shape::Visualizable;
+        for p in Polytope4::ALL {
+            let result = <Polytope4 as Visualizable<4>>::to_triangles(&p);
+            assert!(matches!(
+                result,
+                Err(rye_shape::NotVisualizable::Degenerate)
+            ));
+        }
+    }
+
+    /// [`Polytope4::lines_colored_by_cell`] assigns each segment a palette color based on the
+    /// lowest-indexed cell that contains both endpoints. Pin that segment count is preserved
+    /// and all colors come from the palette (no defaults leak through).
+    #[test]
+    fn lines_colored_by_cell_uses_palette() {
+        let palette: &[[f32; 4]] = &[
+            [1.0, 0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 1.0],
+        ];
+        let mesh = Polytope4::Tesseract.lines_colored_by_cell(palette);
+        assert_eq!(mesh.segments.len(), Polytope4::Tesseract.edge_count());
+        for (start_color, end_color) in &mesh.colors {
+            assert!(palette.contains(start_color));
+            assert!(palette.contains(end_color));
         }
     }
 }

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -219,6 +219,41 @@ impl Polytope4 {
         }
         mesh
     }
+
+    /// Color each edge by its endpoints' 4D positions, producing a per-vertex color field
+    /// that flows continuously across the edge graph. Adjacent edges share their shared-vertex
+    /// color, so the polytope's symmetry shows up as smooth color gradients rather than
+    /// discrete per-edge swatches: useful for dense wireframes like the 600-cell where uniform
+    /// white flattens visually into a tangle.
+    ///
+    /// Mapping (vertex normalized to unit length first):
+    /// - `(x + 1) / 2` to R, `(y + 1) / 2` to G, `(z + 1) / 2` to B, biased into `[0.25, 1.0]`
+    ///   so every edge stays visible (no fully-black vertices).
+    /// - `w` modulates brightness multiplicatively in `[0.7, 1.0]` so the hidden dimension is
+    ///   visible as a soft +w / -w cue without losing contrast.
+    ///
+    /// Deterministic: same polytope always produces the same coloring, no RNG.
+    pub fn lines_colored_by_position(self) -> rye_shape::LineMesh<4> {
+        let topo = self.topology();
+        let mut mesh = rye_shape::LineMesh::<4>::default();
+        mesh.segments.reserve(topo.edges.len());
+        mesh.colors.reserve(topo.edges.len());
+        mesh.widths.reserve(topo.edges.len());
+        let vertex_color = |v: Vec4| -> [f32; 4] {
+            let n = v.try_normalize().unwrap_or(Vec4::ZERO);
+            let bias = |c: f32| 0.25 + 0.75 * (0.5 + 0.5 * c);
+            let w_mod = 0.7 + 0.3 * (0.5 + 0.5 * n.w);
+            [bias(n.x) * w_mod, bias(n.y) * w_mod, bias(n.z) * w_mod, 1.0]
+        };
+        for &[i, j] in topo.edges {
+            let va = topo.vertices[i as usize];
+            let vb = topo.vertices[j as usize];
+            mesh.segments.push((va.to_array(), vb.to_array()));
+            mesh.colors.push((vertex_color(va), vertex_color(vb)));
+            mesh.widths.push(DEFAULT_LINE_WIDTH);
+        }
+        mesh
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rye-shape/src/visualizable.rs
+++ b/crates/rye-shape/src/visualizable.rs
@@ -19,9 +19,9 @@
 //!
 //! ## Const-generic dim
 //!
-//! `N` is the ambient dimension: 2 for R², 3 for R³, 4 for R⁴, etc. Const-generic so dimension
-//! mismatches are compile-time errors and vertex storage is stack-friendly (`[f32; N]`, not
-//! `Vec<f32>`). The viral type parameter is contained by:
+//! `N` is the ambient dimension: 2 for R², 3 for R³, 4 for R⁴, etc. Const-generic so
+//! dimension mismatches are compile-time errors and vertex storage is stack-friendly
+//! (`[f32; N]`, not `Vec<f32>`). The viral type parameter is contained by:
 //!
 //! - Scene-level wrappers in `rye-scene` use an enum (`SceneNode::Lines3 | Lines4 | ...`) so
 //!   downstream code only sees `RasterMesh` (enum), not generic types.

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -15,23 +15,17 @@
 //!
 //! ## Console commands
 //!
-//! - `axes on|off`: toggle the world-space colored axes.
-//! - `cube on|off`: toggle the unit cube wireframe.
-//! - `widths on|off`: toggle the four horizontal width-sweep lines.
-//! - `gradient on|off`: toggle the rainbow gradient line.
-//! - `tilted on|off`: toggle the fan of tilted lines.
+//! - `tests <target> <value>`: select what renders. `<target>` is one of:
+//!   - `all`, `axes`, `cube`, `widths`, `gradient`, `tilted`: toggle that R³ category;
+//!     `<value>` is `on` or `off`. Use `tests all off` to clear the R³ scene when you only
+//!     want to see the R⁴ polytope.
+//!   - `polytope`: set the R⁴ polytope overlay. `<value>` is one of `5cell`, `tesseract`,
+//!     `16cell`, `24cell`, `120cell`, `600cell` (hyphenated aliases accepted) or `off`. The
+//!     wireframe projects to R³ via `Orthographic { drop_axis: 3 }`, scaled 2.5x, with an
+//!     animated xw + yz rotation so axis-aligned polytopes don't collapse on projection.
 //! - `samples N`: set per-segment tessellation density. `1` is the default and is correct for
 //!   flat-Euclidean impls; higher values exercise the writer-pattern path that curved-space
 //!   impls will use.
-//! - `polytope <name|off>`: show an R⁴ polytope wireframe alongside the R³ scene. `<name>`
-//!   is one of `5cell`, `tesseract`, `16cell`, `24cell`, `120cell`, `600cell` (hyphenated
-//!   aliases accepted). The wireframe is projected to R³ via `Orthographic { drop_axis: 3 }`
-//!   and scaled 2.5x so it's visible alongside the unit cube. An animated 4D rotation (xw +
-//!   yz planes) is applied before projection so axis-aligned polytopes like the tesseract
-//!   don't collapse onto a degenerate R³ silhouette.
-//! - `tests <on|off>`: bulk-toggle all R³ raster-test categories (axes / cube / widths /
-//!   gradient / tilted) in one go. Useful for clearing the R³ scene when you only want to
-//!   look at an R⁴ polytope.
 //! - `reset`: restore all toggles to default and samples = 1 and polytope off.
 
 use std::borrow::Cow;
@@ -349,8 +343,10 @@ impl Demo {
         let proj_mat = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
         let view_proj = proj_mat * view_mat;
         let vp_size = Vec2::new(cfg.width as f32, cfg.height as f32);
-        self.line_raster_r3.set_camera(&rd.queue, view_proj, vp_size);
-        self.line_raster_r4.set_camera(&rd.queue, view_proj, vp_size);
+        self.line_raster_r3
+            .set_camera(&rd.queue, view_proj, vp_size);
+        self.line_raster_r4
+            .set_camera(&rd.queue, view_proj, vp_size);
 
         // Clear the framebuffer to a dark slate so the lines are visible. The rasterizer's
         // pass uses LoadOp::Load, so we need a prior pass to clear; do it inline here via a
@@ -410,71 +406,71 @@ struct RasterTestApp {
 impl RasterTestApp {
     fn build_console() -> Console<Demo> {
         let mut c = Console::<Demo>::new();
+        // `tests` umbrella: typed subcommands instead of one ad-hoc string-dispatch body.
+        // The framework parses on/off for toggle subs, completes polytope names at the value
+        // slot only when the user has typed `tests polytope ` (context-aware completion).
         c.register(
-            rye_egui::cmd(
-                "axes",
-                "toggle world-axes (on|off)",
-                toggle_cmd("axes", |t| &mut t.axes),
-            )
-            .with_args(&[&["on", "off"]]),
-        );
-        c.register(
-            rye_egui::cmd(
-                "cube",
-                "toggle unit-cube wireframe (on|off)",
-                toggle_cmd("cube", |t| &mut t.cube),
-            )
-            .with_args(&[&["on", "off"]]),
-        );
-        c.register(
-            rye_egui::cmd(
-                "widths",
-                "toggle width-sweep lines (on|off)",
-                toggle_cmd("widths", |t| &mut t.widths),
-            )
-            .with_args(&[&["on", "off"]]),
-        );
-        c.register(
-            rye_egui::cmd(
-                "gradient",
-                "toggle gradient line (on|off)",
-                toggle_cmd("gradient", |t| &mut t.gradient),
-            )
-            .with_args(&[&["on", "off"]]),
-        );
-        c.register(
-            rye_egui::cmd(
-                "tilted",
-                "toggle tilted-line fan (on|off)",
-                toggle_cmd("tilted", |t| &mut t.tilted),
-            )
-            .with_args(&[&["on", "off"]]),
-        );
-        c.register(
-            rye_egui::cmd(
-                "tests",
-                "toggle all R³ raster-test categories at once (on|off)",
-                |args, demo: &mut Demo, _out: &mut ConsoleWriter| {
-                    let arg = args
-                        .first()
-                        .ok_or_else(|| anyhow::anyhow!("usage: tests <on|off>"))?;
-                    let v = match arg.to_ascii_lowercase().as_str() {
-                        "on" | "true" | "1" => true,
-                        "off" | "false" | "0" => false,
-                        other => {
-                            return Err(anyhow::anyhow!("unknown arg `{other}` (try on|off)"))
-                        }
-                    };
-                    demo.toggles.axes = v;
-                    demo.toggles.cube = v;
-                    demo.toggles.widths = v;
-                    demo.toggles.gradient = v;
-                    demo.toggles.tilted = v;
-                    demo.dirty = true;
+            rye_egui::subcommands::<Demo>("tests", "toggle what renders in raster_test")
+                .toggle("all", "toggle every R³ raster-test category at once", |d, v| {
+                    d.toggles.axes = v;
+                    d.toggles.cube = v;
+                    d.toggles.widths = v;
+                    d.toggles.gradient = v;
+                    d.toggles.tilted = v;
+                    d.dirty = true;
                     Ok(())
-                },
-            )
-            .with_args(&[&["on", "off"]]),
+                })
+                .toggle("axes", "toggle world-axes (R/G/B basis vectors)", |d, v| {
+                    d.toggles.axes = v;
+                    d.dirty = true;
+                    Ok(())
+                })
+                .toggle("cube", "toggle unit-cube wireframe", |d, v| {
+                    d.toggles.cube = v;
+                    d.dirty = true;
+                    Ok(())
+                })
+                .toggle("widths", "toggle width-sweep horizontal lines", |d, v| {
+                    d.toggles.widths = v;
+                    d.dirty = true;
+                    Ok(())
+                })
+                .toggle("gradient", "toggle red-to-blue gradient line", |d, v| {
+                    d.toggles.gradient = v;
+                    d.dirty = true;
+                    Ok(())
+                })
+                .toggle("tilted", "toggle tilted-line fan", |d, v| {
+                    d.toggles.tilted = v;
+                    d.dirty = true;
+                    Ok(())
+                })
+                .choice(
+                    "polytope",
+                    "set R⁴ polytope overlay (or `off` to clear it)",
+                    &[
+                        "off", "5cell", "tesseract", "16cell", "24cell", "120cell", "600cell",
+                    ],
+                    |d, name| {
+                        d.polytope = match name.to_ascii_lowercase().as_str() {
+                            "off" | "none" => None,
+                            "5cell" | "5-cell" | "pentatope" => Some(Polytope4::Pentatope),
+                            "8cell" | "8-cell" | "tesseract" => Some(Polytope4::Tesseract),
+                            "16cell" | "16-cell" => Some(Polytope4::Cell16),
+                            "24cell" | "24-cell" => Some(Polytope4::Cell24),
+                            "120cell" | "120-cell" => Some(Polytope4::Cell120),
+                            "600cell" | "600-cell" => Some(Polytope4::Cell600),
+                            other => {
+                                return Err(anyhow::anyhow!(
+                                    "unknown polytope `{other}` (try 5cell, tesseract, \
+                                     16cell, 24cell, 120cell, 600cell, or off)"
+                                ))
+                            }
+                        };
+                        d.dirty = true;
+                        Ok(())
+                    },
+                ),
         );
         c.register(rye_egui::cmd(
             "samples",
@@ -492,37 +488,6 @@ impl RasterTestApp {
                 Ok(())
             },
         ));
-        c.register(
-            rye_egui::cmd(
-                "polytope",
-                "set R⁴ polytope wireframe overlay (5cell|tesseract|16cell|24cell|120cell|600cell|off)",
-                |args, demo: &mut Demo, _out: &mut ConsoleWriter| {
-                    let name = args
-                        .first()
-                        .ok_or_else(|| anyhow::anyhow!("usage: polytope <name|off>"))?;
-                    demo.polytope = match name.to_ascii_lowercase().as_str() {
-                        "off" | "none" => None,
-                        "5cell" | "5-cell" | "pentatope" => Some(Polytope4::Pentatope),
-                        "8cell" | "8-cell" | "tesseract" => Some(Polytope4::Tesseract),
-                        "16cell" | "16-cell" => Some(Polytope4::Cell16),
-                        "24cell" | "24-cell" => Some(Polytope4::Cell24),
-                        "120cell" | "120-cell" => Some(Polytope4::Cell120),
-                        "600cell" | "600-cell" => Some(Polytope4::Cell600),
-                        other => {
-                            return Err(anyhow::anyhow!(
-                                "unknown polytope `{other}` (try 5cell, tesseract, 16cell, 24cell, \
-                                 120cell, 600cell, or off)"
-                            ))
-                        }
-                    };
-                    demo.dirty = true;
-                    Ok(())
-                },
-            )
-            .with_args(&[&[
-                "5cell", "tesseract", "16cell", "24cell", "120cell", "600cell", "off",
-            ]]),
-        );
         c.register(rye_egui::cmd(
             "reset",
             "restore all toggles to default (everything on, samples = 1, no polytope)",
@@ -544,27 +509,6 @@ impl RasterTestApp {
         // Standard framework log mirror so tracing events show up in the console scrollback.
         rye_app::log::register_command(&mut c);
         c
-    }
-}
-
-/// Helper: build a console command that flips a boolean inside [`Toggles`].
-fn toggle_cmd<F>(
-    name: &'static str,
-    field: F,
-) -> impl FnMut(&[&str], &mut Demo, &mut ConsoleWriter) -> Result<()> + 'static
-where
-    F: Fn(&mut Toggles) -> &mut bool + 'static,
-{
-    move |args, demo: &mut Demo, _out: &mut ConsoleWriter| {
-        let new = match args.first().copied() {
-            Some("on") => true,
-            Some("off") => false,
-            Some(_) => return Err(anyhow::anyhow!("usage: {name} on|off")),
-            None => !*field(&mut demo.toggles), // toggle if no arg
-        };
-        *field(&mut demo.toggles) = new;
-        demo.dirty = true;
-        Ok(())
     }
 }
 

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -411,15 +411,19 @@ impl RasterTestApp {
         // slot only when the user has typed `tests polytope ` (context-aware completion).
         c.register(
             rye_egui::subcommands::<Demo>("tests", "toggle what renders in raster_test")
-                .toggle("all", "toggle every R³ raster-test category at once", |d, v| {
-                    d.toggles.axes = v;
-                    d.toggles.cube = v;
-                    d.toggles.widths = v;
-                    d.toggles.gradient = v;
-                    d.toggles.tilted = v;
-                    d.dirty = true;
-                    Ok(())
-                })
+                .toggle(
+                    "all",
+                    "toggle every R³ raster-test category at once",
+                    |d, v| {
+                        d.toggles.axes = v;
+                        d.toggles.cube = v;
+                        d.toggles.widths = v;
+                        d.toggles.gradient = v;
+                        d.toggles.tilted = v;
+                        d.dirty = true;
+                        Ok(())
+                    },
+                )
                 .toggle("axes", "toggle world-axes (R/G/B basis vectors)", |d, v| {
                     d.toggles.axes = v;
                     d.dirty = true;
@@ -449,7 +453,13 @@ impl RasterTestApp {
                     "polytope",
                     "set R⁴ polytope overlay (or `off` to clear it)",
                     &[
-                        "off", "5cell", "tesseract", "16cell", "24cell", "120cell", "600cell",
+                        "off",
+                        "5cell",
+                        "tesseract",
+                        "16cell",
+                        "24cell",
+                        "120cell",
+                        "600cell",
                     ],
                     |d, name| {
                         d.polytope = match name.to_ascii_lowercase().as_str() {

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -23,10 +23,15 @@
 //! - `samples N`: set per-segment tessellation density. `1` is the default and is correct for
 //!   flat-Euclidean impls; higher values exercise the writer-pattern path that curved-space
 //!   impls will use.
-//! - `polytope <name|off>`: show an R⁴ polytope wireframe alongside the R³ scene. `<name>` is
-//!   one of `5cell`, `tesseract`, `16cell`, `24cell`, `120cell`, `600cell` (hyphenated aliases
-//!   accepted). The wireframe is projected to R³ via `Orthographic { drop_axis: 3 }` (drop-w)
-//!   and scaled 2.5x so it's visible alongside the unit cube.
+//! - `polytope <name|off>`: show an R⁴ polytope wireframe alongside the R³ scene. `<name>`
+//!   is one of `5cell`, `tesseract`, `16cell`, `24cell`, `120cell`, `600cell` (hyphenated
+//!   aliases accepted). The wireframe is projected to R³ via `Orthographic { drop_axis: 3 }`
+//!   and scaled 2.5x so it's visible alongside the unit cube. An animated 4D rotation (xw +
+//!   yz planes) is applied before projection so axis-aligned polytopes like the tesseract
+//!   don't collapse onto a degenerate R³ silhouette.
+//! - `tests <on|off>`: bulk-toggle all R³ raster-test categories (axes / cube / widths /
+//!   gradient / tilted) in one go. Useful for clearing the R³ scene when you only want to
+//!   look at an R⁴ polytope.
 //! - `reset`: restore all toggles to default and samples = 1 and polytope off.
 
 use std::borrow::Cow;
@@ -38,13 +43,36 @@ use rye_egui::{Console, ConsoleWriter};
 use rye_math::{EuclideanR3, EuclideanR4, Projection};
 use rye_physics::polytope::Polytope4;
 use rye_render::{device::RenderDevice, LineRasterNode};
-use rye_shape::{LineMesh, Visualizable};
+use rye_shape::LineMesh;
 use winit::window::WindowAttributes;
 
 /// R⁴ scale factor for the polytope wireframe. Polytope vertices live on the unit
 /// 3-sphere; scaling up to 2.5 makes the wireframe comfortably visible alongside the R³
 /// test scene without overflowing the cube's ±1.5 extent.
 const POLYTOPE_SCALE: f32 = 2.5;
+
+/// Angular speeds (rad/s) of the animated 4D rotation applied to polytope vertices before
+/// drop-w projection. Two independent simple rotations: `XW_RATE` rotates in the xw plane
+/// (separates the tesseract's inner / outer cubes when projected); `YZ_RATE` rotates inside
+/// the projected R³ for visual depth. Non-commensurate rates so the orbit doesn't repeat.
+const XW_RATE: f32 = 0.40;
+const YZ_RATE: f32 = 0.30;
+
+/// Apply an animated 4D rotation to a single point. Rotates in the xw plane by `t * XW_RATE`
+/// and in the yz plane by `t * YZ_RATE`. Used to make w-axis-aligned polytopes (the
+/// tesseract is the worst offender) render as visibly 4D under `Orthographic { drop_axis: 3 }`
+/// rather than collapsing onto a degenerate R³ silhouette.
+fn rotate_4d(p: [f32; 4], t: f32) -> [f32; 4] {
+    let (sxw, cxw) = (t * XW_RATE).sin_cos();
+    let (syz, cyz) = (t * YZ_RATE).sin_cos();
+    let [x, y, z, w] = p;
+    [
+        x * cxw - w * sxw,
+        y * cyz - z * syz,
+        y * syz + z * cyz,
+        x * sxw + w * cxw,
+    ]
+}
 
 /// Test-scene toggles. Each maps to a category in [`build_mesh`].
 #[derive(Clone, Copy, Debug)]
@@ -189,8 +217,13 @@ struct Demo {
     /// Tessellation samples-per-segment. 1 for flat space (no interior subdivision); higher
     /// values exercise the writer-pattern path that geodesic-space impls will use later.
     samples: usize,
+    /// Wall-clock time threaded in from [`FrameCtx::time`] each frame. Drives the animated
+    /// 4D rotation in [`rotate_4d`]; only read when `polytope.is_some()`.
+    time: f32,
     /// Set by console toggle / `samples` commands to re-upload meshes on the next frame.
     /// Persists across frames so multiple console mutations within one frame coalesce.
+    /// When `polytope.is_some()` the per-frame animation flips this every frame so the
+    /// rotated mesh re-uploads continuously.
     dirty: bool,
 }
 
@@ -221,6 +254,7 @@ impl Demo {
             toggles: Toggles::default(),
             polytope: None,
             samples: 1,
+            time: 0.0,
             dirty: true,
         };
         demo.reupload(ctx.rd);
@@ -239,13 +273,19 @@ impl Demo {
             self.samples,
         );
 
-        // R⁴ polytope wireframe (if enabled). The scale-up bakes into the mesh before
-        // upload so we don't have to thread a model matrix through the rasterizer; the
-        // wireframe ends up at ~2.5 unit world-space radius.
+        // R⁴ polytope wireframe (if enabled). Vertices are first rotated in R⁴ (so
+        // axis-aligned polytopes don't collapse under drop-w; see [`rotate_4d`]) and then
+        // scaled up so the wireframe ends up at ~2.5 unit world-space radius. Baking both
+        // into the mesh keeps the rasterizer's instance data simple: no per-frame model
+        // matrix threaded through the pipeline.
         if let Some(p) = self.polytope {
-            let mut mesh = <Polytope4 as Visualizable<4>>::to_lines(&p)
-                .expect("polytopes always produce line meshes");
+            // Position-derived per-vertex color: dense wireframes like the 600-cell read as
+            // a coherent color field rather than a uniform tangle. See
+            // [`Polytope4::lines_colored_by_position`].
+            let mut mesh = p.lines_colored_by_position();
             for (a, b) in mesh.segments.iter_mut() {
+                *a = rotate_4d(*a, self.time);
+                *b = rotate_4d(*b, self.time);
                 for k in 0..4 {
                     a[k] *= POLYTOPE_SCALE;
                     b[k] *= POLYTOPE_SCALE;
@@ -284,6 +324,12 @@ impl Demo {
         if !ctx.ui_has_focus {
             self.orbit
                 .advance(ctx.input, &mut self.camera, &EuclideanR3, 0.0);
+        }
+        self.time = ctx.time;
+        // Animated 4D rotation: re-upload the polytope mesh every frame while it's
+        // visible. ~32-720 edges per polytope so the per-frame upload is cheap.
+        if self.polytope.is_some() {
+            self.dirty = true;
         }
         if self.dirty {
             self.reupload(ctx.rd);
@@ -354,36 +400,82 @@ struct RasterTestApp {
     demo: Demo,
     console: Console<Demo>,
     last_egui_keyboard: bool,
+    /// Capture parameters panel (output dir, format, fps, scale, start/stop). Toggled via the
+    /// `capture panel` console command or the F11 default bind. The framework runner reads the
+    /// post-UI swapchain after every frame, so png / gif / apng / frame-sequence output works
+    /// without any per-app render code.
+    capture_panel: rye_app::capture::CapturePanel,
 }
 
 impl RasterTestApp {
     fn build_console() -> Console<Demo> {
         let mut c = Console::<Demo>::new();
-        c.register(rye_egui::cmd(
-            "axes",
-            "toggle world-axes (on|off)",
-            toggle_cmd("axes", |t| &mut t.axes),
-        ));
-        c.register(rye_egui::cmd(
-            "cube",
-            "toggle unit-cube wireframe (on|off)",
-            toggle_cmd("cube", |t| &mut t.cube),
-        ));
-        c.register(rye_egui::cmd(
-            "widths",
-            "toggle width-sweep lines (on|off)",
-            toggle_cmd("widths", |t| &mut t.widths),
-        ));
-        c.register(rye_egui::cmd(
-            "gradient",
-            "toggle gradient line (on|off)",
-            toggle_cmd("gradient", |t| &mut t.gradient),
-        ));
-        c.register(rye_egui::cmd(
-            "tilted",
-            "toggle tilted-line fan (on|off)",
-            toggle_cmd("tilted", |t| &mut t.tilted),
-        ));
+        c.register(
+            rye_egui::cmd(
+                "axes",
+                "toggle world-axes (on|off)",
+                toggle_cmd("axes", |t| &mut t.axes),
+            )
+            .with_args(&[&["on", "off"]]),
+        );
+        c.register(
+            rye_egui::cmd(
+                "cube",
+                "toggle unit-cube wireframe (on|off)",
+                toggle_cmd("cube", |t| &mut t.cube),
+            )
+            .with_args(&[&["on", "off"]]),
+        );
+        c.register(
+            rye_egui::cmd(
+                "widths",
+                "toggle width-sweep lines (on|off)",
+                toggle_cmd("widths", |t| &mut t.widths),
+            )
+            .with_args(&[&["on", "off"]]),
+        );
+        c.register(
+            rye_egui::cmd(
+                "gradient",
+                "toggle gradient line (on|off)",
+                toggle_cmd("gradient", |t| &mut t.gradient),
+            )
+            .with_args(&[&["on", "off"]]),
+        );
+        c.register(
+            rye_egui::cmd(
+                "tilted",
+                "toggle tilted-line fan (on|off)",
+                toggle_cmd("tilted", |t| &mut t.tilted),
+            )
+            .with_args(&[&["on", "off"]]),
+        );
+        c.register(
+            rye_egui::cmd(
+                "tests",
+                "toggle all R³ raster-test categories at once (on|off)",
+                |args, demo: &mut Demo, _out: &mut ConsoleWriter| {
+                    let arg = args
+                        .first()
+                        .ok_or_else(|| anyhow::anyhow!("usage: tests <on|off>"))?;
+                    let v = match arg.to_ascii_lowercase().as_str() {
+                        "on" | "true" | "1" => true,
+                        "off" | "false" | "0" => false,
+                        other => {
+                            return Err(anyhow::anyhow!("unknown arg `{other}` (try on|off)"))
+                        }
+                    };
+                    demo.toggles.axes = v;
+                    demo.toggles.cube = v;
+                    demo.toggles.widths = v;
+                    demo.toggles.gradient = v;
+                    demo.toggles.tilted = v;
+                    demo.dirty = true;
+                    Ok(())
+                },
+            )
+            .with_args(&[&["on", "off"]]),
+        );
         c.register(rye_egui::cmd(
             "samples",
             "set tessellation samples-per-segment (default 1)",
@@ -400,32 +492,37 @@ impl RasterTestApp {
                 Ok(())
             },
         ));
-        c.register(rye_egui::cmd(
-            "polytope",
-            "set R⁴ polytope wireframe overlay (5cell|tesseract|16cell|24cell|120cell|600cell|off)",
-            |args, demo: &mut Demo, _out: &mut ConsoleWriter| {
-                let name = args
-                    .first()
-                    .ok_or_else(|| anyhow::anyhow!("usage: polytope <name|off>"))?;
-                demo.polytope = match name.to_ascii_lowercase().as_str() {
-                    "off" | "none" => None,
-                    "5cell" | "5-cell" | "pentatope" => Some(Polytope4::Pentatope),
-                    "8cell" | "8-cell" | "tesseract" => Some(Polytope4::Tesseract),
-                    "16cell" | "16-cell" => Some(Polytope4::Cell16),
-                    "24cell" | "24-cell" => Some(Polytope4::Cell24),
-                    "120cell" | "120-cell" => Some(Polytope4::Cell120),
-                    "600cell" | "600-cell" => Some(Polytope4::Cell600),
-                    other => {
-                        return Err(anyhow::anyhow!(
-                            "unknown polytope `{other}` (try 5cell, tesseract, 16cell, 24cell, \
-                             120cell, 600cell, or off)"
-                        ))
-                    }
-                };
-                demo.dirty = true;
-                Ok(())
-            },
-        ));
+        c.register(
+            rye_egui::cmd(
+                "polytope",
+                "set R⁴ polytope wireframe overlay (5cell|tesseract|16cell|24cell|120cell|600cell|off)",
+                |args, demo: &mut Demo, _out: &mut ConsoleWriter| {
+                    let name = args
+                        .first()
+                        .ok_or_else(|| anyhow::anyhow!("usage: polytope <name|off>"))?;
+                    demo.polytope = match name.to_ascii_lowercase().as_str() {
+                        "off" | "none" => None,
+                        "5cell" | "5-cell" | "pentatope" => Some(Polytope4::Pentatope),
+                        "8cell" | "8-cell" | "tesseract" => Some(Polytope4::Tesseract),
+                        "16cell" | "16-cell" => Some(Polytope4::Cell16),
+                        "24cell" | "24-cell" => Some(Polytope4::Cell24),
+                        "120cell" | "120-cell" => Some(Polytope4::Cell120),
+                        "600cell" | "600-cell" => Some(Polytope4::Cell600),
+                        other => {
+                            return Err(anyhow::anyhow!(
+                                "unknown polytope `{other}` (try 5cell, tesseract, 16cell, 24cell, \
+                                 120cell, 600cell, or off)"
+                            ))
+                        }
+                    };
+                    demo.dirty = true;
+                    Ok(())
+                },
+            )
+            .with_args(&[&[
+                "5cell", "tesseract", "16cell", "24cell", "120cell", "600cell", "off",
+            ]]),
+        );
         c.register(rye_egui::cmd(
             "reset",
             "restore all toggles to default (everything on, samples = 1, no polytope)",
@@ -437,6 +534,12 @@ impl RasterTestApp {
                 Ok(())
             },
         ));
+
+        // Framework-provided capture: `capture png [pre|post|both] [dir]`,
+        // `capture frames|gif|apng [pre|post|both] [dir]`, `capture stop`, `capture panel`.
+        // Bound to F12 (one-shot png), F9 (toggle gif sequence), F11 (panel).
+        rye_app::capture::register_commands(&mut c);
+        rye_app::capture::bind_default_hotkeys(&mut c);
 
         // Standard framework log mirror so tracing events show up in the console scrollback.
         rye_app::log::register_command(&mut c);
@@ -475,6 +578,7 @@ impl App for RasterTestApp {
             demo,
             console,
             last_egui_keyboard: false,
+            capture_panel: rye_app::capture::CapturePanel::new(),
         })
     }
 
@@ -550,6 +654,7 @@ impl App for RasterTestApp {
                 ui.label("press ` to open console");
                 ui.label("orbit: drag, zoom: scroll, exit: Esc");
             });
+        self.capture_panel.show(ctx);
         rye_app::log::pump_into(&mut self.console);
         self.console.ui(ctx, &mut self.demo);
         self.last_egui_keyboard = ctx.wants_keyboard_input();

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -23,7 +23,11 @@
 //! - `samples N`: set per-segment tessellation density. `1` is the default and is correct for
 //!   flat-Euclidean impls; higher values exercise the writer-pattern path that curved-space
 //!   impls will use.
-//! - `reset`: restore all toggles to default and samples = 1.
+//! - `polytope <name|off>`: show an R⁴ polytope wireframe alongside the R³ scene. `<name>` is
+//!   one of `5cell`, `tesseract`, `16cell`, `24cell`, `120cell`, `600cell` (hyphenated aliases
+//!   accepted). The wireframe is projected to R³ via `Orthographic { drop_axis: 3 }` (drop-w)
+//!   and scaled 2.5x so it's visible alongside the unit cube.
+//! - `reset`: restore all toggles to default and samples = 1 and polytope off.
 
 use std::borrow::Cow;
 
@@ -31,10 +35,16 @@ use anyhow::Result;
 use glam::{Mat4, Vec2, Vec3};
 use rye_app::{egui, run_with_config, App, Camera, FrameCtx, OrbitController, RunConfig, SetupCtx};
 use rye_egui::{Console, ConsoleWriter};
-use rye_math::{EuclideanR3, Projection};
+use rye_math::{EuclideanR3, EuclideanR4, Projection};
+use rye_physics::polytope::Polytope4;
 use rye_render::{device::RenderDevice, LineRasterNode};
-use rye_shape::LineMesh;
+use rye_shape::{LineMesh, Visualizable};
 use winit::window::WindowAttributes;
+
+/// R⁴ scale factor for the polytope wireframe. Polytope vertices live on the unit
+/// 3-sphere; scaling up to 2.5 makes the wireframe comfortably visible alongside the R³
+/// test scene without overflowing the cube's ±1.5 extent.
+const POLYTOPE_SCALE: f32 = 2.5;
 
 /// Test-scene toggles. Each maps to a category in [`build_mesh`].
 #[derive(Clone, Copy, Debug)]
@@ -166,19 +176,32 @@ struct Demo {
     space: EuclideanR3,
     camera: Camera<EuclideanR3>,
     orbit: OrbitController<EuclideanR3>,
-    line_raster: LineRasterNode,
+    /// R³ rasterizer for the curated test scene (axes, cube, width sweep, etc.).
+    line_raster_r3: LineRasterNode,
+    /// R⁴ rasterizer for the optional polytope wireframe overlay. Separate from the R³ node
+    /// so both pipelines can render in sequence against the same color attachment.
+    line_raster_r4: LineRasterNode,
     toggles: Toggles,
+    /// Active R⁴ polytope. `None` disables the R⁴ overlay entirely; `Some(p)` uploads `p`'s
+    /// `Visualizable<4>` line mesh through the `Orthographic { drop_axis: 3 }` (drop-w)
+    /// projection.
+    polytope: Option<Polytope4>,
     /// Tessellation samples-per-segment. 1 for flat space (no interior subdivision); higher
     /// values exercise the writer-pattern path that geodesic-space impls will use later.
     samples: usize,
-    /// Set by console toggle / `samples` commands to re-upload the mesh on the next frame.
+    /// Set by console toggle / `samples` commands to re-upload meshes on the next frame.
     /// Persists across frames so multiple console mutations within one frame coalesce.
     dirty: bool,
 }
 
 impl Demo {
     fn new(ctx: &mut SetupCtx<'_>) -> Result<Self> {
-        let line_raster = LineRasterNode::new(
+        let line_raster_r3 = LineRasterNode::new(
+            &ctx.rd.device,
+            ctx.rd.surface_bundle.config.format,
+            ctx.rd.sample_count(),
+        );
+        let line_raster_r4 = LineRasterNode::new(
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
             ctx.rd.sample_count(),
@@ -193,8 +216,10 @@ impl Demo {
             space: EuclideanR3,
             camera,
             orbit,
-            line_raster,
+            line_raster_r3,
+            line_raster_r4,
             toggles: Toggles::default(),
+            polytope: None,
             samples: 1,
             dirty: true,
         };
@@ -202,16 +227,49 @@ impl Demo {
         Ok(demo)
     }
 
-    /// Re-tessellate and re-upload the mesh. Called whenever toggles or `samples` change.
+    /// Re-tessellate and re-upload both R³ and R⁴ meshes. Called whenever toggles, the
+    /// active polytope, or `samples` change.
     fn reupload(&mut self, rd: &RenderDevice) {
-        let mesh = build_mesh(self.toggles);
-        self.line_raster.upload::<EuclideanR3, 3>(
+        let r3_mesh = build_mesh(self.toggles);
+        self.line_raster_r3.upload::<EuclideanR3, 3>(
             &rd.device,
             &rd.queue,
-            &mesh,
+            &r3_mesh,
             &Projection::Identity,
             self.samples,
         );
+
+        // R⁴ polytope wireframe (if enabled). The scale-up bakes into the mesh before
+        // upload so we don't have to thread a model matrix through the rasterizer; the
+        // wireframe ends up at ~2.5 unit world-space radius.
+        if let Some(p) = self.polytope {
+            let mut mesh = <Polytope4 as Visualizable<4>>::to_lines(&p)
+                .expect("polytopes always produce line meshes");
+            for (a, b) in mesh.segments.iter_mut() {
+                for k in 0..4 {
+                    a[k] *= POLYTOPE_SCALE;
+                    b[k] *= POLYTOPE_SCALE;
+                }
+            }
+            self.line_raster_r4.upload::<EuclideanR4, 4>(
+                &rd.device,
+                &rd.queue,
+                &mesh,
+                &Projection::Orthographic { drop_axis: 3 },
+                self.samples,
+            );
+        } else {
+            // Upload an empty mesh so the R⁴ pass becomes a no-op (zero instances).
+            let empty: LineMesh<4> = LineMesh::default();
+            self.line_raster_r4.upload::<EuclideanR4, 4>(
+                &rd.device,
+                &rd.queue,
+                &empty,
+                &Projection::Orthographic { drop_axis: 3 },
+                self.samples,
+            );
+        }
+
         self.dirty = false;
     }
 }
@@ -245,7 +303,8 @@ impl Demo {
         let proj_mat = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
         let view_proj = proj_mat * view_mat;
         let vp_size = Vec2::new(cfg.width as f32, cfg.height as f32);
-        self.line_raster.set_camera(&rd.queue, view_proj, vp_size);
+        self.line_raster_r3.set_camera(&rd.queue, view_proj, vp_size);
+        self.line_raster_r4.set_camera(&rd.queue, view_proj, vp_size);
 
         // Clear the framebuffer to a dark slate so the lines are visible. The rasterizer's
         // pass uses LoadOp::Load, so we need a prior pass to clear; do it inline here via a
@@ -281,7 +340,8 @@ impl Demo {
         }
         rd.queue.submit(Some(clear_encoder.finish()));
 
-        self.line_raster.execute(rd, view)?;
+        self.line_raster_r3.execute(rd, view)?;
+        self.line_raster_r4.execute(rd, view)?;
         Ok(())
     }
 }
@@ -341,11 +401,38 @@ impl RasterTestApp {
             },
         ));
         c.register(rye_egui::cmd(
+            "polytope",
+            "set R⁴ polytope wireframe overlay (5cell|tesseract|16cell|24cell|120cell|600cell|off)",
+            |args, demo: &mut Demo, _out: &mut ConsoleWriter| {
+                let name = args
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("usage: polytope <name|off>"))?;
+                demo.polytope = match name.to_ascii_lowercase().as_str() {
+                    "off" | "none" => None,
+                    "5cell" | "5-cell" | "pentatope" => Some(Polytope4::Pentatope),
+                    "8cell" | "8-cell" | "tesseract" => Some(Polytope4::Tesseract),
+                    "16cell" | "16-cell" => Some(Polytope4::Cell16),
+                    "24cell" | "24-cell" => Some(Polytope4::Cell24),
+                    "120cell" | "120-cell" => Some(Polytope4::Cell120),
+                    "600cell" | "600-cell" => Some(Polytope4::Cell600),
+                    other => {
+                        return Err(anyhow::anyhow!(
+                            "unknown polytope `{other}` (try 5cell, tesseract, 16cell, 24cell, \
+                             120cell, 600cell, or off)"
+                        ))
+                    }
+                };
+                demo.dirty = true;
+                Ok(())
+            },
+        ));
+        c.register(rye_egui::cmd(
             "reset",
-            "restore all toggles to default (everything on, samples = 1)",
+            "restore all toggles to default (everything on, samples = 1, no polytope)",
             |_args, demo: &mut Demo, _out: &mut ConsoleWriter| {
                 demo.toggles = Toggles::default();
                 demo.samples = 1;
+                demo.polytope = None;
                 demo.dirty = true;
                 Ok(())
             },
@@ -447,6 +534,16 @@ impl App for RasterTestApp {
                     }
                 ));
                 ui.separator();
+                let polytope_label = match self.demo.polytope {
+                    None => Cow::Borrowed("off"),
+                    Some(Polytope4::Pentatope) => Cow::Borrowed("5-cell"),
+                    Some(Polytope4::Tesseract) => Cow::Borrowed("tesseract"),
+                    Some(Polytope4::Cell16) => Cow::Borrowed("16-cell"),
+                    Some(Polytope4::Cell24) => Cow::Borrowed("24-cell"),
+                    Some(Polytope4::Cell120) => Cow::Borrowed("120-cell"),
+                    Some(Polytope4::Cell600) => Cow::Borrowed("600-cell"),
+                };
+                ui.label(format!("polytope (R⁴): {polytope_label}"));
                 ui.label(format!("samples: {}", self.demo.samples));
                 ui.label(format!("camera fps: {:.0}", frame.fps));
                 ui.separator();


### PR DESCRIPTION
## Why

Ships the rasterization tier as a peer to the SDF raymarcher:
`Visualizable<N>` + `RasterizableSpace<N>` traits plus a `LineRasterNode` with antialiased quad expansion. R³ + R⁴ line wireframes; `Projection<N>` enum extensible for curved-space and perspective variants. Foundation for filled-triangle and cross-section overlay work to follow.

## Also

Overhauls the quake console command surface with much better ergonomics: Typed subcommand dispatch via `SubcommandSet`, quoted-arg parsing, and a single source of name/help for bulitins.

## Verify

- `cargo run --release --example raster_test`
- Open console with `` ` ``, then `polytope tesseract`, then `polytope 600cell`
- `tests off` clears the R³ scene; F9 records a gif