### PR TITLE
Feat/rasterizer r4

### DIFF
--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -355,11 +355,11 @@ where
 // Subcommand dispatch
 // ---------------------------------------------------------------------------
 
-// Tab-completion for toggle subcommands intentionally returns an empty list at the
-// value slot. The primary UX for a toggle is *bare* invocation (e.g. `wireframe
-// nearest-active` flips), and surfacing `on|off` in completion implied that one of
-// them was required when it isn't. The parser still accepts `on|off|true|false|1|0`
-// for callers that want explicit set; it's just no longer promoted in the cycle.
+// Tab-completion for toggle subcommands intentionally returns an empty list at the value
+// slot. The primary UX for a toggle is *bare* invocation (e.g. `wireframe nearest-active`
+// flips), and surfacing `on|off` in completion implied that one of them was required when it
+// isn't. The parser still accepts `on|off|true|false|1|0` for callers that want explicit
+// set; it's just no longer promoted in the cycle.
 
 /// Boxed handler for an on/off toggle subcommand. The framework passes `Some(bool)`
 /// when the user supplied `on|off|true|false|1|0` and `None` when the user invoked the
@@ -376,10 +376,24 @@ where
 /// ```
 type ToggleHandler<Ctx> = Box<dyn FnMut(&mut Ctx, Option<bool>) -> anyhow::Result<()>>;
 
-/// Boxed handler for a fixed-choice subcommand. Receives the user's context and the
-/// raw value string (one of the declared choices in normal use; the handler still has
-/// to handle case-insensitivity / aliases if those are wanted).
-type ChoiceHandler<Ctx> = Box<dyn FnMut(&mut Ctx, &str) -> anyhow::Result<()>>;
+/// Boxed handler for a fixed-choice subcommand. The framework passes `Some(value)` when the
+/// user supplied a value and `None` when the subcommand was invoked bare (no value),
+/// mirroring [`ToggleHandler`]'s shape. On `None`, the handler is expected to cycle to the
+/// next choice (or whatever's contextually meaningful); the framework can't help because it
+/// doesn't know the current state.
+///
+/// Idiomatic handler for a `Mode` enum field with a `cycle` method:
+///
+/// ```ignore
+/// .choice("color", "...", &["unique", "active"], |ctx, name| {
+///     ctx.color_mode = match name {
+///         Some(n) => parse_mode(n)?,
+///         None => ctx.color_mode.cycle(),
+///     };
+///     Ok(())
+/// })
+/// ```
+type ChoiceHandler<Ctx> = Box<dyn FnMut(&mut Ctx, Option<&str>) -> anyhow::Result<()>>;
 
 /// Boxed handler for a `SubcommandSet`'s bare invocation (no subcommand supplied).
 /// When set via [`SubcommandSet::on_bare`], replaces the default usage-block error
@@ -398,14 +412,14 @@ type CustomHandler<Ctx> =
 /// One entry in a [`SubcommandSet`]. The dispatch kind decides how the framework
 /// parses the value slot and what's offered for tab completion.
 enum SubcommandKind<Ctx> {
-    /// On/off subcommand. The framework parses `args[1]` as
-    /// `on|off|true|false|1|0` and passes `Some(bool)`; bare invocation (no value)
-    /// passes `None` and the handler is expected to flip its field. No value-slot
-    /// tab completion is offered (bare-flip is the canonical UX; explicit set is
-    /// supported but not promoted).
+    /// On/off subcommand. The framework parses `args[1]` as `on|off|true|false|1|0` and
+    /// passes `Some(bool)`; bare invocation (no value) passes `None` and the handler is
+    /// expected to flip its field. No value-slot tab completion is offered (bare-flip is the
+    /// canonical UX; explicit set is supported but not promoted).
     Toggle { handler: ToggleHandler<Ctx> },
-    /// Fixed-choice subcommand. The framework completes the value slot from `choices`;
-    /// the handler receives the raw value string and decides what to do.
+    /// Fixed-choice subcommand. The framework completes the value slot from `choices`
+    /// and passes `Some(value)` when present, `None` on bare invocation (handler is
+    /// expected to cycle).
     Choice {
         choices: Vec<&'static str>,
         handler: ChoiceHandler<Ctx>,
@@ -509,7 +523,7 @@ impl<Ctx: 'static> SubcommandSet<Ctx> {
         handler: F,
     ) -> Self
     where
-        F: FnMut(&mut Ctx, &str) -> anyhow::Result<()> + 'static,
+        F: FnMut(&mut Ctx, Option<&str>) -> anyhow::Result<()> + 'static,
     {
         self.subs.insert(
             name,
@@ -752,9 +766,10 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
                 handler(ctx, v)
             }
             SubcommandKind::Choice { handler, .. } => {
-                let value = rest
-                    .first()
-                    .ok_or_else(|| anyhow::anyhow!("usage: {} {sub_name} <value>", self.name))?;
+                // `Some(value)` with an explicit arg, `None` on bare invocation. The
+                // handler decides what to do on `None` (cycle to next choice is the
+                // canonical pattern; alternatives include "error" or "no-op").
+                let value: Option<&str> = rest.first().copied();
                 let _ = out;
                 handler(ctx, value)
             }
@@ -2036,7 +2051,7 @@ mod tests {
                 "set polytope",
                 &["5cell", "tesseract", "off"],
                 |c, name| {
-                    c.1 = format!("polytope={name}");
+                    c.1 = format!("polytope={}", name.unwrap_or("<bare>"));
                     Ok(())
                 },
             )
@@ -2105,17 +2120,16 @@ mod tests {
         assert_eq!(ctx, (0, "axes=false".into()));
     }
 
-    /// Choice subcommand still requires a value (no cycle-on-bare equivalent yet).
-    /// Pins the contract so a future cycle-on-bare extension updates this test.
+    /// Bare choice invocation passes `None` to the handler; the handler decides what
+    /// "no value" means (cycle, no-op, error). Pins the framework-level contract that
+    /// the handler is invoked at all.
     #[test]
-    fn subcommand_choice_missing_value_errors() {
+    fn subcommand_choice_bare_invocation_passes_none() {
         let mut con = Console::<SubCtx>::new();
         con.register(sample_subset());
         let mut ctx: SubCtx = (0, String::new());
         con.execute("tests polytope", &mut ctx);
-        let last = con.history.back().unwrap();
-        assert_eq!(last.kind, LineKind::Error);
-        assert!(last.text.contains("usage"), "got: {}", last.text);
+        assert_eq!(ctx.1, "polytope=<bare>");
     }
 
     /// Bare `SubcommandSet` invocation (no subcommand) calls the registered

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -355,10 +355,11 @@ where
 // Subcommand dispatch
 // ---------------------------------------------------------------------------
 
-/// Static on/off completion list used by every `Toggle` subcommand. Lives here so the
-/// `arg_choices_ctx` impl can hand back a `&'static [&'static str]` without owning a
-/// per-instance Vec.
-const ON_OFF_CHOICES: &[&str] = &["off", "on"];
+// Tab-completion for toggle subcommands intentionally returns an empty list at the
+// value slot. The primary UX for a toggle is *bare* invocation (e.g. `wireframe
+// nearest-active` flips), and surfacing `on|off` in completion implied that one of
+// them was required when it isn't. The parser still accepts `on|off|true|false|1|0`
+// for callers that want explicit set; it's just no longer promoted in the cycle.
 
 /// Boxed handler for an on/off toggle subcommand. The framework passes `Some(bool)`
 /// when the user supplied `on|off|true|false|1|0` and `None` when the user invoked the
@@ -397,9 +398,11 @@ type CustomHandler<Ctx> =
 /// One entry in a [`SubcommandSet`]. The dispatch kind decides how the framework
 /// parses the value slot and what's offered for tab completion.
 enum SubcommandKind<Ctx> {
-    /// On/off subcommand. The framework parses `args[1]` as `on|off` and passes the
-    /// resulting bool to `handler`. Completion at the value slot is the static
-    /// `["off", "on"]` list.
+    /// On/off subcommand. The framework parses `args[1]` as
+    /// `on|off|true|false|1|0` and passes `Some(bool)`; bare invocation (no value)
+    /// passes `None` and the handler is expected to flip its field. No value-slot
+    /// tab completion is offered (bare-flip is the canonical UX; explicit set is
+    /// supported but not promoted).
     Toggle { handler: ToggleHandler<Ctx> },
     /// Fixed-choice subcommand. The framework completes the value slot from `choices`;
     /// the handler receives the raw value string and decides what to do.
@@ -667,11 +670,10 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
         let sub_slot = arg_index - 1;
         match &entry.kind {
             SubcommandKind::Toggle { .. } => {
-                if sub_slot == 0 {
-                    ON_OFF_CHOICES
-                } else {
-                    &[]
-                }
+                // Empty by design — see the comment on `ON_OFF_CHOICES`'s old slot
+                // above. Bare invocation is the canonical UX; `on|off` is still
+                // accepted as input but not surfaced as a suggestion.
+                &[]
             }
             SubcommandKind::Choice { choices, .. } => {
                 if sub_slot == 0 {
@@ -2145,18 +2147,28 @@ mod tests {
     }
 
     /// Tab completion at the value slot narrows to ONLY the chosen subcommand's choices.
-    /// This is the load-bearing context-aware-completion test: previously the second-arg
-    /// completion list would have to be the union (`on, off, 5cell, ...`).
+    /// This is the load-bearing context-aware-completion test: the value slot
+    /// completion is narrow to the chosen subcommand's allowed values, not the
+    /// union over all subcommands.
+    ///
+    /// Toggle subcommands deliberately surface NO value-slot suggestions: bare
+    /// invocation flips, so `on|off` is supported as input but not promoted in
+    /// the cycle (avoids implying that one of them is required when it isn't).
+    /// Choice subcommands surface their declared choice list.
     #[test]
     fn subcommand_value_completion_is_context_aware() {
         let mut con = Console::<SubCtx>::new();
         con.register(sample_subset());
 
-        // `tests axes ` -> only on/off in the cycle.
+        // `tests axes ` -> toggle, no suggestions (bare invocation is the UX;
+        // typing `on|off` still works but isn't promoted).
         con.input = "tests axes ".into();
         let ctx = con.completion_context().unwrap();
         let m = con.completion_matches(&ctx);
-        assert_eq!(m, vec!["off".to_string(), "on".to_string()]);
+        assert!(
+            m.is_empty(),
+            "toggle value slot should suggest nothing, got {m:?}"
+        );
 
         // `tests polytope ` -> only polytope names in the cycle, no on/off.
         con.input = "tests polytope ".into();

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -670,8 +670,8 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
         let sub_slot = arg_index - 1;
         match &entry.kind {
             SubcommandKind::Toggle { .. } => {
-                // Empty by design — see the comment on `ON_OFF_CHOICES`'s old slot
-                // above. Bare invocation is the canonical UX; `on|off` is still
+                // Empty by design (see the comment on `ON_OFF_CHOICES`'s old slot
+                // above). Bare invocation is the canonical UX; `on|off` is still
                 // accepted as input but not surfaced as a suggestion.
                 &[]
             }

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -360,14 +360,31 @@ where
 /// per-instance Vec.
 const ON_OFF_CHOICES: &[&str] = &["off", "on"];
 
-/// Boxed handler for an on/off toggle subcommand. Receives the user's context and the
-/// parsed bool; returns a `Result` so handlers can fail with usage / validation errors.
-type ToggleHandler<Ctx> = Box<dyn FnMut(&mut Ctx, bool) -> anyhow::Result<()>>;
+/// Boxed handler for an on/off toggle subcommand. The framework passes `Some(bool)`
+/// when the user supplied `on|off|true|false|1|0` and `None` when the user invoked the
+/// subcommand bare (no value). The handler is responsible for flipping the field in
+/// the `None` case; the framework can't because it doesn't own the field.
+///
+/// Idiomatic shape for a `bool` field on `Ctx`:
+///
+/// ```ignore
+/// .toggle("axes", "toggle world-axes", |ctx, v| {
+///     ctx.show_axes = v.unwrap_or(!ctx.show_axes);
+///     Ok(())
+/// })
+/// ```
+type ToggleHandler<Ctx> = Box<dyn FnMut(&mut Ctx, Option<bool>) -> anyhow::Result<()>>;
 
 /// Boxed handler for a fixed-choice subcommand. Receives the user's context and the
 /// raw value string (one of the declared choices in normal use; the handler still has
 /// to handle case-insensitivity / aliases if those are wanted).
 type ChoiceHandler<Ctx> = Box<dyn FnMut(&mut Ctx, &str) -> anyhow::Result<()>>;
+
+/// Boxed handler for a `SubcommandSet`'s bare invocation (no subcommand supplied).
+/// When set via [`SubcommandSet::on_bare`], replaces the default usage-block error
+/// with a caller-defined action, typically flipping a primary toggle field so
+/// `wireframe` alone reads as "flip the overlay's main on/off."
+type BareHandler<Ctx> = Box<dyn FnMut(&mut Ctx) -> anyhow::Result<()>>;
 
 /// Boxed handler for a custom-grammar subcommand. Receives the user's context, the
 /// raw args slice AFTER the subcommand name (positional + key-value tokens, framework
@@ -440,14 +457,30 @@ pub struct SubcommandSet<Ctx> {
     /// [`Command::arg_choices`] / [`Command::arg_choices_ctx`] call so [`Self::toggle`]
     /// and [`Self::choice`] can stay infallible chainable builders.
     name_cache: std::cell::OnceCell<Vec<&'static str>>,
+    /// Optional bare-invocation handler. When set via [`Self::on_bare`], the
+    /// command's `run` calls it instead of returning the usage-block error when the
+    /// user types just the command name with no subcommand. Use for "primary toggle"
+    /// commands where bare invocation should flip a main field.
+    bare: Option<BareHandler<Ctx>>,
 }
 
 impl<Ctx: 'static> SubcommandSet<Ctx> {
     /// Register an on/off subcommand. The framework parses the value slot as
-    /// `on | off | true | false | 1 | 0`; the handler receives the parsed bool.
+    /// `on | off | true | false | 1 | 0` when present and passes `Some(bool)`; when
+    /// the user types just the subcommand name with no value, the handler is called
+    /// with `None` so it can flip the field in place.
+    ///
+    /// Idiomatic handler shape for a `bool` field:
+    ///
+    /// ```ignore
+    /// .toggle("axes", "toggle world-axes", |ctx, v| {
+    ///     ctx.show_axes = v.unwrap_or(!ctx.show_axes);
+    ///     Ok(())
+    /// })
+    /// ```
     pub fn toggle<F>(mut self, name: &'static str, help: &'static str, handler: F) -> Self
     where
-        F: FnMut(&mut Ctx, bool) -> anyhow::Result<()> + 'static,
+        F: FnMut(&mut Ctx, Option<bool>) -> anyhow::Result<()> + 'static,
     {
         self.subs.insert(
             name,
@@ -542,6 +575,29 @@ impl<Ctx: 'static> SubcommandSet<Ctx> {
         self
     }
 
+    /// Attach a bare-invocation handler. When set, typing just the command name
+    /// (no subcommand, no args) runs `handler` instead of returning a usage error.
+    /// Use for "primary toggle" commands where bare invocation should flip a main
+    /// field (e.g. `wireframe` toggles the overlay's main on/off, then
+    /// `wireframe nearest-active` and `wireframe color` modulate behavior).
+    ///
+    /// ```ignore
+    /// subcommands::<Ctx>("wireframe", "...")
+    ///     .on_bare(|ctx| {
+    ///         ctx.wireframe_enabled = !ctx.wireframe_enabled;
+    ///         Ok(())
+    ///     })
+    ///     .toggle("nearest-active", "...", |ctx, v| { ... })
+    ///     .choice("color", "...", &["position", "active"], |ctx, v| { ... })
+    /// ```
+    pub fn on_bare<F>(mut self, handler: F) -> Self
+    where
+        F: FnMut(&mut Ctx) -> anyhow::Result<()> + 'static,
+    {
+        self.bare = Some(Box::new(handler));
+        self
+    }
+
     fn cached_names(&self) -> &[&'static str] {
         self.name_cache
             .get_or_init(|| self.subs.keys().copied().collect())
@@ -556,6 +612,7 @@ pub fn subcommands<Ctx: 'static>(name: &'static str, help: &'static str) -> Subc
         help,
         subs: BTreeMap::new(),
         name_cache: std::cell::OnceCell::new(),
+        bare: None,
     }
 }
 
@@ -652,8 +709,11 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
 
     fn run(&mut self, args: &[&str], ctx: &mut Ctx, out: &mut ConsoleWriter) -> anyhow::Result<()> {
         let Some((sub_name, rest)) = args.split_first() else {
-            // Usage block lists subcommands with their one-line help so `tests` with no
-            // args is self-documenting instead of dumping a bare grammar.
+            // Bare invocation. If `on_bare` is registered, call it ("primary toggle"
+            // pattern); otherwise emit a usage block listing subcommands.
+            if let Some(handler) = self.bare.as_mut() {
+                return handler(ctx);
+            }
             let mut msg = format!("usage: {} <subcommand> <value>; subcommands:", self.name);
             for (name, entry) in &self.subs {
                 msg.push_str(&format!("\n  {name:12} {}", entry.help));
@@ -670,18 +730,21 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
         };
         match &mut entry.kind {
             SubcommandKind::Toggle { handler } => {
-                let value = rest
-                    .first()
-                    .ok_or_else(|| anyhow::anyhow!("usage: {} {sub_name} <on|off>", self.name))?;
-                let v = match value.to_ascii_lowercase().as_str() {
-                    "on" | "true" | "1" => true,
-                    "off" | "false" | "0" => false,
-                    other => {
-                        return Err(anyhow::anyhow!(
-                            "unknown value `{other}` for `{} {sub_name}` (try on|off)",
-                            self.name
-                        ))
-                    }
+                // Bare subcommand invocation (no value): hand `None` to the handler so
+                // it can flip its field. With a value: parse `on|off|true|false|1|0`
+                // and pass `Some(bool)`.
+                let v: Option<bool> = match rest.first() {
+                    None => None,
+                    Some(value) => match value.to_ascii_lowercase().as_str() {
+                        "on" | "true" | "1" => Some(true),
+                        "off" | "false" | "0" => Some(false),
+                        other => {
+                            return Err(anyhow::anyhow!(
+                                "unknown value `{other}` for `{} {sub_name}` (try on|off)",
+                                self.name
+                            ))
+                        }
+                    },
                 };
                 let _ = out;
                 handler(ctx, v)
@@ -1954,13 +2017,16 @@ mod tests {
     fn sample_subset() -> SubcommandSet<SubCtx> {
         subcommands::<SubCtx>("tests", "umbrella")
             .toggle("axes", "toggle axes", |c, v| {
-                c.0 = if v { 1 } else { 0 };
-                c.1 = format!("axes={v}");
+                // Bare invocation flips between 1 and 0; explicit on|off sets directly.
+                let on = v.unwrap_or(c.0 != 1);
+                c.0 = if on { 1 } else { 0 };
+                c.1 = format!("axes={on}");
                 Ok(())
             })
             .toggle("cube", "toggle cube", |c, v| {
-                c.0 = if v { 2 } else { 0 };
-                c.1 = format!("cube={v}");
+                let on = v.unwrap_or(c.0 != 2);
+                c.0 = if on { 2 } else { 0 };
+                c.1 = format!("cube={on}");
                 Ok(())
             })
             .choice(
@@ -2020,15 +2086,62 @@ mod tests {
         );
     }
 
+    /// Bare toggle invocation (no value) is a flip. The handler receives `None` and
+    /// is expected to invert the current field state. Verifies the
+    /// "`wireframe nearest-active` flips without explicit on|off" UX path the demos
+    /// rely on.
     #[test]
-    fn subcommand_missing_value_errors() {
+    fn subcommand_toggle_bare_invocation_flips() {
         let mut con = Console::<SubCtx>::new();
         con.register(sample_subset());
         let mut ctx: SubCtx = (0, String::new());
+        // First bare invocation: 0 != 1 -> on.
         con.execute("tests axes", &mut ctx);
+        assert_eq!(ctx, (1, "axes=true".into()));
+        // Second bare invocation: 1 == 1 -> off.
+        con.execute("tests axes", &mut ctx);
+        assert_eq!(ctx, (0, "axes=false".into()));
+    }
+
+    /// Choice subcommand still requires a value (no cycle-on-bare equivalent yet).
+    /// Pins the contract so a future cycle-on-bare extension updates this test.
+    #[test]
+    fn subcommand_choice_missing_value_errors() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset());
+        let mut ctx: SubCtx = (0, String::new());
+        con.execute("tests polytope", &mut ctx);
         let last = con.history.back().unwrap();
         assert_eq!(last.kind, LineKind::Error);
         assert!(last.text.contains("usage"), "got: {}", last.text);
+    }
+
+    /// Bare `SubcommandSet` invocation (no subcommand) calls the registered
+    /// `on_bare` handler instead of returning a usage-block error. Verifies the
+    /// "`wireframe` flips main on/off" UX path.
+    #[test]
+    fn subcommand_bare_runs_on_bare_handler() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset().on_bare(|c| {
+            c.1 = "bare!".into();
+            Ok(())
+        }));
+        let mut ctx: SubCtx = (0, String::new());
+        con.execute("tests", &mut ctx);
+        assert_eq!(ctx.1, "bare!");
+    }
+
+    /// Without `on_bare`, bare `SubcommandSet` invocation falls back to the usage
+    /// block (the historical behavior).
+    #[test]
+    fn subcommand_bare_without_handler_emits_usage() {
+        let mut con = Console::<SubCtx>::new();
+        con.register(sample_subset());
+        let mut ctx: SubCtx = (0, String::new());
+        con.execute("tests", &mut ctx);
+        let last = con.history.back().unwrap();
+        assert_eq!(last.kind, LineKind::Error);
+        assert!(last.text.contains("subcommands"), "got: {}", last.text);
     }
 
     /// Tab completion at the value slot narrows to ONLY the chosen subcommand's choices.

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -147,8 +147,22 @@ pub trait Command<Ctx>: 'static {
     /// (`capture.start`).
     fn name(&self) -> &str;
 
-    /// One-line description shown by `help`.
+    /// One-line description shown by `help` (no argument) when listing every command.
+    /// Conventionally <= ~60 chars so the listing fits in a single console row.
     fn help(&self) -> &str;
+
+    /// Multi-line help shown by `help <name>` for a specific command. Default returns
+    /// just the one-line [`Self::help`] string -- override when the command's surface
+    /// is richer than fits one line (multiple subcommands, multi-step usage examples,
+    /// arg-by-arg explanations).
+    ///
+    /// `\n` line breaks are honored; the panel paints each line into the scrollback as
+    /// its own entry so word-wrap and scroll behavior stay consistent with the rest of
+    /// the console. Returns owned `String` so subcommand-dispatching commands can build
+    /// the listing dynamically from their registered children without storing a static.
+    fn long_help(&self) -> String {
+        self.help().to_string()
+    }
 
     /// Tab-completion choices for the `arg_index`-th positional argument, without
     /// awareness of values typed in prior slots. Default is empty (no completion /
@@ -215,6 +229,9 @@ pub trait Command<Ctx>: 'static {
 pub struct FnCommand<F> {
     name: &'static str,
     help: &'static str,
+    /// Optional multi-line text returned by [`Command::long_help`] when set. When `None`,
+    /// `long_help` falls back to repeating `help`. Set via [`FnCommand::with_long_help`].
+    long_help: Option<&'static str>,
     arg_choices: Vec<Vec<&'static str>>,
     /// Per-key value choices for `key=value` args, applied across every arg
     /// position the key appears at. Keyed by the bare key name (no `=`).
@@ -253,6 +270,28 @@ impl<F> FnCommand<F> {
         self.value_choices.insert(key, values.to_vec());
         self
     }
+
+    /// Attach a multi-line help block returned by [`Command::long_help`]. Newlines are
+    /// honored; the console paints each line as its own scrollback entry so wrapping +
+    /// scroll behavior stay consistent. Use for commands whose surface (multiple
+    /// subcommand-style args, usage examples) doesn't fit one line.
+    ///
+    /// ```ignore
+    /// cmd("wireframe", "wireframe overlay (see help)", handler)
+    ///     .with_args(&[&["on", "off", "nearest-active"], &["on", "off"]])
+    ///     .with_long_help(
+    ///         "Cross-section + parent-wireframe overlay.\n\
+    ///          \n\
+    ///          subcommands:\n  \
+    ///          on              enable the overlay\n  \
+    ///          off             disable\n  \
+    ///          nearest-active  toggle the per-cell brightness gradient",
+    ///     )
+    /// ```
+    pub fn with_long_help(mut self, long: &'static str) -> Self {
+        self.long_help = Some(long);
+        self
+    }
 }
 
 /// Build a [`Command`] from a closure. The closure mutates a `Ctx` and writes lines
@@ -273,6 +312,7 @@ where
     FnCommand {
         name,
         help,
+        long_help: None,
         arg_choices: Vec::new(),
         value_choices: HashMap::new(),
         f,
@@ -288,6 +328,11 @@ where
     }
     fn help(&self) -> &str {
         self.help
+    }
+    fn long_help(&self) -> String {
+        self.long_help
+            .map(str::to_string)
+            .unwrap_or_else(|| self.help.to_string())
     }
     fn arg_choices(&self, arg_index: usize) -> &[&'static str] {
         self.arg_choices
@@ -520,6 +565,26 @@ impl<Ctx: 'static> Command<Ctx> for SubcommandSet<Ctx> {
     }
     fn help(&self) -> &str {
         self.help
+    }
+
+    fn long_help(&self) -> String {
+        // First line is the umbrella's one-liner; subsequent lines list every
+        // registered subcommand with its description. `help <set-name>` then reads as a
+        // mini-manual page for the whole subcommand family.
+        let mut out = String::with_capacity(128 + self.subs.len() * 64);
+        out.push_str(self.help);
+        if !self.subs.is_empty() {
+            out.push_str("\nsubcommands:");
+            for (name, entry) in &self.subs {
+                let kind = match entry.kind {
+                    SubcommandKind::Toggle { .. } => "<on|off>",
+                    SubcommandKind::Choice { .. } => "<choice>",
+                    SubcommandKind::Custom { .. } => "<args...>",
+                };
+                out.push_str(&format!("\n  {name:14} {kind:9}  {}", entry.help));
+            }
+        }
+        out
     }
 
     fn arg_choices(&self, arg_index: usize) -> &[&'static str] {
@@ -1234,11 +1299,32 @@ impl<Ctx: 'static> Console<Ctx> {
         match target {
             Some(name) => {
                 if let Some(b) = Builtin::from_name(name) {
+                    // Built-ins only have one-line descriptions; no multi-line variant.
                     self.push_history(HistoryLine::output(format!("{}: {}", b.name(), b.help())));
-                } else if let Some(c) = self.commands.get(name) {
-                    self.push_history(HistoryLine::output(format!("{}: {}", c.name(), c.help())));
                 } else {
-                    self.push_history(HistoryLine::error(format!("no command '{name}'")));
+                    // Materialize the help lines BEFORE pushing to history: `c` borrows
+                    // `self.commands` immutably and `push_history` borrows `self` mutably,
+                    // so the two can't coexist.
+                    let prepared: Option<(String, Vec<String>)> =
+                        self.commands.get(name).map(|c| {
+                            let header_prefix = format!("{}: ", c.name());
+                            let body = c.long_help();
+                            let indent = " ".repeat(c.name().len() + 2);
+                            let mut lines = body.lines();
+                            let first = lines.next().unwrap_or("");
+                            let mut rendered = vec![format!("{header_prefix}{first}")];
+                            for line in lines {
+                                rendered.push(format!("{indent}{line}"));
+                            }
+                            (c.name().to_string(), rendered)
+                        });
+                    if let Some((_name, lines)) = prepared {
+                        for line in lines {
+                            self.push_history(HistoryLine::output(line));
+                        }
+                    } else {
+                        self.push_history(HistoryLine::error(format!("no command '{name}'")));
+                    }
                 }
             }
             None => {

--- a/crates/rye-egui/src/console/panel.rs
+++ b/crates/rye-egui/src/console/panel.rs
@@ -28,7 +28,8 @@
 //! frame), so the user can click outside the window to give keyboard back to the app.
 
 use egui::{
-    Color32, FontId, Frame, Layout, Margin, Order, RichText, ScrollArea, Sense, Stroke, TextEdit,
+    Color32, FontId, Frame, Label, Layout, Margin, Order, RichText, ScrollArea, Sense, Stroke,
+    TextEdit, TextWrapMode,
 };
 
 use super::{Console, HistoryLine, LineKind, PANEL_HEIGHT_FRACTION};
@@ -229,6 +230,28 @@ fn draw_separator(ui: &mut egui::Ui, width: f32) {
 }
 
 fn draw_scrollback<Ctx>(ui: &mut egui::Ui, console: &Console<Ctx>, height: f32, width: f32) {
+    // Word-wrap design notes (engine-wide, not console-internal):
+    //
+    // The previous layout wrapped each `HistoryLine` in `ui.horizontal()`, which sets an
+    // unbounded horizontal area; egui's `Label` wrap heuristic then gives up because
+    // there's no constraint to wrap against. The fix is twofold:
+    //
+    // 1. Drop `ui.horizontal()`. The label goes directly into the (vertical) ScrollArea
+    //    so it inherits the ScrollArea's content width.
+    // 2. Set the label's wrap mode explicitly to [`TextWrapMode::Wrap`]. Default mode
+    //    elides with `...` instead of wrapping; we want hard wrap.
+    //
+    // Side padding (the 8px gutter that used to come from `add_space`) now comes from a
+    // [`Frame::inner_margin`] so the wrap-width calculation correctly accounts for it:
+    // padding inside the constraint, not outside. Each line still renders as one logical
+    // history entry; when text spans multiple visual rows, all wrapped rows belong to the
+    // same scrollback entry so navigation + selection behave correctly.
+    //
+    // Continuation-line hanging indent is intentionally NOT added: with proportional
+    // monospace it's hard to pick a visually distinguishing indent without breaking
+    // copy-paste of code blocks. If the readability becomes a problem in practice the
+    // right fix is CPU-side soft-wrap into `LayoutSection`s, not a hanging-indent
+    // post-process.
     ui.allocate_ui_with_layout(
         egui::vec2(width, height),
         Layout::top_down(egui::Align::Min),
@@ -238,14 +261,21 @@ fn draw_scrollback<Ctx>(ui: &mut egui::Ui, console: &Console<Ctx>, height: f32, 
                 .stick_to_bottom(true)
                 .max_height(height)
                 .show(ui, |ui| {
-                    ui.add_space(4.0);
-                    for line in &console.history {
-                        ui.horizontal(|ui| {
-                            ui.add_space(8.0);
-                            ui.label(line_text(line));
+                    Frame::new()
+                        .inner_margin(Margin {
+                            left: 8,
+                            right: 8,
+                            top: 4,
+                            bottom: 4,
+                        })
+                        .show(ui, |ui| {
+                            // Tight per-line vertical spacing keeps the scrollback
+                            // dense without crowding wrapped continuation rows.
+                            ui.spacing_mut().item_spacing.y = 2.0;
+                            for line in &console.history {
+                                ui.add(Label::new(line_text(line)).wrap_mode(TextWrapMode::Wrap));
+                            }
                         });
-                    }
-                    ui.add_space(4.0);
                 });
         },
     );

--- a/crates/rye-math/src/lib.rs
+++ b/crates/rye-math/src/lib.rs
@@ -30,6 +30,7 @@ pub mod euclidean_r2;
 pub mod euclidean_r4;
 pub mod hyperbolic;
 pub mod rasterizable;
+pub mod sectionable;
 pub mod space;
 pub mod spherical;
 pub mod tangent;
@@ -43,6 +44,9 @@ pub use euclidean_r2::{EuclideanR2, Iso2};
 pub use euclidean_r4::{EuclideanR4, Iso4Flat};
 pub use hyperbolic::{HyperbolicH3, Iso3H};
 pub use rasterizable::{Projection, RasterizableSpace};
+pub use sectionable::{
+    SectionableSpace, WPlane, EDGE_PARALLEL_EPSILON, SLICE_PERTURBATION_EPSILON,
+};
 pub use space::{Space, WgslSpace};
 pub use spherical::{Iso4, SphericalS3};
 pub use tangent::Tangent;

--- a/crates/rye-math/src/sectionable.rs
+++ b/crates/rye-math/src/sectionable.rs
@@ -139,8 +139,7 @@ mod tests {
         let slice = WPlane::new(0.0);
         let p0 = Vec4::new(1.0, 2.0, 3.0, -1.0);
         let p1 = Vec4::new(5.0, 6.0, 7.0, 1.0);
-        let (t, p3) =
-            <EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, p0, p1).unwrap();
+        let (t, p3) = <EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, p0, p1).unwrap();
         assert!((t - 0.5).abs() < 1e-6);
         assert_eq!(p3, Vec3::new(3.0, 4.0, 5.0));
     }
@@ -173,8 +172,7 @@ mod tests {
         let slice = WPlane::new(0.0);
         let p0 = Vec4::new(2.0, 2.0, 2.0, 0.0);
         let p1 = Vec4::new(5.0, 5.0, 5.0, 1.0);
-        let (t, p3) =
-            <EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, p0, p1).unwrap();
+        let (t, p3) = <EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, p0, p1).unwrap();
         assert!(t.abs() < 1e-6);
         assert_eq!(p3, Vec3::new(2.0, 2.0, 2.0));
     }

--- a/crates/rye-math/src/sectionable.rs
+++ b/crates/rye-math/src/sectionable.rs
@@ -1,0 +1,204 @@
+//! [`SectionableSpace<N>`] trait + axis-aligned hyperplane types + flat-Euclidean impls.
+//!
+//! A cross-section is the geometry "an inhabitant at the slice would actually see": the
+//! `N`-dimensional space's intersection with a hyperplane, expressed in the `(N-1)`-
+//! dimensional space of the slice. This is the load-bearing primitive for the 4D throughline
+//! demos -- slicing R⁴ into R³ exposes a dimension the viewer can't directly perceive.
+//!
+//! ## Why a Space-level trait, not a polytope helper
+//!
+//! Cross-section is the same conceptual operation regardless of what's being sliced. The
+//! polytope cross-section we ship first is one consumer; future curved-space and
+//! BlendedSpace cross-sections share the algorithm above [`SectionableSpace::edge_section`]
+//! (cap-polygon assembly, plane fit, fan triangulation are all space-agnostic). The trait
+//! shape mirrors [`crate::rasterizable::RasterizableSpace`]: the flat-vs-curved distinction
+//! lives in a single method.
+//!
+//! ## Hyperplane representation
+//!
+//! For flat R⁴ at v1 we use an axis-aligned `w`-slice ([`WPlane`]): the simplest case, which
+//! is also what the rotate_polytopes demo sweeps. Arbitrary-normal hyperplanes for R⁴ and
+//! geodesic hyperplanes for curved spaces are additive extensions; the trait has no
+//! commitment to a specific hyperplane geometry beyond `type Hyperplane`.
+//!
+//! ## Numerical care
+//!
+//! [`SectionableSpace::edge_section`] uses an FMA-friendly lerp ordering and rejects edges
+//! whose endpoints are too close to the slice plane to give a numerically stable intersection
+//! ([`EDGE_PARALLEL_EPSILON`]). Callers handling the surrounding cell-assembly algorithm
+//! perturb the slice value when any polytope vertex sits within [`SLICE_PERTURBATION_EPSILON`]
+//! of it; that single perturbation kills three degeneracies at once (vertex on slice, edge in
+//! slice plane, slice grazes a face).
+
+use glam::{Vec3, Vec4};
+
+use crate::space::Space;
+use crate::EuclideanR4;
+
+/// Smallest `|dw|` between an edge's endpoints for which [`SectionableSpace::edge_section`]
+/// will return an intersection. Edges with smaller dw are treated as parallel to the slice
+/// hyperplane (so the intersection is either the whole edge or empty, both handled by the
+/// cell-assembly caller rather than by returning a single point).
+///
+/// Chosen to be larger than the f32 roundoff on a unit-circumradius `dw` computation
+/// (~1e-7) by a 10x margin. See `SLICE_PERTURBATION_EPSILON` for the dual epsilon used by
+/// the caller's slice perturbation.
+pub const EDGE_PARALLEL_EPSILON: f32 = 1e-6;
+
+/// Recommended `epsilon` for slice perturbation: when any polytope vertex's slice-axis
+/// coordinate sits within this value of the slice, the caller (cell-assembly algorithm)
+/// shifts the slice by this amount to avoid degenerate cases. A single perturbation kills
+/// three degeneracies at once: vertex on slice, edge in slice plane, slice grazes a face.
+pub const SLICE_PERTURBATION_EPSILON: f32 = 1e-5;
+
+/// Axis-aligned w-slice hyperplane for R⁴ (the standard 4D demo case). Encodes "the
+/// 3-flat where `w = w_slice`." A newtype rather than a bare `f32` so future hyperplane
+/// variants (arbitrary normal, geodesic) extend the same trait without breaking the
+/// `type Hyperplane` boundary.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WPlane {
+    pub w_slice: f32,
+}
+
+impl WPlane {
+    pub const fn new(w_slice: f32) -> Self {
+        Self { w_slice }
+    }
+}
+
+/// A Space whose inhabitants live in `N` dimensions and which supports taking a
+/// cross-section: an `(N - 1)`-dimensional Space containing the intersection geometry of
+/// the parent with a hyperplane.
+///
+/// `N` is the const-generic ambient dimension, matching the
+/// [`crate::rasterizable::RasterizableSpace`] convention. The associated `SectionSpace` is
+/// the Space the section *lives in* (its
+/// `Point` type is the cap-vertex coordinate type used by the cell-assembly algorithm).
+/// The associated `Hyperplane` lets curved-space impls carry the extra structure
+/// (geodesic basis) that a flat-space `(point, normal)` pair doesn't need.
+pub trait SectionableSpace<const N: usize>: Space {
+    /// The `(N - 1)`-dimensional Space the section lives in. For flat R⁴, this is
+    /// [`crate::EuclideanR3`]. For S³, it would be [`crate::SphericalS3`]-restricted-to-a-
+    /// great-2-sphere, which is `SphericalS2` (a future addition).
+    type SectionSpace: Space;
+
+    /// Hyperplane identifier. Flat spaces use simple variants like [`WPlane`] (axis-aligned)
+    /// or a future `(point, normal)` pair; curved spaces will use geodesic-hyperplane
+    /// descriptors (point on the parent + tangent basis spanning the slice).
+    type Hyperplane;
+
+    /// Intersect a geodesic edge `(p0, p1)` with `slice`. Returns the lerp parameter
+    /// `t in [0, 1]` and the intersection point expressed in [`Self::SectionSpace`], or
+    /// `None` if the edge does not cross the slice or is parallel to it within
+    /// [`EDGE_PARALLEL_EPSILON`].
+    ///
+    /// For flat spaces this is a linear solve. For curved spaces it walks the geodesic from
+    /// `p0` to `p1` and bisects on side-of-slice; closed-form solves exist for the standard
+    /// chart parameterizations of S³ and H³.
+    fn edge_section(
+        slice: &Self::Hyperplane,
+        p0: Self::Point,
+        p1: Self::Point,
+    ) -> Option<(f32, <Self::SectionSpace as Space>::Point)>;
+}
+
+impl SectionableSpace<4> for EuclideanR4 {
+    type SectionSpace = crate::EuclideanR3;
+    type Hyperplane = WPlane;
+
+    fn edge_section(slice: &WPlane, p0: Vec4, p1: Vec4) -> Option<(f32, Vec3)> {
+        let dw = p1.w - p0.w;
+        // Edge parallel to the w-slice (within roundoff): the intersection is either the
+        // whole edge or empty. Both are degenerate from this method's "single point" point
+        // of view; the cell-assembly caller handles them by perturbing the slice (per
+        // SLICE_PERTURBATION_EPSILON) before the per-edge loop.
+        if dw.abs() < EDGE_PARALLEL_EPSILON {
+            return None;
+        }
+        let t = (slice.w_slice - p0.w) / dw;
+        // Strictly inside the edge. `<` rather than `<=` at the boundaries prevents
+        // double-counting at shared cell vertices when the slice grazes a vertex's w.
+        if !(0.0..=1.0).contains(&t) {
+            return None;
+        }
+        // FMA-friendly lerp ordering: `p0 + t * (p1 - p0)` preserves precision when t is
+        // near 0 or 1, vs. the algebraically equivalent `(1 - t) * p0 + t * p1`.
+        let p = p0 + t * (p1 - p0);
+        Some((t, Vec3::new(p.x, p.y, p.z)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Edge straddling w = 0 yields the lerp midpoint when endpoints have equal-magnitude
+    /// opposite w. Sanity check on both the t value and the dropped-w R³ coordinate.
+    #[test]
+    fn r4_edge_section_midpoint() {
+        let slice = WPlane::new(0.0);
+        let p0 = Vec4::new(1.0, 2.0, 3.0, -1.0);
+        let p1 = Vec4::new(5.0, 6.0, 7.0, 1.0);
+        let (t, p3) =
+            <EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, p0, p1).unwrap();
+        assert!((t - 0.5).abs() < 1e-6);
+        assert_eq!(p3, Vec3::new(3.0, 4.0, 5.0));
+    }
+
+    /// Edge with both endpoints on the same side of the slice returns `None`.
+    #[test]
+    fn r4_edge_section_no_crossing_returns_none() {
+        let slice = WPlane::new(0.0);
+        let p0 = Vec4::new(0.0, 0.0, 0.0, 0.5);
+        let p1 = Vec4::new(0.0, 0.0, 0.0, 1.5);
+        assert!(<EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, p0, p1).is_none());
+    }
+
+    /// Edge parallel to the slice (both endpoints share w within the parallel epsilon)
+    /// returns `None`; the cell-assembly caller handles the whole-edge-in-plane case by
+    /// perturbing the slice.
+    #[test]
+    fn r4_edge_section_parallel_edge_returns_none() {
+        let slice = WPlane::new(0.0);
+        let p0 = Vec4::new(0.0, 0.0, 0.0, 0.0);
+        let p1 = Vec4::new(1.0, 1.0, 1.0, 1e-7);
+        assert!(<EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, p0, p1).is_none());
+    }
+
+    /// Edge whose first endpoint sits exactly on the slice returns `t = 0` and the
+    /// endpoint's R³ coordinates. The cell-assembly caller is expected to perturb the
+    /// slice to avoid this boundary, but `edge_section` itself doesn't reject it.
+    #[test]
+    fn r4_edge_section_endpoint_on_slice_returns_t_zero() {
+        let slice = WPlane::new(0.0);
+        let p0 = Vec4::new(2.0, 2.0, 2.0, 0.0);
+        let p1 = Vec4::new(5.0, 5.0, 5.0, 1.0);
+        let (t, p3) =
+            <EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, p0, p1).unwrap();
+        assert!(t.abs() < 1e-6);
+        assert_eq!(p3, Vec3::new(2.0, 2.0, 2.0));
+    }
+
+    /// 5-cell midpoint slice fixture: one apex edge crosses the w=0 hyperplane at lerp
+    /// parameter t = 0.8 (solves `1 + t * -1.25 = 0` for the standard apex w=1, base w=-0.25
+    /// pentatope generators) and the R³ intersection is at `0.8 * v_i` where `v_i` is the
+    /// base vertex's R³ coords. Matches Coxeter's classical result for the pentatope's
+    /// midpoint cross-section being a regular tetrahedron.
+    #[test]
+    fn r4_edge_section_matches_pentatope_midpoint_worked_example() {
+        let slice = WPlane::new(0.0);
+        // Apex v0 = (0, 0, 0, 1); base vertex v1 = (t, t, t, -0.25) with t = sqrt(15)/(4*sqrt(3)).
+        let t_base = (15.0f32).sqrt() / (4.0 * (3.0f32).sqrt());
+        let apex = Vec4::new(0.0, 0.0, 0.0, 1.0);
+        let v1 = Vec4::new(t_base, t_base, t_base, -0.25);
+        let (t, p3) = <EuclideanR4 as SectionableSpace<4>>::edge_section(&slice, apex, v1)
+            .expect("apex edge straddles w = 0");
+        // Lerp parameter solves 1 + t*(-1.25) = 0 -> t = 0.8.
+        assert!((t - 0.8).abs() < 1e-6);
+        // Intersection point P1 = (0.8 * t_base, 0.8 * t_base, 0.8 * t_base).
+        let expected = 0.8 * t_base;
+        assert!((p3.x - expected).abs() < 1e-5);
+        assert!((p3.y - expected).abs() < 1e-5);
+        assert!((p3.z - expected).abs() < 1e-5);
+    }
+}

--- a/crates/rye-math/src/sectionable.rs
+++ b/crates/rye-math/src/sectionable.rs
@@ -116,8 +116,12 @@ impl SectionableSpace<4> for EuclideanR4 {
             return None;
         }
         let t = (slice.w_slice - p0.w) / dw;
-        // Strictly inside the edge. `<` rather than `<=` at the boundaries prevents
-        // double-counting at shared cell vertices when the slice grazes a vertex's w.
+        // Closed `[0, 1]` interval: an endpoint exactly on the slice (t = 0 or t = 1)
+        // counts as an intersection at that endpoint's R³ coordinates. The cell-
+        // assembly caller's `SLICE_PERTURBATION_EPSILON` shift moves the slice off
+        // any polytope vertex before this method is called, so the endpoint case is
+        // primarily reached by callers who skip perturbation; it is exercised by
+        // [`r4_edge_section_endpoint_on_slice_returns_t_zero`].
         if !(0.0..=1.0).contains(&t) {
             return None;
         }

--- a/crates/rye-physics/src/euclidean_r4.rs
+++ b/crates/rye-physics/src/euclidean_r4.rs
@@ -794,6 +794,13 @@ pub fn icosian_inradius_unit() -> f32 {
 /// - `offset`: the inradius (uniform across all face planes for a regular polytope).
 ///
 /// A point `p` is inside the 120-cell iff `dot(n_i, p) <= offset` for all 120 normals.
+// BUG: the dual-vertex normals are exact for the 24 axial + 16 tesseract-corner orbits but only
+// approximate for the 96 golden-ratio orbits, so the SDF surface here is a slightly-truncated
+// 120-cell. The mismatch is visible when the section-perimeter wireframe is overlaid on the SDF.
+// A previous attempt to substitute topology-derived face normals triggered a wgpu/naga device
+// error in the raymarch pipeline and was reverted. Forward path: render filled cross-section
+// triangles via the rasterizer and stop relying on the SDF for surface visualization of this
+// polytope.
 pub fn cell120_face_planes() -> (Vec<Vec4>, f32) {
     (cell600_vertices(1.0), icosian_inradius_unit())
 }
@@ -802,6 +809,10 @@ pub fn cell120_face_planes() -> (Vec<Vec4>, f32) {
 ///
 /// Returns `(normals, offset)` where `normals` are the 600 unit-length face-direction vectors.
 /// These are the 120-cell's vertices, already unit-length when generated at circumradius 1.
+// BUG: same approximation as `cell120_face_planes`. The 600-cell's true face normals are the
+// 600 cell centroids of its tetrahedral cells, not the 120-cell's vertex set; the two coincide
+// on the axial/tesseract orbits and diverge on the 96 golden-ratio orbits. Same forward path:
+// rasterized section faces will replace the SDF surface for this polytope.
 pub fn cell600_face_planes() -> (Vec<Vec4>, f32) {
     (cell120_vertices(1.0), icosian_inradius_unit())
 }

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -140,6 +140,45 @@ impl Polytope4 {
     pub fn cell_count(self) -> usize {
         self.topology().cells.len()
     }
+
+    /// Face hyperplanes derived from cell topology. For each cell, the cell centroid (mean
+    /// of its vertices, in 4D) lies along the polytope's outward radial direction at that
+    /// face; normalizing gives the unit face normal, and the centroid's length is the
+    /// inradius (constant across all cells of a regular polytope).
+    ///
+    /// Returns `(normals, inradius)` matching the shape of the existing
+    /// [`crate::euclidean_r4::cell120_face_planes`] / [`crate::euclidean_r4::cell600_face_planes`]
+    /// helpers. Use with [`crate::euclidean_r4::polytope_sdf_wolfe`] to compute an exact SDF
+    /// for any regular convex 4-polytope.
+    ///
+    /// **Difference from the existing `cell{120,600}_face_planes` helpers.** Those use the
+    /// *dual polytope's vertex set* as face normals, which is exact for the 24 axial + 16
+    /// tesseract-corner orbits but approximate for the 96 golden-ratio orbits (the documented
+    /// BUG). This method derives normals from cell topology directly, so it's exact for every
+    /// cell of every regular convex 4-polytope. The pre-existing helpers remain available for
+    /// backward compatibility with the raymarch kernel's `polytope_extended_sdfs_wgsl`, which
+    /// embeds the BUGgy vertex tables; this method is the version to use for correctness.
+    pub fn face_planes(self) -> (Vec<Vec4>, f32) {
+        let topo = self.topology();
+        let mut normals = Vec::with_capacity(topo.cells.len());
+        let mut inradius_sum = 0.0;
+        for cell in topo.cells {
+            let centroid: Vec4 = cell
+                .iter()
+                .map(|&i| topo.vertices[i as usize])
+                .sum::<Vec4>()
+                / cell.len() as f32;
+            let r = centroid.length();
+            // Centroid magnitude is the cell's inradius; the centroid direction is the outward
+            // face normal. For a regular polytope all cell centroids share the same magnitude
+            // (up to f32 noise); we average across all cells to absorb that noise rather than
+            // read it off the first cell.
+            normals.push(centroid / r);
+            inradius_sum += r;
+        }
+        let inradius = inradius_sum / normals.len() as f32;
+        (normals, inradius)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -282,9 +321,13 @@ const SECTION_FILL_COLOR: [f32; 4] = [1.0, 1.0, 1.0, 0.55];
 const SECTION_EDGE_COLOR: [f32; 4] = [0.30, 0.85, 0.95, 1.0];
 const SECTION_EDGE_WIDTH: f32 = 2.0;
 
-/// Per-cell cross-section assembly. Intersects the 4-polytope's cells with the w-slice
-/// hyperplane, producing the section as a pair (filled triangles, perimeter edges) ready to
-/// hand to `rye-render`'s `TriangleRasterNode` + `LineRasterNode`.
+/// Per-cell cross-section assembly returning the overlay-shaped pair `(translucent
+/// fill triangles, bright cyan perimeter edges)`. Use when the section is rendered
+/// *on top of* an existing surface (the SDF raymarch, a parent wireframe) and you want
+/// the cap interiors visible-through and their boundaries outlined.
+///
+/// For replacing the polychoral SDF surface entirely with rasterized geometry, use
+/// [`polytope4_section_faces`] instead: opaque, solid-colored, no perimeter edges.
 ///
 /// Algorithm:
 ///
@@ -307,25 +350,25 @@ const SECTION_EDGE_WIDTH: f32 = 2.0;
 ///
 /// Returns `(triangles, perimeter)`. Either may be empty if the slice doesn't cross the
 /// polytope at all.
-pub fn polytope4_section(
+pub fn polytope4_section_overlay(
     polytope: Polytope4,
     slice: rye_math::WPlane,
 ) -> (rye_shape::TriangleMesh<3>, rye_shape::LineMesh<3>) {
     let topo = polytope.topology();
-    polytope_section_with_vertices(topo.edges, topo.cells, topo.vertices, slice)
+    polytope_section_overlay_with_vertices(topo.edges, topo.cells, topo.vertices, slice)
 }
 
-/// Lower-level cross-section assembly that takes vertices, edges, and cells directly. Use
-/// this when the polytope's vertices have been transformed (rigid-body rotation, world-space
-/// placement, animated 4D rotation) before sectioning -- the canonical [`polytope4_section`]
-/// reads vertices from [`Polytope4::topology`] and isn't aware of any transform applied
-/// after.
+/// Lower-level overlay-shape cross-section assembly that takes vertices, edges, and cells
+/// directly. Use this when the polytope's vertices have been transformed (rigid-body
+/// rotation, world-space placement, animated 4D rotation) before sectioning -- the
+/// canonical [`polytope4_section_overlay`] reads vertices from [`Polytope4::topology`] and
+/// isn't aware of any transform applied after.
 ///
 /// The vertex set must remain index-compatible with `edges` and `cells`: each `edges[i]`
 /// pair indexes into `vertices`, and each `cells[i]` is a vertex-index list. Topology shape
 /// (edges, cells) is unchanged by rigid transforms, so callers reuse the parent polytope's
 /// topology arrays and substitute only the vertex set.
-pub fn polytope_section_with_vertices(
+pub fn polytope_section_overlay_with_vertices(
     edges: &[[u32; 2]],
     cells: &[&[u32]],
     vertices: &[Vec4],
@@ -373,7 +416,7 @@ pub fn polytope_section_with_vertices(
 /// the *primary* surface representation for a polychoral body at a w-slice, replacing
 /// the SDF raymarch for the six regular convex 4-polytopes.
 ///
-/// Differs from [`polytope_section_with_vertices`] in two ways:
+/// Differs from [`polytope_section_overlay_with_vertices`] in two ways:
 ///
 /// - Returns only the [`rye_shape::TriangleMesh<3>`]; the caller composes perimeter
 ///   edges separately (typically via the wireframe overlay).
@@ -402,29 +445,47 @@ pub fn polytope_section_faces_with_vertices(
     color: [f32; 4],
 ) -> rye_shape::TriangleMesh<3> {
     let mut tri_mesh = rye_shape::TriangleMesh::<3>::default();
+    polytope_section_faces_append(edges, cells, vertices, slice, color, &mut tri_mesh);
+    tri_mesh
+}
 
+/// Append-flavored variant of [`polytope_section_faces_with_vertices`]: writes into a
+/// caller-owned [`rye_shape::TriangleMesh<3>`], offsetting indices by the existing
+/// vertex count so multiple bodies can be merged into a single upload buffer without
+/// per-body heap allocations. Use this on per-frame render hot paths where the same
+/// scratch mesh is reused frame-over-frame; use [`polytope_section_faces_with_vertices`]
+/// for one-shot callers that want a fresh mesh.
+///
+/// Behavior is otherwise identical: same slice perturbation, same cell pruning, same
+/// fan triangulation, same color assignment. Concretely, calling this function on an
+/// empty mesh is equivalent to calling the non-append variant.
+pub fn polytope_section_faces_append(
+    edges: &[[u32; 2]],
+    cells: &[&[u32]],
+    vertices: &[Vec4],
+    slice: rye_math::WPlane,
+    color: [f32; 4],
+    out: &mut rye_shape::TriangleMesh<3>,
+) {
     for_each_section_cap(edges, cells, vertices, slice, |ordered, centroid| {
-        let cv_base = tri_mesh.vertices.len() as u32;
-        tri_mesh.vertices.push(centroid.to_array());
-        tri_mesh.colors.push(color);
+        let cv_base = out.vertices.len() as u32;
+        out.vertices.push(centroid.to_array());
+        out.colors.push(color);
         for cap_v in ordered {
-            tri_mesh.vertices.push(cap_v.to_array());
-            tri_mesh.colors.push(color);
+            out.vertices.push(cap_v.to_array());
+            out.colors.push(color);
         }
         let n = ordered.len() as u32;
         for k in 0..n {
             let k_next = (k + 1) % n;
-            tri_mesh
-                .indices
+            out.indices
                 .push([cv_base, cv_base + 1 + k, cv_base + 1 + k_next]);
         }
     });
-
-    tri_mesh
 }
 
 /// Canonical-vertex convenience: section faces using the polytope's own topology
-/// vertices (unrotated, unit circumradius). Mirrors [`polytope4_section`] but returns
+/// vertices (unrotated, unit circumradius). Mirrors [`polytope4_section_overlay`] but returns
 /// just the solid-colored opaque triangle mesh suitable for replacing the SDF surface.
 pub fn polytope4_section_faces(
     polytope: Polytope4,
@@ -446,7 +507,7 @@ pub fn polytope4_section_faces(
 /// frames.
 ///
 /// Algorithm details captured here in one place so the two public consumers
-/// ([`polytope_section_with_vertices`] for overlays, [`polytope_section_faces_with_vertices`]
+/// ([`polytope_section_overlay_with_vertices`] for overlays, [`polytope_section_faces_with_vertices`]
 /// for surface replacement) share the geometric logic. Either consumer can change its
 /// output shape (color, width, mesh format) without touching the cross-section math.
 fn for_each_section_cap(
@@ -457,6 +518,19 @@ fn for_each_section_cap(
     mut emit: impl FnMut(&[Vec3], Vec3),
 ) {
     let slice = perturb_slice_if_needed(slice, vertices);
+
+    // Polytope's R³ centroid (drop-w of the 4D vertex mean). Used as the reference "inside"
+    // point so each cap's fan-triangle winding can be oriented with the face normal pointing
+    // AWAY from it. Consistent orientation is invisible under the current two-sided Lambert
+    // (`abs(dot(n, L))` in `triangle_raster.wgsl`) but is required for any future single-sided
+    // shading, back-face culling, or shadow pass; pre-paying the cost here means consumers
+    // don't have to repair winding downstream.
+    let polytope_center_r3: Vec3 = if vertices.is_empty() {
+        Vec3::ZERO
+    } else {
+        let mean: Vec4 = vertices.iter().copied().sum::<Vec4>() / vertices.len() as f32;
+        Vec3::new(mean.x, mean.y, mean.z)
+    };
 
     for cell in cells {
         // Per-cell w-range pruning: cells entirely above or below the slice can't
@@ -497,9 +571,22 @@ fn for_each_section_cap(
         // convex 3-cell with a hyperplane). `fit_plane_basis` finds two orthonormal basis
         // vectors in the cap's plane via the first non-collinear pair of cap offsets.
         let centroid: Vec3 = cap.iter().copied().sum::<Vec3>() / cap.len() as f32;
-        let Some((basis_u, basis_v)) = fit_plane_basis(centroid, &cap) else {
+        let Some((basis_u, mut basis_v)) = fit_plane_basis(centroid, &cap) else {
             continue;
         };
+
+        // Orient `(basis_u, basis_v)` so the fan-triangle face normal `u × v` points away
+        // from the polytope's R³ center. Without this, `fit_plane_basis`'s choice of `basis_v`
+        // depends on which cap vertex it picked first as the orthogonal probe, which differs
+        // per cap and yields inconsistent winding across the assembled section. The dot-
+        // product compared against `1e-6` guards against the rare case where the cap centroid
+        // coincides with the polytope center (zero-magnitude reference direction); skip the
+        // flip there (orientation is arbitrary in that degenerate case anyway).
+        let outward = centroid - polytope_center_r3;
+        let face_normal = basis_u.cross(basis_v);
+        if outward.length_squared() > 1e-12 && face_normal.dot(outward) < 0.0 {
+            basis_v = -basis_v;
+        }
 
         // Order cap points by angle around the centroid in the (u, v) plane. Convex
         // polygons sort cleanly under atan2 ordering since the centroid is interior.
@@ -523,7 +610,7 @@ fn perturb_slice_if_needed(slice: rye_math::WPlane, vertices: &[Vec4]) -> rye_ma
 }
 
 /// Min and max w-coordinate of a cell's vertex set. O(n) per cell; used by the per-cell
-/// pruning step in [`polytope4_section`].
+/// pruning step in [`polytope4_section_overlay`].
 fn cell_w_range(cell: &[u32], vertices: &[Vec4]) -> (f32, f32) {
     let mut w_min = f32::INFINITY;
     let mut w_max = f32::NEG_INFINITY;
@@ -546,7 +633,7 @@ fn cell_w_range(cell: &[u32], vertices: &[Vec4]) -> (f32, f32) {
 ///
 /// Returns `None` when all cap points are collinear or coincide with the centroid -- a
 /// degenerate cap that the caller should skip. The slice-perturbation step in
-/// [`polytope4_section`] keeps this from firing under non-pathological inputs.
+/// [`polytope4_section_overlay`] keeps this from firing under non-pathological inputs.
 fn fit_plane_basis(centroid: Vec3, points: &[Vec3]) -> Option<(Vec3, Vec3)> {
     let eps = rye_math::EDGE_PARALLEL_EPSILON;
     let mut basis_u = Vec3::ZERO;
@@ -1348,7 +1435,8 @@ mod tests {
     /// Matches Coxeter's classical result: pentatope midpoint section is a regular tetrahedron.
     #[test]
     fn pentatope_section_at_midpoint() {
-        let (tri, edges) = polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
+        let (tri, edges) =
+            polytope4_section_overlay(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
         assert_eq!(tri.indices.len(), 12, "expected 12 fan triangles");
         assert_eq!(edges.segments.len(), 12, "expected 12 perimeter segments");
         // Each cap has 4 mesh-vertices (centroid + 3 cap points). 4 caps total.
@@ -1361,7 +1449,8 @@ mod tests {
     /// triangles; perimeter has 6 caps * 4 edges = 24 segments.
     #[test]
     fn tesseract_section_at_midpoint_has_six_square_caps() {
-        let (tri, edges) = polytope4_section(Polytope4::Tesseract, rye_math::WPlane::new(0.0));
+        let (tri, edges) =
+            polytope4_section_overlay(Polytope4::Tesseract, rye_math::WPlane::new(0.0));
         assert_eq!(tri.indices.len(), 24, "6 cubical cells * 4 fan-triangles");
         assert_eq!(edges.segments.len(), 24, "6 caps * 4 perimeter edges");
         // Each cap has 5 mesh-vertices (centroid + 4 cap points). 6 caps total.
@@ -1373,7 +1462,7 @@ mod tests {
     #[test]
     fn section_outside_polytope_is_empty() {
         for polytope in Polytope4::ALL {
-            let (tri, edges) = polytope4_section(polytope, rye_math::WPlane::new(2.0));
+            let (tri, edges) = polytope4_section_overlay(polytope, rye_math::WPlane::new(2.0));
             assert!(
                 tri.indices.is_empty(),
                 "{polytope:?} above-vertex slice should yield no triangles"
@@ -1391,7 +1480,8 @@ mod tests {
     /// case would. Test with the 5-cell base-vertex w = -0.25.
     #[test]
     fn vertex_on_slice_is_perturbed_not_nan() {
-        let (tri, edges) = polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(-0.25));
+        let (tri, edges) =
+            polytope4_section_overlay(Polytope4::Pentatope, rye_math::WPlane::new(-0.25));
         for v in &tri.vertices {
             for component in v {
                 assert!(component.is_finite(), "triangle vertex must be finite");
@@ -1410,7 +1500,7 @@ mod tests {
     #[test]
     fn midpoint_slice_is_non_empty_for_every_polytope() {
         for polytope in Polytope4::ALL {
-            let (tri, edges) = polytope4_section(polytope, rye_math::WPlane::new(0.0));
+            let (tri, edges) = polytope4_section_overlay(polytope, rye_math::WPlane::new(0.0));
             assert!(
                 !tri.indices.is_empty(),
                 "{polytope:?} midpoint slice should yield triangles"
@@ -1425,7 +1515,7 @@ mod tests {
     // ----------------- Section faces (filled, solid-colored) -----------------
     //
     // The face variant ([`polytope4_section_faces`]) shares its geometric core with
-    // [`polytope4_section`] via [`for_each_section_cap`]. Tests below pin the
+    // [`polytope4_section_overlay`] via [`for_each_section_cap`]. Tests below pin the
     // invariants specific to the face variant: triangle count agreement with the
     // overlay variant, and that every vertex carries the caller-provided color.
 
@@ -1438,17 +1528,17 @@ mod tests {
         let probe_color = [0.5, 0.5, 0.5, 1.0];
         for polytope in Polytope4::ALL {
             let slice = rye_math::WPlane::new(0.1);
-            let (overlay_tri, _) = polytope4_section(polytope, slice);
+            let (overlay_tri, _) = polytope4_section_overlay(polytope, slice);
             let faces_tri = polytope4_section_faces(polytope, slice, probe_color);
             assert_eq!(
                 faces_tri.indices.len(),
                 overlay_tri.indices.len(),
-                "{polytope:?}: section_faces triangle count must match polytope4_section"
+                "{polytope:?}: section_faces triangle count must match polytope4_section_overlay"
             );
             assert_eq!(
                 faces_tri.vertices.len(),
                 overlay_tri.vertices.len(),
-                "{polytope:?}: section_faces vertex count must match polytope4_section"
+                "{polytope:?}: section_faces vertex count must match polytope4_section_overlay"
             );
         }
     }
@@ -1490,7 +1580,7 @@ mod tests {
     //
     // No equivalent tests for 5/8/16/24-cell: their face planes aren't exposed
     // as `pub` helpers, and the rasterized section path is correct by
-    // construction (`polytope_section_with_vertices` operates on the topology
+    // construction (`polytope_section_overlay_with_vertices` operates on the topology
     // directly, no SDF involvement).
 
     /// Reconstruct 4D perimeter vertices from the R³ perimeter mesh: every
@@ -1519,7 +1609,7 @@ mod tests {
     fn cell120_section_perimeter_diverges_from_sdf_documenting_bug() {
         use crate::euclidean_r4::{cell120_face_planes, polytope_sdf_wolfe};
         let slice = rye_math::WPlane::new(0.0);
-        let (_, perim) = polytope4_section(Polytope4::Cell120, slice);
+        let (_, perim) = polytope4_section_overlay(Polytope4::Cell120, slice);
         let (normals, inradius) = cell120_face_planes();
 
         let mut max_dev: f32 = 0.0;
@@ -1542,6 +1632,47 @@ mod tests {
         );
     }
 
+    /// The four polytopes without the documented face-plane BUG agree exactly
+    /// (within f32 tolerance) with the topology-derived SDF along the section
+    /// perimeter. This is the "no camera tricks" gate the M3 doc framed: section
+    /// algorithm and SDF agree, both compute the *same* surface.
+    ///
+    /// Uses `Polytope4::face_planes` (topology-derived, exact for every regular
+    /// convex 4-polytope) rather than the raymarch kernel's `cell{120,600}_face_planes`
+    /// (dual-vertex approximation). 120- and 600-cell are deliberately not in this
+    /// loop because the kernel's helpers are buggy; their divergence is pinned by
+    /// the `*_documenting_bug` tests below.
+    #[test]
+    fn five_eight_sixteen_twentyfour_cell_section_perimeter_on_sdf_surface() {
+        use crate::euclidean_r4::polytope_sdf_wolfe;
+        let cases = [
+            Polytope4::Pentatope,
+            Polytope4::Tesseract,
+            Polytope4::Cell16,
+            Polytope4::Cell24,
+        ];
+        // Each perimeter vertex sits on a parent edge intersected with the slice
+        // plane, so it lies on the polytope's surface by construction. `polytope_sdf_wolfe`
+        // should return ~0 at every such vertex when given accurate face planes.
+        // Tolerance is `1e-3`, well above f32 noise from the SDF's Wolfe-greedy
+        // projection (~1e-5 in practice) but tight enough to fire on any face-plane
+        // approximation that approaches the 120/600 BUG magnitudes (~1e-2).
+        const TOL: f32 = 1e-3;
+        let slice = rye_math::WPlane::new(0.0);
+        for polytope in cases {
+            let (_, perim) = polytope4_section_overlay(polytope, slice);
+            let (normals, inradius) = polytope.face_planes();
+            for p4 in perimeter_vertices_4d(&perim, slice.w_slice) {
+                let d = polytope_sdf_wolfe(p4, &normals, inradius).abs();
+                assert!(
+                    d < TOL,
+                    "{polytope:?}: perimeter vertex {p4:?} has |SDF| = {d}, expected < {TOL}; \
+                     section and SDF disagree"
+                );
+            }
+        }
+    }
+
     /// Same shape as `cell120_section_perimeter_diverges_from_sdf_documenting_bug`
     /// for the 600-cell. The 600-cell carries the symmetric BUG: its true face
     /// normals are the cell centroids of its tetrahedral cells, but the SDF uses
@@ -1550,7 +1681,7 @@ mod tests {
     fn cell600_section_perimeter_diverges_from_sdf_documenting_bug() {
         use crate::euclidean_r4::{cell600_face_planes, polytope_sdf_wolfe};
         let slice = rye_math::WPlane::new(0.0);
-        let (_, perim) = polytope4_section(Polytope4::Cell600, slice);
+        let (_, perim) = polytope4_section_overlay(Polytope4::Cell600, slice);
         let (normals, inradius) = cell600_face_planes();
 
         let mut max_dev: f32 = 0.0;
@@ -1597,7 +1728,7 @@ mod tests {
     /// recovers the number of caps. Compares against an independent count of
     /// straddling cells computed from the topology directly.
     #[test]
-    fn cell_pruning_matches_full_scan() {
+    fn cell_pruning_matches_straddle_count() {
         // Slice values across the [-1, 1] interior of each polytope. Avoid grazing
         // values (within `SLICE_PERTURBATION_EPSILON` of any vertex's w) so the
         // perturbation path doesn't shift the slice between our independent count
@@ -1629,7 +1760,7 @@ mod tests {
                     })
                     .count();
 
-                let (tri, _) = polytope4_section(polytope, rye_math::WPlane::new(w));
+                let (tri, _) = polytope4_section_overlay(polytope, rye_math::WPlane::new(w));
                 let actual_caps = tri.vertices.len().saturating_sub(tri.indices.len());
 
                 assert_eq!(
@@ -1641,7 +1772,131 @@ mod tests {
         }
     }
 
-    /// `polytope4_section` is a pure function of `(polytope, slice)`: re-invoking it
+    /// Every fan-triangle in the section mesh has its face normal pointing AWAY from
+    /// the polytope's R³ center. Pins the winding-consistency contract that lets a
+    /// future single-sided lighting / back-face culling consumer rely on the section
+    /// surface being topologically outward-oriented. Two-sided Lambert (the current
+    /// shading) is invariant under winding, so this property isn't visible at the
+    /// surface, but it's load-bearing for downstream consumers we haven't built yet.
+    #[test]
+    fn section_face_normals_point_outward_from_polytope_center() {
+        for polytope in Polytope4::ALL {
+            // Polytope is centered at origin in canonical coordinates, so the
+            // outward direction at any cap is the cap centroid itself.
+            let center = Vec3::ZERO;
+            for &slice_w in &[-0.5_f32, -0.2, 0.0, 0.2, 0.5] {
+                let (mesh, _) = polytope4_section_overlay(polytope, rye_math::WPlane::new(slice_w));
+                for &[a, b, c] in &mesh.indices {
+                    let va = Vec3::from(mesh.vertices[a as usize]);
+                    let vb = Vec3::from(mesh.vertices[b as usize]);
+                    let vc = Vec3::from(mesh.vertices[c as usize]);
+                    let n = (vb - va).cross(vc - va);
+                    if n.length_squared() < 1e-10 {
+                        continue; // degenerate triangle; skip
+                    }
+                    let tri_centroid = (va + vb + vc) / 3.0;
+                    let outward = tri_centroid - center;
+                    if outward.length_squared() < 1e-10 {
+                        continue; // triangle straddles polytope center; orientation ambiguous
+                    }
+                    assert!(
+                        n.dot(outward) > 0.0,
+                        "{polytope:?} at w={slice_w}: triangle ({va:?}, {vb:?}, {vc:?}) \
+                         has inward-facing normal {n:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Randomized robustness sweep: across each polytope, sample 16 random Rotor4 orientations
+    /// applied to the canonical vertex set and 16 random slice values, exercising the cross-
+    /// section algorithm under non-axis-aligned inputs. Asserts: every emitted vertex is finite
+    /// (no NaN/Inf), every triangle index references a valid vertex, every line-segment endpoint
+    /// matches an existing triangle vertex up to perturbation tolerance, and the perimeter is
+    /// always non-empty when the slice falls inside the polytope's rotated w-range.
+    ///
+    /// Catches a different failure class from the fixed-vertex tests: numerical instability that
+    /// only triggers at off-axis orientations (cap-collinearity that survives `fit_plane_basis`,
+    /// FMA rounding at edge intersections, perturbation aliasing). Pure deterministic: uses
+    /// a xorshift PRNG seeded with a fixed value, so failures reproduce verbatim across runs.
+    #[test]
+    fn section_under_random_rotors_stays_well_formed() {
+        let mut state: u32 = 0x517_C0DE;
+        let mut rand = || {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            (state as f32 / u32::MAX as f32) * 2.0 - 1.0
+        };
+        for polytope in Polytope4::ALL {
+            let topo = polytope.topology();
+            for _ in 0..16 {
+                // Build a random unit rotor by populating each bivector component with a
+                // signed-uniform value and normalising. `xyzw` is included for full Spin(4)
+                // coverage even though it's zero for SO(4) rotations (Rotor4 carries it as a
+                // generator-level field; normalisation absorbs it into the unit-norm constraint).
+                let rotor = rye_math::Rotor4 {
+                    s: rand(),
+                    xy: rand(),
+                    xz: rand(),
+                    xw: rand(),
+                    yz: rand(),
+                    yw: rand(),
+                    zw: rand(),
+                    xyzw: rand(),
+                }
+                .normalize();
+                let rotated: Vec<Vec4> = {
+                    use rye_math::Rotor as _;
+                    topo.vertices.iter().map(|v| rotor.apply(*v)).collect()
+                };
+                // Slice value in `(-1, 1)`. Unit-circumradius polytopes have w-range bounded by
+                // `[-1, 1]`; rotors preserve circumradius, so this stays inside the polytope.
+                let slice_w = rand() * 0.8;
+                let slice = rye_math::WPlane::new(slice_w);
+                let (tri, perim) =
+                    polytope_section_overlay_with_vertices(topo.edges, topo.cells, &rotated, slice);
+
+                // Finite-output property: any NaN/Inf in the output signals a degenerate-cap
+                // path that escaped the `< 3 cap points` filter or the plane-fit fallback.
+                for v in &tri.vertices {
+                    for c in v {
+                        assert!(c.is_finite(), "{polytope:?} tri vertex non-finite: {v:?}");
+                    }
+                }
+                for (a, b) in &perim.segments {
+                    for c in a.iter().chain(b.iter()) {
+                        assert!(c.is_finite(), "{polytope:?} perim endpoint non-finite");
+                    }
+                }
+                // Index-validity property: each triangle index references an in-bounds vertex.
+                for &[i0, i1, i2] in &tri.indices {
+                    let n = tri.vertices.len() as u32;
+                    assert!(
+                        i0 < n && i1 < n && i2 < n,
+                        "{polytope:?} index out of bounds"
+                    );
+                }
+                // Non-empty-section property: with the slice inside the rotated polytope's
+                // w-range, the section MUST produce at least one cap. A zero-perimeter result
+                // means the perturbation + pruning combo dropped a cell it shouldn't have.
+                let (w_min, w_max) = rotated
+                    .iter()
+                    .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), v| {
+                        (lo.min(v.w), hi.max(v.w))
+                    });
+                if slice_w > w_min + 0.05 && slice_w < w_max - 0.05 {
+                    assert!(
+                        !perim.segments.is_empty(),
+                        "{polytope:?} slice w={slice_w} inside [{w_min}, {w_max}] but produced empty section"
+                    );
+                }
+            }
+        }
+    }
+
+    /// `polytope4_section_overlay` is a pure function of `(polytope, slice)`: re-invoking it
     /// with a different slice produces a different section mesh. Trivial but pins
     /// the contract so a future caching optimization that accidentally returns a
     /// stale mesh across slice changes fires here.
@@ -1656,8 +1911,8 @@ mod tests {
     /// changes).
     #[test]
     fn section_recomputes_when_w_slice_changes() {
-        let (a, _) = polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
-        let (b, _) = polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(0.4));
+        let (a, _) = polytope4_section_overlay(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
+        let (b, _) = polytope4_section_overlay(Polytope4::Pentatope, rye_math::WPlane::new(0.4));
         assert_ne!(
             a.vertices, b.vertices,
             "section at w=0.0 and w=0.4 must differ; result was identical, \

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -331,10 +331,152 @@ pub fn polytope_section_with_vertices(
     vertices: &[Vec4],
     slice: rye_math::WPlane,
 ) -> (rye_shape::TriangleMesh<3>, rye_shape::LineMesh<3>) {
-    let slice = perturb_slice_if_needed(slice, vertices);
-
     let mut tri_mesh = rye_shape::TriangleMesh::<3>::default();
     let mut edge_mesh = rye_shape::LineMesh::<3>::default();
+
+    for_each_section_cap(edges, cells, vertices, slice, |ordered, centroid| {
+        // Emit a triangle fan from the centroid. The centroid is invisible inside the
+        // convex cap; cap vertices form the visible perimeter.
+        let cv_base = tri_mesh.vertices.len() as u32;
+        tri_mesh.vertices.push(centroid.point3.to_array());
+        tri_mesh.colors.push(SECTION_FILL_COLOR);
+        for cap_v in ordered {
+            tri_mesh.vertices.push(cap_v.point3.to_array());
+            tri_mesh.colors.push(SECTION_FILL_COLOR);
+        }
+        let n = ordered.len() as u32;
+        for k in 0..n {
+            let k_next = (k + 1) % n;
+            tri_mesh
+                .indices
+                .push([cv_base, cv_base + 1 + k, cv_base + 1 + k_next]);
+        }
+
+        // Emit the perimeter as cap-vertex-pair line segments. Shared edges between
+        // adjacent cell caps are drawn twice (cells share their face-on-slice edges); the
+        // duplication is visually invisible and avoids a global edge-dedup pass.
+        for k in 0..ordered.len() {
+            let a = ordered[k].point3;
+            let b = ordered[(k + 1) % ordered.len()].point3;
+            edge_mesh.segments.push((a.to_array(), b.to_array()));
+            edge_mesh
+                .colors
+                .push((SECTION_EDGE_COLOR, SECTION_EDGE_COLOR));
+            edge_mesh.widths.push(SECTION_EDGE_WIDTH);
+        }
+    });
+
+    (tri_mesh, edge_mesh)
+}
+
+/// Cross-section faces only, opaque + per-vertex position-colored, fan-triangulated.
+/// Intended as the *primary* surface representation for a polychoral body at a w-slice,
+/// replacing the SDF raymarch for the six regular convex 4-polytopes.
+///
+/// Differs from [`polytope_section_with_vertices`] in two ways:
+///
+/// - Returns only the [`rye_shape::TriangleMesh<3>`]; the caller composes perimeter
+///   edges separately (typically via the wireframe overlay).
+/// - Per-vertex color comes from [`vertex_color_by_position`] applied to the *4D* parent
+///   point at each edge intersection. Adjacent cells share their cap-vertex 4D positions
+///   (the same edge intersects the same point in both cells), so the gradient is
+///   continuous across cell boundaries (same property the parent wireframe has).
+///   Alpha = 1.0; pairs with `FragmentShading::FaceNormalLambert` in `rye-render` for
+///   faceted shaded surfaces (the rasterizer derives face normals from screen-space
+///   derivatives of position, so no normal attribute is required here).
+///
+/// The centroid (fan apex) is colored by `vertex_color_by_position` of its 4D centroid
+/// (mean of cap 4D points), not by averaging colors. Keeps the coloring law consistent
+/// across all vertices.
+///
+/// Performance: 600-cell midpoint slice produces ~24-60 active cells × tetrahedral cap
+/// (3-point) × 3 fan-triangles ≈ 200-500 triangles per body per frame. The cost is
+/// dominated by the per-edge intersection sweep (`edges.len() × cells.len()` worst case,
+/// pruned per-cell), not the fan-triangulation step.
+pub fn polytope_section_faces_with_vertices(
+    edges: &[[u32; 2]],
+    cells: &[&[u32]],
+    vertices: &[Vec4],
+    slice: rye_math::WPlane,
+) -> rye_shape::TriangleMesh<3> {
+    let mut tri_mesh = rye_shape::TriangleMesh::<3>::default();
+
+    for_each_section_cap(edges, cells, vertices, slice, |ordered, centroid| {
+        let cv_base = tri_mesh.vertices.len() as u32;
+        tri_mesh.vertices.push(centroid.point3.to_array());
+        tri_mesh
+            .colors
+            .push(opaque(vertex_color_by_position(centroid.point4)));
+        for cap_v in ordered {
+            tri_mesh.vertices.push(cap_v.point3.to_array());
+            tri_mesh
+                .colors
+                .push(opaque(vertex_color_by_position(cap_v.point4)));
+        }
+        let n = ordered.len() as u32;
+        for k in 0..n {
+            let k_next = (k + 1) % n;
+            tri_mesh
+                .indices
+                .push([cv_base, cv_base + 1 + k, cv_base + 1 + k_next]);
+        }
+    });
+
+    tri_mesh
+}
+
+/// Canonical-vertex convenience: section faces using the polytope's own topology
+/// vertices (unrotated, unit circumradius). Mirrors [`polytope4_section`] but returns
+/// just the position-colored opaque triangle mesh suitable for replacing the SDF
+/// surface.
+pub fn polytope4_section_faces(
+    polytope: Polytope4,
+    slice: rye_math::WPlane,
+) -> rye_shape::TriangleMesh<3> {
+    let topo = polytope.topology();
+    polytope_section_faces_with_vertices(topo.edges, topo.cells, topo.vertices, slice)
+}
+
+/// One cap vertex paired with its 4D origin. The R³ point is what the rasterizer
+/// consumes; the R⁴ point is what [`vertex_color_by_position`] needs to keep coloring
+/// continuous across cells (the same 4D edge intersection has the same color in every
+/// cell that contains the edge).
+#[derive(Copy, Clone, Debug)]
+struct CapVertex {
+    point3: Vec3,
+    point4: Vec4,
+}
+
+/// Promote a [`vertex_color_by_position`] RGBA (alpha = 1.0 by construction) to an
+/// opaque RGBA. Defined for clarity at call sites that emit opaque section faces;
+/// the upstream function already sets alpha = 1.0, so this is currently the identity.
+/// Explicit in case the upstream alpha encoding changes.
+fn opaque(rgba: [f32; 4]) -> [f32; 4] {
+    [rgba[0], rgba[1], rgba[2], 1.0]
+}
+
+/// Shared core of the section algorithm: iterate over every cell whose w-range crosses
+/// the slice, intersect the cell's edges with the slice, fit + order the resulting cap
+/// polygon, and invoke `emit` once per cell with the ordered cap vertices (each carrying
+/// both R³ and R⁴ coordinates) and the centroid. Cells that miss the slice or whose cap
+/// degenerates (< 3 vertices, collinear cap) are skipped silently.
+///
+/// `emit` is called *in cell order*, which is the topology cell order (deterministic
+/// across runs). Mesh-builders can rely on it for stable triangle ordering between
+/// frames.
+///
+/// Algorithm details captured here in one place so the two public consumers
+/// ([`polytope_section_with_vertices`] for overlays, [`polytope_section_faces_with_vertices`]
+/// for surface replacement) share the geometric logic. Either consumer can change its
+/// output shape (color, width, mesh format) without touching the cross-section math.
+fn for_each_section_cap(
+    edges: &[[u32; 2]],
+    cells: &[&[u32]],
+    vertices: &[Vec4],
+    slice: rye_math::WPlane,
+    mut emit: impl FnMut(&[CapVertex], CapVertex),
+) {
+    let slice = perturb_slice_if_needed(slice, vertices);
 
     for cell in cells {
         // Per-cell w-range pruning: cells entirely above or below the slice can't
@@ -352,19 +494,26 @@ pub fn polytope_section_with_vertices(
         // per-cell 2-face incidence data; works because the standard polychora's edge
         // sets are exactly their cells' edge sets (cells are convex 3-polytopes whose
         // 1-skeleton is a subgraph of the parent).
-        let mut cap: Vec<Vec3> = Vec::with_capacity(8);
+        let mut cap: Vec<CapVertex> = Vec::with_capacity(8);
         for &[i, j] in edges {
             if !cell.contains(&i) || !cell.contains(&j) {
                 continue;
             }
-            if let Some((_, p3)) =
+            let p0 = vertices[i as usize];
+            let p1 = vertices[j as usize];
+            if let Some((t, p3)) =
                 <rye_math::EuclideanR4 as rye_math::SectionableSpace<4>>::edge_section(
-                    &slice,
-                    vertices[i as usize],
-                    vertices[j as usize],
+                    &slice, p0, p1,
                 )
             {
-                cap.push(p3);
+                // Reconstruct the 4D intersection point from the lerp parameter `t`.
+                // Same `t` produces the same `p4` for both cells sharing this edge, so
+                // position-coloring stays seamless across cap boundaries.
+                let p4 = p0 + (p1 - p0) * t;
+                cap.push(CapVertex {
+                    point3: p3,
+                    point4: p4,
+                });
             }
         }
         if cap.len() < 3 {
@@ -374,48 +523,27 @@ pub fn polytope_section_with_vertices(
         // Centroid + plane basis. The cap is a convex 2-polygon in R³ (intersection of a
         // convex 3-cell with a hyperplane). `fit_plane_basis` finds two orthonormal basis
         // vectors in the cap's plane via the first non-collinear pair of cap offsets.
-        let centroid: Vec3 = cap.iter().copied().sum::<Vec3>() / cap.len() as f32;
-        let Some((basis_u, basis_v)) = fit_plane_basis(centroid, &cap) else {
+        let centroid_p3: Vec3 = cap.iter().map(|cv| cv.point3).sum::<Vec3>() / cap.len() as f32;
+        let centroid_p4: Vec4 = cap.iter().map(|cv| cv.point4).sum::<Vec4>() / cap.len() as f32;
+        let cap_p3: Vec<Vec3> = cap.iter().map(|cv| cv.point3).collect();
+        let Some((basis_u, basis_v)) = fit_plane_basis(centroid_p3, &cap_p3) else {
             continue;
         };
 
         // Order cap points by angle around the centroid in the (u, v) plane. Convex
-        // polygons sort cleanly under atan2 ordering since the centroid is interior.
-        let ordered = order_around_centroid(&cap, centroid, basis_u, basis_v);
+        // polygons sort cleanly under atan2 ordering since the centroid is interior. We
+        // sort the (p3, p4) pairs together so the 4D color stays attached to its 3D
+        // partner across the reorder.
+        let ordered = order_cap_around_centroid(&cap, centroid_p3, basis_u, basis_v);
 
-        // Emit a triangle fan from the centroid. Adds the centroid as an interior vertex
-        // (invisible inside the convex cap) plus each cap vertex; triangles are
-        // (centroid, ordered[k], ordered[k+1]).
-        let cv_base = tri_mesh.vertices.len() as u32;
-        tri_mesh.vertices.push(centroid.to_array());
-        tri_mesh.colors.push(SECTION_FILL_COLOR);
-        for p in &ordered {
-            tri_mesh.vertices.push(p.to_array());
-            tri_mesh.colors.push(SECTION_FILL_COLOR);
-        }
-        let n = ordered.len() as u32;
-        for k in 0..n {
-            let k_next = (k + 1) % n;
-            tri_mesh
-                .indices
-                .push([cv_base, cv_base + 1 + k, cv_base + 1 + k_next]);
-        }
-
-        // Emit the perimeter as cap-vertex-pair line segments. Shared edges between
-        // adjacent cell caps are drawn twice (cells share their face-on-slice edges); the
-        // duplication is visually invisible and avoids a global edge-dedup pass.
-        for k in 0..ordered.len() {
-            let a = ordered[k];
-            let b = ordered[(k + 1) % ordered.len()];
-            edge_mesh.segments.push((a.to_array(), b.to_array()));
-            edge_mesh
-                .colors
-                .push((SECTION_EDGE_COLOR, SECTION_EDGE_COLOR));
-            edge_mesh.widths.push(SECTION_EDGE_WIDTH);
-        }
+        emit(
+            &ordered,
+            CapVertex {
+                point3: centroid_p3,
+                point4: centroid_p4,
+            },
+        );
     }
-
-    (tri_mesh, edge_mesh)
 }
 
 /// Shift the slice by [`rye_math::SLICE_PERTURBATION_EPSILON`] when any polytope vertex's w
@@ -481,26 +609,28 @@ fn fit_plane_basis(centroid: Vec3, points: &[Vec3]) -> Option<(Vec3, Vec3)> {
     None
 }
 
-/// Sort cap points by angle around the centroid in the cap's `(basis_u, basis_v)` plane.
+/// Sort cap vertices by angle around the centroid in the cap's `(basis_u, basis_v)` plane.
 /// Convex polygons sort cleanly under this ordering since the centroid is interior; the
-/// resulting sequence walks the perimeter once.
-fn order_around_centroid(
-    points: &[Vec3],
+/// resulting sequence walks the perimeter once. The 4D companion coordinate
+/// (`CapVertex::point4`) rides along with each R³ point so position-coloring stays
+/// attached to the right cap vertex through the reorder.
+fn order_cap_around_centroid(
+    cap: &[CapVertex],
     centroid: Vec3,
     basis_u: Vec3,
     basis_v: Vec3,
-) -> Vec<Vec3> {
-    let mut indexed: Vec<(usize, f32)> = points
+) -> Vec<CapVertex> {
+    let mut indexed: Vec<(usize, f32)> = cap
         .iter()
         .enumerate()
-        .map(|(i, p)| {
-            let off = *p - centroid;
+        .map(|(i, cv)| {
+            let off = cv.point3 - centroid;
             let angle = off.dot(basis_v).atan2(off.dot(basis_u));
             (i, angle)
         })
         .collect();
     indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-    indexed.into_iter().map(|(i, _)| points[i]).collect()
+    indexed.into_iter().map(|(i, _)| cap[i]).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -1328,6 +1458,110 @@ mod tests {
                 !edges.segments.is_empty(),
                 "{polytope:?} midpoint slice should yield perimeter edges"
             );
+        }
+    }
+
+    // ----------------- Section faces (filled, position-colored) -----------------
+    //
+    // The face variant ([`polytope4_section_faces`]) shares its geometric core with
+    // [`polytope4_section`] via [`for_each_section_cap`]. The tests below pin the
+    // additional invariants specific to the face variant: triangle count agreement
+    // with the overlay variant, opaque + non-uniform per-vertex coloring, and color
+    // continuity across cell boundaries.
+
+    /// Face triangulation produces the same triangle count as the overlay's triangle
+    /// output, since both go through the same cap-iteration core. Agreement here is
+    /// the cheapest assertion that the refactor didn't drop or duplicate triangles in
+    /// one variant relative to the other.
+    #[test]
+    fn section_faces_triangle_count_matches_section_triangles() {
+        for polytope in Polytope4::ALL {
+            let slice = rye_math::WPlane::new(0.1);
+            let (overlay_tri, _) = polytope4_section(polytope, slice);
+            let faces_tri = polytope4_section_faces(polytope, slice);
+            assert_eq!(
+                faces_tri.indices.len(),
+                overlay_tri.indices.len(),
+                "{polytope:?}: section_faces triangle count must match polytope4_section"
+            );
+            assert_eq!(
+                faces_tri.vertices.len(),
+                overlay_tri.vertices.len(),
+                "{polytope:?}: section_faces vertex count must match polytope4_section"
+            );
+        }
+    }
+
+    /// All face vertices have alpha = 1.0 and at least one non-grey color appears.
+    /// Pins that the position-coloring scheme is actually being applied (a regression
+    /// to a fixed white fill would still produce alpha = 1.0 but only one unique color
+    /// across all vertices).
+    #[test]
+    fn section_faces_are_opaque_and_position_colored() {
+        // 5-cell midpoint slice produces 4 tetrahedral caps with cap vertices on the
+        // edges of the parent (the 4D edge midpoints), which span enough of the unit
+        // 3-sphere to produce visibly different colors per vertex.
+        let mesh = polytope4_section_faces(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
+        assert!(!mesh.colors.is_empty(), "section faces must produce colors");
+        for c in &mesh.colors {
+            assert!(
+                (c[3] - 1.0).abs() < 1e-6,
+                "section face vertex must be opaque (alpha = 1.0), got {c:?}"
+            );
+        }
+        // At least two distinct colors across the cap vertex set. Catches a
+        // regression where all vertices land on the same color (e.g. a future
+        // refactor accidentally passing the centroid 4D point to every cap vertex).
+        let distinct: std::collections::HashSet<[u32; 3]> = mesh
+            .colors
+            .iter()
+            .map(|c| [c[0].to_bits(), c[1].to_bits(), c[2].to_bits()])
+            .collect();
+        assert!(
+            distinct.len() >= 2,
+            "section face coloring is degenerate: only {} unique color(s)",
+            distinct.len()
+        );
+    }
+
+    /// Cap vertices shared between adjacent cells (i.e., a parent-edge's intersection
+    /// with the slice, which belongs to every cell containing that edge) receive the
+    /// SAME color in every cap. Catches a regression where the cap-vertex color
+    /// depends on cell context rather than the 4D intersection point.
+    #[test]
+    fn section_faces_color_is_continuous_across_cells() {
+        // Tesseract midpoint slice has 6 square caps; each cap-edge of one cap is
+        // shared with exactly one adjacent cap. So cap-vertex coordinates appear in
+        // pairs: two cells, same R³ position, must have the same color.
+        let mesh = polytope4_section_faces(Polytope4::Tesseract, rye_math::WPlane::new(0.0));
+
+        // Bucket cap vertices by R³ position (with quantization to absorb f32 jitter).
+        // For each position, all bucketed colors must agree.
+        use std::collections::HashMap;
+        let mut by_pos: HashMap<[i32; 3], Vec<[f32; 4]>> = HashMap::new();
+        for (v, c) in mesh.vertices.iter().zip(mesh.colors.iter()) {
+            let key = [
+                (v[0] * 1e4).round() as i32,
+                (v[1] * 1e4).round() as i32,
+                (v[2] * 1e4).round() as i32,
+            ];
+            by_pos.entry(key).or_default().push(*c);
+        }
+        for (pos, colors) in &by_pos {
+            // Centroids are unique per cell; only inspect positions that appear in
+            // multiple caps (= cap-perimeter vertices shared between adjacent cells).
+            if colors.len() < 2 {
+                continue;
+            }
+            let first = colors[0];
+            for c in &colors[1..] {
+                for k in 0..4 {
+                    assert!(
+                        (c[k] - first[k]).abs() < 1e-5,
+                        "color discontinuity at shared cap vertex {pos:?}: {first:?} vs {c:?}"
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -257,6 +257,241 @@ impl Polytope4 {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-section algorithm
+// ---------------------------------------------------------------------------
+
+/// Default cross-section fill color: translucent white. Picks up tinting from the SDF or
+/// parent wireframe behind it; alpha 0.55 keeps both visible.
+const SECTION_FILL_COLOR: [f32; 4] = [1.0, 1.0, 1.0, 0.55];
+/// Default cross-section perimeter color: bright cyan, opaque. Reads as the "boundary of
+/// what you're currently looking at" against both the dim parent wireframe and SDF.
+const SECTION_EDGE_COLOR: [f32; 4] = [0.30, 0.85, 0.95, 1.0];
+const SECTION_EDGE_WIDTH: f32 = 2.0;
+
+/// Per-cell cross-section assembly. Intersects the 4-polytope's cells with the w-slice
+/// hyperplane, producing the section as a pair (filled triangles, perimeter edges) ready to
+/// hand to `rye-render`'s `TriangleRasterNode` + `LineRasterNode`.
+///
+/// Algorithm:
+///
+/// 1. Perturb the slice if any vertex's w sits within `SLICE_PERTURBATION_EPSILON`. The
+///    single perturbation kills three degeneracies at once (vertex on slice, edge in slice
+///    plane, slice grazes a face).
+/// 2. For each cell, compute its w-range and skip if entirely above or below the slice.
+/// 3. For each parent edge restricted to that cell (both endpoints in the cell's vertex
+///    list), intersect the edge with the slice via
+///    [`rye_math::SectionableSpace::edge_section`]. Collect the resulting R³ points as the
+///    cap polygon.
+/// 4. If the cap has fewer than 3 points the cell barely grazes the slice; skip.
+/// 5. Otherwise, fit the cap's plane via the first non-collinear basis, order the cap
+///    points by angle around their centroid, fan-triangulate from the centroid, and emit
+///    the perimeter as a sequence of line segments.
+///
+/// The same algorithm produces classical cross-section polytopes from `Polytope4` topology
+/// alone: 5-cell midpoint slice -> regular tetrahedron, tesseract midpoint slice -> cube,
+/// 16-cell -> octahedron, etc. No per-polytope special-casing.
+///
+/// Returns `(triangles, perimeter)`. Either may be empty if the slice doesn't cross the
+/// polytope at all.
+pub fn polytope4_section(
+    polytope: Polytope4,
+    slice: rye_math::WPlane,
+) -> (rye_shape::TriangleMesh<3>, rye_shape::LineMesh<3>) {
+    let topo = polytope.topology();
+    polytope_section_with_vertices(topo.edges, topo.cells, topo.vertices, slice)
+}
+
+/// Lower-level cross-section assembly that takes vertices, edges, and cells directly. Use
+/// this when the polytope's vertices have been transformed (rigid-body rotation, world-space
+/// placement, animated 4D rotation) before sectioning -- the canonical [`polytope4_section`]
+/// reads vertices from [`Polytope4::topology`] and isn't aware of any transform applied
+/// after.
+///
+/// The vertex set must remain index-compatible with `edges` and `cells`: each `edges[i]`
+/// pair indexes into `vertices`, and each `cells[i]` is a vertex-index list. Topology shape
+/// (edges, cells) is unchanged by rigid transforms, so callers reuse the parent polytope's
+/// topology arrays and substitute only the vertex set.
+pub fn polytope_section_with_vertices(
+    edges: &[[u32; 2]],
+    cells: &[&[u32]],
+    vertices: &[Vec4],
+    slice: rye_math::WPlane,
+) -> (rye_shape::TriangleMesh<3>, rye_shape::LineMesh<3>) {
+    let slice = perturb_slice_if_needed(slice, vertices);
+
+    let mut tri_mesh = rye_shape::TriangleMesh::<3>::default();
+    let mut edge_mesh = rye_shape::LineMesh::<3>::default();
+
+    for cell in cells {
+        // Per-cell w-range pruning: cells entirely above or below the slice can't
+        // contribute, and skipping them early is the load-bearing optimization for the
+        // 600-cell (600 cells x 720 edges naive = ~430K ops; with pruning, typical case
+        // is ~100 active cells x 30 edges-per-cell = ~3K ops).
+        let (w_min, w_max) = cell_w_range(cell, vertices);
+        if w_max < slice.w_slice - rye_math::SLICE_PERTURBATION_EPSILON
+            || w_min > slice.w_slice + rye_math::SLICE_PERTURBATION_EPSILON
+        {
+            continue;
+        }
+
+        // Cell-edges = parent-edges restricted to the cell's vertex set. Avoids needing
+        // per-cell 2-face incidence data; works because the standard polychora's edge
+        // sets are exactly their cells' edge sets (cells are convex 3-polytopes whose
+        // 1-skeleton is a subgraph of the parent).
+        let mut cap: Vec<Vec3> = Vec::with_capacity(8);
+        for &[i, j] in edges {
+            if !cell.contains(&i) || !cell.contains(&j) {
+                continue;
+            }
+            if let Some((_, p3)) =
+                <rye_math::EuclideanR4 as rye_math::SectionableSpace<4>>::edge_section(
+                    &slice,
+                    vertices[i as usize],
+                    vertices[j as usize],
+                )
+            {
+                cap.push(p3);
+            }
+        }
+        if cap.len() < 3 {
+            continue;
+        }
+
+        // Centroid + plane basis. The cap is a convex 2-polygon in R³ (intersection of a
+        // convex 3-cell with a hyperplane). `fit_plane_basis` finds two orthonormal basis
+        // vectors in the cap's plane via the first non-collinear pair of cap offsets.
+        let centroid: Vec3 = cap.iter().copied().sum::<Vec3>() / cap.len() as f32;
+        let Some((basis_u, basis_v)) = fit_plane_basis(centroid, &cap) else {
+            continue;
+        };
+
+        // Order cap points by angle around the centroid in the (u, v) plane. Convex
+        // polygons sort cleanly under atan2 ordering since the centroid is interior.
+        let ordered = order_around_centroid(&cap, centroid, basis_u, basis_v);
+
+        // Emit a triangle fan from the centroid. Adds the centroid as an interior vertex
+        // (invisible inside the convex cap) plus each cap vertex; triangles are
+        // (centroid, ordered[k], ordered[k+1]).
+        let cv_base = tri_mesh.vertices.len() as u32;
+        tri_mesh.vertices.push(centroid.to_array());
+        tri_mesh.colors.push(SECTION_FILL_COLOR);
+        for p in &ordered {
+            tri_mesh.vertices.push(p.to_array());
+            tri_mesh.colors.push(SECTION_FILL_COLOR);
+        }
+        let n = ordered.len() as u32;
+        for k in 0..n {
+            let k_next = (k + 1) % n;
+            tri_mesh
+                .indices
+                .push([cv_base, cv_base + 1 + k, cv_base + 1 + k_next]);
+        }
+
+        // Emit the perimeter as cap-vertex-pair line segments. Shared edges between
+        // adjacent cell caps are drawn twice (cells share their face-on-slice edges); the
+        // duplication is visually invisible and avoids a global edge-dedup pass.
+        for k in 0..ordered.len() {
+            let a = ordered[k];
+            let b = ordered[(k + 1) % ordered.len()];
+            edge_mesh.segments.push((a.to_array(), b.to_array()));
+            edge_mesh
+                .colors
+                .push((SECTION_EDGE_COLOR, SECTION_EDGE_COLOR));
+            edge_mesh.widths.push(SECTION_EDGE_WIDTH);
+        }
+    }
+
+    (tri_mesh, edge_mesh)
+}
+
+/// Shift the slice by [`rye_math::SLICE_PERTURBATION_EPSILON`] when any polytope vertex's w
+/// sits within that epsilon. Kills vertex-on-slice / edge-in-plane / face-graze
+/// degeneracies in one step so the cell-assembly loop can ignore them.
+fn perturb_slice_if_needed(slice: rye_math::WPlane, vertices: &[Vec4]) -> rye_math::WPlane {
+    let eps = rye_math::SLICE_PERTURBATION_EPSILON;
+    let near = vertices
+        .iter()
+        .any(|v| (v.w - slice.w_slice).abs() < eps);
+    if near {
+        rye_math::WPlane::new(slice.w_slice + eps)
+    } else {
+        slice
+    }
+}
+
+/// Min and max w-coordinate of a cell's vertex set. O(n) per cell; used by the per-cell
+/// pruning step in [`polytope4_section`].
+fn cell_w_range(cell: &[u32], vertices: &[Vec4]) -> (f32, f32) {
+    let mut w_min = f32::INFINITY;
+    let mut w_max = f32::NEG_INFINITY;
+    for &i in cell {
+        let w = vertices[i as usize].w;
+        if w < w_min {
+            w_min = w;
+        }
+        if w > w_max {
+            w_max = w;
+        }
+    }
+    (w_min, w_max)
+}
+
+/// Find two orthonormal basis vectors `(basis_u, basis_v)` spanning the plane of the
+/// cap polygon. Picks the first non-trivial offset from the centroid as `basis_u`, then
+/// looks for a second offset whose cross with `basis_u` is non-degenerate (gives the
+/// plane normal); `basis_v` is recovered as `normal x basis_u`.
+///
+/// Returns `None` when all cap points are collinear or coincide with the centroid -- a
+/// degenerate cap that the caller should skip. The slice-perturbation step in
+/// [`polytope4_section`] keeps this from firing under non-pathological inputs.
+fn fit_plane_basis(centroid: Vec3, points: &[Vec3]) -> Option<(Vec3, Vec3)> {
+    let eps = rye_math::EDGE_PARALLEL_EPSILON;
+    let mut basis_u = Vec3::ZERO;
+    for p in points {
+        let off = *p - centroid;
+        if off.length_squared() > eps * eps {
+            basis_u = off.normalize();
+            break;
+        }
+    }
+    if basis_u == Vec3::ZERO {
+        return None;
+    }
+    for p in points {
+        let off = *p - centroid;
+        let cross = basis_u.cross(off);
+        if cross.length_squared() > eps * eps {
+            let normal = cross.normalize();
+            let basis_v = normal.cross(basis_u);
+            return Some((basis_u, basis_v));
+        }
+    }
+    None
+}
+
+/// Sort cap points by angle around the centroid in the cap's `(basis_u, basis_v)` plane.
+/// Convex polygons sort cleanly under this ordering since the centroid is interior; the
+/// resulting sequence walks the perimeter once.
+fn order_around_centroid(
+    points: &[Vec3],
+    centroid: Vec3,
+    basis_u: Vec3,
+    basis_v: Vec3,
+) -> Vec<Vec3> {
+    let mut indexed: Vec<(usize, f32)> = points
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let off = *p - centroid;
+            let angle = off.dot(basis_v).atan2(off.dot(basis_u));
+            (i, angle)
+        })
+        .collect();
+    indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    indexed.into_iter().map(|(i, _)| points[i]).collect()
+}
+
+// ---------------------------------------------------------------------------
 // Per-polytope vertex caches
 // ---------------------------------------------------------------------------
 //
@@ -997,6 +1232,93 @@ mod tests {
         for (start_color, end_color) in &mesh.colors {
             assert!(palette.contains(start_color));
             assert!(palette.contains(end_color));
+        }
+    }
+
+    // ----------------- Cross-section algorithm -----------------
+
+    /// 5-cell at the midpoint slice: exactly 4 of the 5 cells cross w=0 (the cell missing
+    /// the apex sits entirely at w=-0.25 and is skipped by per-cell pruning). Each crossing
+    /// cell contributes a triangle cap (3 cap vertices), fan-triangulated as 3 sub-triangles
+    /// from the centroid. Total: 4 caps * 3 sub-triangles = 12 triangles; perimeter has
+    /// 4 caps * 3 edges = 12 edges (with duplication where caps share boundary edges).
+    /// Matches Coxeter's classical result: pentatope midpoint section is a regular tetrahedron.
+    #[test]
+    fn pentatope_section_at_midpoint() {
+        let (tri, edges) =
+            polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
+        assert_eq!(tri.indices.len(), 12, "expected 12 fan triangles");
+        assert_eq!(edges.segments.len(), 12, "expected 12 perimeter segments");
+        // Each cap has 4 mesh-vertices (centroid + 3 cap points). 4 caps total.
+        assert_eq!(tri.vertices.len(), 16);
+    }
+
+    /// Tesseract at the midpoint slice: 6 of the 8 cubical cells cross w=0 (the 2 cells with
+    /// `w = +/- 0.5` fixed don't). Each crossing cell contributes a square cap (4 cap
+    /// vertices), fan-triangulated as 4 sub-triangles. Total: 6 caps * 4 sub-triangles = 24
+    /// triangles; perimeter has 6 caps * 4 edges = 24 segments.
+    #[test]
+    fn tesseract_section_at_midpoint_has_six_square_caps() {
+        let (tri, edges) =
+            polytope4_section(Polytope4::Tesseract, rye_math::WPlane::new(0.0));
+        assert_eq!(tri.indices.len(), 24, "6 cubical cells * 4 fan-triangles");
+        assert_eq!(edges.segments.len(), 24, "6 caps * 4 perimeter edges");
+        // Each cap has 5 mesh-vertices (centroid + 4 cap points). 6 caps total.
+        assert_eq!(tri.vertices.len(), 30);
+    }
+
+    /// Slice well outside the polytope (`w = 2` is beyond every vertex's w in any of the
+    /// six polychora) returns an empty section. Per-cell pruning catches this in O(cells).
+    #[test]
+    fn section_outside_polytope_is_empty() {
+        for polytope in Polytope4::ALL {
+            let (tri, edges) = polytope4_section(polytope, rye_math::WPlane::new(2.0));
+            assert!(
+                tri.indices.is_empty(),
+                "{polytope:?} above-vertex slice should yield no triangles"
+            );
+            assert!(
+                edges.segments.is_empty(),
+                "{polytope:?} above-vertex slice should yield no perimeter edges"
+            );
+        }
+    }
+
+    /// Slice placed exactly on a polytope's vertex w-coordinate triggers the perturbation
+    /// path. The result should be valid (no NaN, no infinite triangles), even if the
+    /// perturbed slice produces a slightly different cap than the unperturbed analytical
+    /// case would. Test with the 5-cell base-vertex w = -0.25.
+    #[test]
+    fn vertex_on_slice_is_perturbed_not_nan() {
+        let (tri, edges) =
+            polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(-0.25));
+        for v in &tri.vertices {
+            for component in v {
+                assert!(component.is_finite(), "triangle vertex must be finite");
+            }
+        }
+        for (a, b) in &edges.segments {
+            for component in a.iter().chain(b.iter()) {
+                assert!(component.is_finite(), "edge vertex must be finite");
+            }
+        }
+    }
+
+    /// Slice value inside the polytope's w-range produces non-empty section for every one
+    /// of the six polychora. Catches accidental "always-empty" failures from per-cell
+    /// pruning misjudging the slice value.
+    #[test]
+    fn midpoint_slice_is_non_empty_for_every_polytope() {
+        for polytope in Polytope4::ALL {
+            let (tri, edges) = polytope4_section(polytope, rye_math::WPlane::new(0.0));
+            assert!(
+                !tri.indices.is_empty(),
+                "{polytope:?} midpoint slice should yield triangles"
+            );
+            assert!(
+                !edges.segments.is_empty(),
+                "{polytope:?} midpoint slice should yield perimeter edges"
+            );
         }
     }
 }

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -1572,4 +1572,96 @@ mod tests {
              a face-normal regression may have widened the error."
         );
     }
+
+    // ----------------- Pruning + recompute invariants -----------------
+
+    /// w-range of a cell, helper for `cell_pruning_matches_full_scan`. Independent
+    /// copy of the algorithm's internal `cell_w_range`; if the two ever drift, this
+    /// test fires and signals a refactor that didn't update both sites.
+    fn test_cell_w_range(cell: &[u32], vertices: &[Vec4]) -> (f32, f32) {
+        cell.iter()
+            .map(|&i| vertices[i as usize].w)
+            .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), w| {
+                (lo.min(w), hi.max(w))
+            })
+    }
+
+    /// The per-cell w-range pruning step inside the section algorithm is the
+    /// load-bearing optimization for the 600-cell (factor 100x speedup at typical
+    /// slices). It MUST be exact: every cell that straddles the slice contributes a
+    /// cap, and no cell contributes that doesn't straddle.
+    ///
+    /// Counts caps in the output via `vertices.len() - indices.len()`: each cap's
+    /// fan-triangulation adds one centroid vertex over and above its N cap-vertices
+    /// and emits N triangles, so subtracting triangle count from vertex count
+    /// recovers the number of caps. Compares against an independent count of
+    /// straddling cells computed from the topology directly.
+    #[test]
+    fn cell_pruning_matches_full_scan() {
+        // Slice values across the [-1, 1] interior of each polytope. Avoid grazing
+        // values (within `SLICE_PERTURBATION_EPSILON` of any vertex's w) so the
+        // perturbation path doesn't shift the slice between our independent count
+        // and the algorithm's count.
+        let slices = [-0.7, -0.3, -0.1, 0.0, 0.1, 0.3, 0.7];
+        let eps = rye_math::SLICE_PERTURBATION_EPSILON;
+
+        for polytope in Polytope4::ALL {
+            let topo = polytope.topology();
+            for &w in &slices {
+                // Reproduce the algorithm's perturbation logic so our independent
+                // straddle count uses the same effective slice value the algorithm
+                // does internally.
+                let effective_w = if topo.vertices.iter().any(|v| (v.w - w).abs() < eps) {
+                    w + eps
+                } else {
+                    w
+                };
+                let expected_caps: usize = topo
+                    .cells
+                    .iter()
+                    .filter(|cell| {
+                        let (lo, hi) = test_cell_w_range(cell, topo.vertices);
+                        // Strict `<` matches the algorithm's effective predicate:
+                        // a cell whose w_max == effective_w + eps would be skipped
+                        // by the algorithm's edge-section step (no crossing edge
+                        // produces a finite intersection point at that boundary).
+                        lo < effective_w && effective_w < hi
+                    })
+                    .count();
+
+                let (tri, _) = polytope4_section(polytope, rye_math::WPlane::new(w));
+                let actual_caps = tri.vertices.len().saturating_sub(tri.indices.len());
+
+                assert_eq!(
+                    actual_caps, expected_caps,
+                    "{polytope:?} at slice w={w}: algorithm produced {actual_caps} caps, \
+                     topology-derived straddle count expected {expected_caps}"
+                );
+            }
+        }
+    }
+
+    /// `polytope4_section` is a pure function of `(polytope, slice)`: re-invoking it
+    /// with a different slice produces a different section mesh. Trivial but pins
+    /// the contract so a future caching optimization that accidentally returns a
+    /// stale mesh across slice changes fires here.
+    ///
+    /// **Polytope choice matters.** The tesseract's cubical cells have w-edges
+    /// going from (x,y,z,-0.5) to (x,y,z,+0.5): same R³ endpoints, only differing
+    /// in w. Slicing at any interior `w` produces the same R³ intersection point
+    /// (x,y,z,w_slice), so the tesseract's R³ section is *literally invariant*
+    /// across its w-range. A non-trivial recompute test needs a polytope whose
+    /// cells aren't axis-aligned in w; the 5-cell qualifies (apex edges run from
+    /// (0,0,0,1) to (t,t,t,-0.25), so the slice intersection moves in R³ as `w`
+    /// changes).
+    #[test]
+    fn section_recomputes_when_w_slice_changes() {
+        let (a, _) = polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
+        let (b, _) = polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(0.4));
+        assert_ne!(
+            a.vertices, b.vertices,
+            "section at w=0.0 and w=0.4 must differ; result was identical, \
+             suggesting a stale cache or incorrect slice parameter use"
+        );
+    }
 }

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -267,12 +267,7 @@ pub fn vertex_color_by_position(v: Vec4) -> [f32; 4] {
     let n = v.try_normalize().unwrap_or(Vec4::ZERO);
     let bias = |c: f32| 0.25 + 0.75 * (0.5 + 0.5 * c);
     let w_mod = 0.7 + 0.3 * (0.5 + 0.5 * n.w);
-    [
-        bias(n.x) * w_mod,
-        bias(n.y) * w_mod,
-        bias(n.z) * w_mod,
-        1.0,
-    ]
+    [bias(n.x) * w_mod, bias(n.y) * w_mod, bias(n.z) * w_mod, 1.0]
 }
 
 // ---------------------------------------------------------------------------
@@ -428,9 +423,7 @@ pub fn polytope_section_with_vertices(
 /// degeneracies in one step so the cell-assembly loop can ignore them.
 fn perturb_slice_if_needed(slice: rye_math::WPlane, vertices: &[Vec4]) -> rye_math::WPlane {
     let eps = rye_math::SLICE_PERTURBATION_EPSILON;
-    let near = vertices
-        .iter()
-        .any(|v| (v.w - slice.w_slice).abs() < eps);
+    let near = vertices.iter().any(|v| (v.w - slice.w_slice).abs() < eps);
     if near {
         rye_math::WPlane::new(slice.w_slice + eps)
     } else {
@@ -1264,8 +1257,7 @@ mod tests {
     /// Matches Coxeter's classical result: pentatope midpoint section is a regular tetrahedron.
     #[test]
     fn pentatope_section_at_midpoint() {
-        let (tri, edges) =
-            polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
+        let (tri, edges) = polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
         assert_eq!(tri.indices.len(), 12, "expected 12 fan triangles");
         assert_eq!(edges.segments.len(), 12, "expected 12 perimeter segments");
         // Each cap has 4 mesh-vertices (centroid + 3 cap points). 4 caps total.
@@ -1278,8 +1270,7 @@ mod tests {
     /// triangles; perimeter has 6 caps * 4 edges = 24 segments.
     #[test]
     fn tesseract_section_at_midpoint_has_six_square_caps() {
-        let (tri, edges) =
-            polytope4_section(Polytope4::Tesseract, rye_math::WPlane::new(0.0));
+        let (tri, edges) = polytope4_section(Polytope4::Tesseract, rye_math::WPlane::new(0.0));
         assert_eq!(tri.indices.len(), 24, "6 cubical cells * 4 fan-triangles");
         assert_eq!(edges.segments.len(), 24, "6 caps * 4 perimeter edges");
         // Each cap has 5 mesh-vertices (centroid + 4 cap points). 6 caps total.
@@ -1309,8 +1300,7 @@ mod tests {
     /// case would. Test with the 5-cell base-vertex w = -0.25.
     #[test]
     fn vertex_on_slice_is_perturbed_not_nan() {
-        let (tri, edges) =
-            polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(-0.25));
+        let (tri, edges) = polytope4_section(Polytope4::Pentatope, rye_math::WPlane::new(-0.25));
         for v in &tri.vertices {
             for component in v {
                 assert!(component.is_finite(), "triangle vertex must be finite");

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -239,21 +239,40 @@ impl Polytope4 {
         mesh.segments.reserve(topo.edges.len());
         mesh.colors.reserve(topo.edges.len());
         mesh.widths.reserve(topo.edges.len());
-        let vertex_color = |v: Vec4| -> [f32; 4] {
-            let n = v.try_normalize().unwrap_or(Vec4::ZERO);
-            let bias = |c: f32| 0.25 + 0.75 * (0.5 + 0.5 * c);
-            let w_mod = 0.7 + 0.3 * (0.5 + 0.5 * n.w);
-            [bias(n.x) * w_mod, bias(n.y) * w_mod, bias(n.z) * w_mod, 1.0]
-        };
         for &[i, j] in topo.edges {
             let va = topo.vertices[i as usize];
             let vb = topo.vertices[j as usize];
             mesh.segments.push((va.to_array(), vb.to_array()));
-            mesh.colors.push((vertex_color(va), vertex_color(vb)));
+            mesh.colors
+                .push((vertex_color_by_position(va), vertex_color_by_position(vb)));
             mesh.widths.push(DEFAULT_LINE_WIDTH);
         }
         mesh
     }
+}
+
+/// Map a unit-circumradius 4D vertex to an RGBA color via position-based encoding.
+///
+/// - Normalize the vertex to unit length first (skipped if it's the zero vector).
+/// - `(x + 1) / 2` to R, `(y + 1) / 2` to G, `(z + 1) / 2` to B, biased into `[0.25, 1.0]`
+///   so every vertex stays visible (no fully-black bias).
+/// - `w` modulates brightness multiplicatively in `[0.7, 1.0]` so the hidden dimension is
+///   visible as a soft +w / -w cue without losing contrast.
+///
+/// Deterministic + continuous: adjacent edges sharing a vertex pick up the same vertex
+/// color at that endpoint, so the polytope's symmetry shows as smooth color gradients
+/// across the edge graph. Used by [`Polytope4::lines_colored_by_position`] and by
+/// example-side overlays that build their own meshes from per-body transformed vertices.
+pub fn vertex_color_by_position(v: Vec4) -> [f32; 4] {
+    let n = v.try_normalize().unwrap_or(Vec4::ZERO);
+    let bias = |c: f32| 0.25 + 0.75 * (0.5 + 0.5 * c);
+    let w_mod = 0.7 + 0.3 * (0.5 + 0.5 * n.w);
+    [
+        bias(n.x) * w_mod,
+        bias(n.y) * w_mod,
+        bias(n.z) * w_mod,
+        1.0,
+    ]
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -1470,4 +1470,106 @@ mod tests {
             );
         }
     }
+
+    // ----------------- Cross-validation: section perimeter vs SDF surface ---
+    //
+    // The section perimeter is built from intersections of the parent polytope's
+    // *actual* edge graph with the slice hyperplane, so every perimeter vertex
+    // sits on the parent polytope's true surface by construction. For a
+    // mathematically correct SDF, `polytope_sdf_wolfe(perimeter_vertex, ...)`
+    // would therefore return zero (within numerical tolerance).
+    //
+    // The 120-cell and 600-cell SDFs in [`crate::euclidean_r4`] use dual-polytope
+    // vertices as face normals (see the `BUG` comment on `cell120_face_planes`
+    // and `cell600_face_planes`). Those normals are exact for the 24 axial + 16
+    // tesseract-corner orbits but approximate on the 96 golden-ratio orbits, so
+    // the SDF picks up a measurable non-zero value at perimeter vertices that
+    // lie on those orbits' edges. Tests below pin this divergence quantitatively
+    // so a future BUG fix fires here loudly enough to trigger a coordinated
+    // update of both the SDF code and the rotate_polytopes `surface sdf` path.
+    //
+    // No equivalent tests for 5/8/16/24-cell: their face planes aren't exposed
+    // as `pub` helpers, and the rasterized section path is correct by
+    // construction (`polytope_section_with_vertices` operates on the topology
+    // directly, no SDF involvement).
+
+    /// Reconstruct 4D perimeter vertices from the R³ perimeter mesh: every
+    /// section-perimeter vertex sits on the slice hyperplane by construction, so
+    /// its w-coordinate is exactly `slice.w_slice`.
+    fn perimeter_vertices_4d(perim: &rye_shape::LineMesh<3>, w: f32) -> Vec<Vec4> {
+        let mut out = Vec::with_capacity(perim.segments.len() * 2);
+        for (a, b) in &perim.segments {
+            out.push(Vec4::new(a[0], a[1], a[2], w));
+            out.push(Vec4::new(b[0], b[1], b[2], w));
+        }
+        out
+    }
+
+    /// Worst-case |SDF| evaluated at the 120-cell section perimeter at the
+    /// midpoint slice. The 24 + 16 axial/tesseract-corner orbits give SDF ≈ 0
+    /// (face normals exact); the 96 golden-ratio orbits show a bounded
+    /// non-trivial deviation. Pin both ends:
+    /// - Lower bound `> 1e-3`: a BUG fix that makes the SDF exact would drop
+    ///   this to ~0; the assert fires and someone updates the test bound or
+    ///   deletes the test alongside removing the BUG comments.
+    /// - Upper bound `< 0.1`: catches a face-normal regression that would
+    ///   produce a much wider deviation (e.g., swapping normals for the wrong
+    ///   polytope's vertex set, or a basis-rotation introduced upstream).
+    #[test]
+    fn cell120_section_perimeter_diverges_from_sdf_documenting_bug() {
+        use crate::euclidean_r4::{cell120_face_planes, polytope_sdf_wolfe};
+        let slice = rye_math::WPlane::new(0.0);
+        let (_, perim) = polytope4_section(Polytope4::Cell120, slice);
+        let (normals, inradius) = cell120_face_planes();
+
+        let mut max_dev: f32 = 0.0;
+        for p4 in perimeter_vertices_4d(&perim, slice.w_slice) {
+            let d = polytope_sdf_wolfe(p4, &normals, inradius).abs();
+            if d > max_dev {
+                max_dev = d;
+            }
+        }
+        assert!(
+            max_dev > 1e-3,
+            "Cell120 perimeter agrees with SDF surface within {max_dev}; expected \
+             measurable divergence from the documented BUG. Did `cell120_face_planes` \
+             get fixed? If so, delete this test and the BUG comment."
+        );
+        assert!(
+            max_dev < 0.1,
+            "Cell120 SDF divergence {max_dev} exceeds the documented BUG window; \
+             a face-normal regression may have widened the error."
+        );
+    }
+
+    /// Same shape as `cell120_section_perimeter_diverges_from_sdf_documenting_bug`
+    /// for the 600-cell. The 600-cell carries the symmetric BUG: its true face
+    /// normals are the cell centroids of its tetrahedral cells, but the SDF uses
+    /// the 120-cell's vertex set instead.
+    #[test]
+    fn cell600_section_perimeter_diverges_from_sdf_documenting_bug() {
+        use crate::euclidean_r4::{cell600_face_planes, polytope_sdf_wolfe};
+        let slice = rye_math::WPlane::new(0.0);
+        let (_, perim) = polytope4_section(Polytope4::Cell600, slice);
+        let (normals, inradius) = cell600_face_planes();
+
+        let mut max_dev: f32 = 0.0;
+        for p4 in perimeter_vertices_4d(&perim, slice.w_slice) {
+            let d = polytope_sdf_wolfe(p4, &normals, inradius).abs();
+            if d > max_dev {
+                max_dev = d;
+            }
+        }
+        assert!(
+            max_dev > 1e-3,
+            "Cell600 perimeter agrees with SDF surface within {max_dev}; expected \
+             measurable divergence from the documented BUG. Did `cell600_face_planes` \
+             get fixed? If so, delete this test and the BUG comment."
+        );
+        assert!(
+            max_dev < 0.1,
+            "Cell600 SDF divergence {max_dev} exceeds the documented BUG window; \
+             a face-normal regression may have widened the error."
+        );
+    }
 }

--- a/crates/rye-physics/src/polytope.rs
+++ b/crates/rye-physics/src/polytope.rs
@@ -338,10 +338,10 @@ pub fn polytope_section_with_vertices(
         // Emit a triangle fan from the centroid. The centroid is invisible inside the
         // convex cap; cap vertices form the visible perimeter.
         let cv_base = tri_mesh.vertices.len() as u32;
-        tri_mesh.vertices.push(centroid.point3.to_array());
+        tri_mesh.vertices.push(centroid.to_array());
         tri_mesh.colors.push(SECTION_FILL_COLOR);
         for cap_v in ordered {
-            tri_mesh.vertices.push(cap_v.point3.to_array());
+            tri_mesh.vertices.push(cap_v.to_array());
             tri_mesh.colors.push(SECTION_FILL_COLOR);
         }
         let n = ordered.len() as u32;
@@ -356,8 +356,8 @@ pub fn polytope_section_with_vertices(
         // adjacent cell caps are drawn twice (cells share their face-on-slice edges); the
         // duplication is visually invisible and avoids a global edge-dedup pass.
         for k in 0..ordered.len() {
-            let a = ordered[k].point3;
-            let b = ordered[(k + 1) % ordered.len()].point3;
+            let a = ordered[k];
+            let b = ordered[(k + 1) % ordered.len()];
             edge_mesh.segments.push((a.to_array(), b.to_array()));
             edge_mesh
                 .colors
@@ -369,25 +369,26 @@ pub fn polytope_section_with_vertices(
     (tri_mesh, edge_mesh)
 }
 
-/// Cross-section faces only, opaque + per-vertex position-colored, fan-triangulated.
-/// Intended as the *primary* surface representation for a polychoral body at a w-slice,
-/// replacing the SDF raymarch for the six regular convex 4-polytopes.
+/// Cross-section faces only, solid-colored + opaque + fan-triangulated. Intended as
+/// the *primary* surface representation for a polychoral body at a w-slice, replacing
+/// the SDF raymarch for the six regular convex 4-polytopes.
 ///
 /// Differs from [`polytope_section_with_vertices`] in two ways:
 ///
 /// - Returns only the [`rye_shape::TriangleMesh<3>`]; the caller composes perimeter
 ///   edges separately (typically via the wireframe overlay).
-/// - Per-vertex color comes from [`vertex_color_by_position`] applied to the *4D* parent
-///   point at each edge intersection. Adjacent cells share their cap-vertex 4D positions
-///   (the same edge intersects the same point in both cells), so the gradient is
-///   continuous across cell boundaries (same property the parent wireframe has).
-///   Alpha = 1.0; pairs with `FragmentShading::FaceNormalLambert` in `rye-render` for
-///   faceted shaded surfaces (the rasterizer derives face normals from screen-space
-///   derivatives of position, so no normal attribute is required here).
+/// - Every vertex is the same `color`. Faceted shading is delivered by the rasterizer
+///   (pair this with `FragmentShading::FaceNormalLambert` in `rye-render`, which
+///   derives face normals from screen-space derivatives of position). Flat color +
+///   per-face Lambert reproduces the visual identity of the SDF: a single solid hue
+///   per body, with light + shadow revealing the geometry. Position-based per-vertex
+///   color is intentionally NOT used here because it produces a heatmap-like gradient
+///   across the surface and bleeds across body boundaries when several bodies sit at
+///   different world-x positions.
 ///
-/// The centroid (fan apex) is colored by `vertex_color_by_position` of its 4D centroid
-/// (mean of cap 4D points), not by averaging colors. Keeps the coloring law consistent
-/// across all vertices.
+/// For position-based per-vertex coloring (the wireframe scheme), use
+/// [`vertex_color_by_position`] directly when building your own mesh; the wireframe
+/// path in `rotate_polytopes` is the reference consumer.
 ///
 /// Performance: 600-cell midpoint slice produces ~24-60 active cells × tetrahedral cap
 /// (3-point) × 3 fan-triangles ≈ 200-500 triangles per body per frame. The cost is
@@ -398,20 +399,17 @@ pub fn polytope_section_faces_with_vertices(
     cells: &[&[u32]],
     vertices: &[Vec4],
     slice: rye_math::WPlane,
+    color: [f32; 4],
 ) -> rye_shape::TriangleMesh<3> {
     let mut tri_mesh = rye_shape::TriangleMesh::<3>::default();
 
     for_each_section_cap(edges, cells, vertices, slice, |ordered, centroid| {
         let cv_base = tri_mesh.vertices.len() as u32;
-        tri_mesh.vertices.push(centroid.point3.to_array());
-        tri_mesh
-            .colors
-            .push(opaque(vertex_color_by_position(centroid.point4)));
+        tri_mesh.vertices.push(centroid.to_array());
+        tri_mesh.colors.push(color);
         for cap_v in ordered {
-            tri_mesh.vertices.push(cap_v.point3.to_array());
-            tri_mesh
-                .colors
-                .push(opaque(vertex_color_by_position(cap_v.point4)));
+            tri_mesh.vertices.push(cap_v.to_array());
+            tri_mesh.colors.push(color);
         }
         let n = ordered.len() as u32;
         for k in 0..n {
@@ -427,39 +425,21 @@ pub fn polytope_section_faces_with_vertices(
 
 /// Canonical-vertex convenience: section faces using the polytope's own topology
 /// vertices (unrotated, unit circumradius). Mirrors [`polytope4_section`] but returns
-/// just the position-colored opaque triangle mesh suitable for replacing the SDF
-/// surface.
+/// just the solid-colored opaque triangle mesh suitable for replacing the SDF surface.
 pub fn polytope4_section_faces(
     polytope: Polytope4,
     slice: rye_math::WPlane,
+    color: [f32; 4],
 ) -> rye_shape::TriangleMesh<3> {
     let topo = polytope.topology();
-    polytope_section_faces_with_vertices(topo.edges, topo.cells, topo.vertices, slice)
-}
-
-/// One cap vertex paired with its 4D origin. The R³ point is what the rasterizer
-/// consumes; the R⁴ point is what [`vertex_color_by_position`] needs to keep coloring
-/// continuous across cells (the same 4D edge intersection has the same color in every
-/// cell that contains the edge).
-#[derive(Copy, Clone, Debug)]
-struct CapVertex {
-    point3: Vec3,
-    point4: Vec4,
-}
-
-/// Promote a [`vertex_color_by_position`] RGBA (alpha = 1.0 by construction) to an
-/// opaque RGBA. Defined for clarity at call sites that emit opaque section faces;
-/// the upstream function already sets alpha = 1.0, so this is currently the identity.
-/// Explicit in case the upstream alpha encoding changes.
-fn opaque(rgba: [f32; 4]) -> [f32; 4] {
-    [rgba[0], rgba[1], rgba[2], 1.0]
+    polytope_section_faces_with_vertices(topo.edges, topo.cells, topo.vertices, slice, color)
 }
 
 /// Shared core of the section algorithm: iterate over every cell whose w-range crosses
 /// the slice, intersect the cell's edges with the slice, fit + order the resulting cap
-/// polygon, and invoke `emit` once per cell with the ordered cap vertices (each carrying
-/// both R³ and R⁴ coordinates) and the centroid. Cells that miss the slice or whose cap
-/// degenerates (< 3 vertices, collinear cap) are skipped silently.
+/// polygon, and invoke `emit` once per cell with the ordered cap vertices and centroid
+/// (all in R³). Cells that miss the slice or whose cap degenerates (< 3 vertices,
+/// collinear cap) are skipped silently.
 ///
 /// `emit` is called *in cell order*, which is the topology cell order (deterministic
 /// across runs). Mesh-builders can rely on it for stable triangle ordering between
@@ -474,7 +454,7 @@ fn for_each_section_cap(
     cells: &[&[u32]],
     vertices: &[Vec4],
     slice: rye_math::WPlane,
-    mut emit: impl FnMut(&[CapVertex], CapVertex),
+    mut emit: impl FnMut(&[Vec3], Vec3),
 ) {
     let slice = perturb_slice_if_needed(slice, vertices);
 
@@ -494,26 +474,19 @@ fn for_each_section_cap(
         // per-cell 2-face incidence data; works because the standard polychora's edge
         // sets are exactly their cells' edge sets (cells are convex 3-polytopes whose
         // 1-skeleton is a subgraph of the parent).
-        let mut cap: Vec<CapVertex> = Vec::with_capacity(8);
+        let mut cap: Vec<Vec3> = Vec::with_capacity(8);
         for &[i, j] in edges {
             if !cell.contains(&i) || !cell.contains(&j) {
                 continue;
             }
-            let p0 = vertices[i as usize];
-            let p1 = vertices[j as usize];
-            if let Some((t, p3)) =
+            if let Some((_, p3)) =
                 <rye_math::EuclideanR4 as rye_math::SectionableSpace<4>>::edge_section(
-                    &slice, p0, p1,
+                    &slice,
+                    vertices[i as usize],
+                    vertices[j as usize],
                 )
             {
-                // Reconstruct the 4D intersection point from the lerp parameter `t`.
-                // Same `t` produces the same `p4` for both cells sharing this edge, so
-                // position-coloring stays seamless across cap boundaries.
-                let p4 = p0 + (p1 - p0) * t;
-                cap.push(CapVertex {
-                    point3: p3,
-                    point4: p4,
-                });
+                cap.push(p3);
             }
         }
         if cap.len() < 3 {
@@ -523,26 +496,16 @@ fn for_each_section_cap(
         // Centroid + plane basis. The cap is a convex 2-polygon in R³ (intersection of a
         // convex 3-cell with a hyperplane). `fit_plane_basis` finds two orthonormal basis
         // vectors in the cap's plane via the first non-collinear pair of cap offsets.
-        let centroid_p3: Vec3 = cap.iter().map(|cv| cv.point3).sum::<Vec3>() / cap.len() as f32;
-        let centroid_p4: Vec4 = cap.iter().map(|cv| cv.point4).sum::<Vec4>() / cap.len() as f32;
-        let cap_p3: Vec<Vec3> = cap.iter().map(|cv| cv.point3).collect();
-        let Some((basis_u, basis_v)) = fit_plane_basis(centroid_p3, &cap_p3) else {
+        let centroid: Vec3 = cap.iter().copied().sum::<Vec3>() / cap.len() as f32;
+        let Some((basis_u, basis_v)) = fit_plane_basis(centroid, &cap) else {
             continue;
         };
 
         // Order cap points by angle around the centroid in the (u, v) plane. Convex
-        // polygons sort cleanly under atan2 ordering since the centroid is interior. We
-        // sort the (p3, p4) pairs together so the 4D color stays attached to its 3D
-        // partner across the reorder.
-        let ordered = order_cap_around_centroid(&cap, centroid_p3, basis_u, basis_v);
+        // polygons sort cleanly under atan2 ordering since the centroid is interior.
+        let ordered = order_around_centroid(&cap, centroid, basis_u, basis_v);
 
-        emit(
-            &ordered,
-            CapVertex {
-                point3: centroid_p3,
-                point4: centroid_p4,
-            },
-        );
+        emit(&ordered, centroid);
     }
 }
 
@@ -609,28 +572,26 @@ fn fit_plane_basis(centroid: Vec3, points: &[Vec3]) -> Option<(Vec3, Vec3)> {
     None
 }
 
-/// Sort cap vertices by angle around the centroid in the cap's `(basis_u, basis_v)` plane.
+/// Sort cap points by angle around the centroid in the cap's `(basis_u, basis_v)` plane.
 /// Convex polygons sort cleanly under this ordering since the centroid is interior; the
-/// resulting sequence walks the perimeter once. The 4D companion coordinate
-/// (`CapVertex::point4`) rides along with each R³ point so position-coloring stays
-/// attached to the right cap vertex through the reorder.
-fn order_cap_around_centroid(
-    cap: &[CapVertex],
+/// resulting sequence walks the perimeter once.
+fn order_around_centroid(
+    points: &[Vec3],
     centroid: Vec3,
     basis_u: Vec3,
     basis_v: Vec3,
-) -> Vec<CapVertex> {
-    let mut indexed: Vec<(usize, f32)> = cap
+) -> Vec<Vec3> {
+    let mut indexed: Vec<(usize, f32)> = points
         .iter()
         .enumerate()
-        .map(|(i, cv)| {
-            let off = cv.point3 - centroid;
+        .map(|(i, p)| {
+            let off = *p - centroid;
             let angle = off.dot(basis_v).atan2(off.dot(basis_u));
             (i, angle)
         })
         .collect();
     indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-    indexed.into_iter().map(|(i, _)| cap[i]).collect()
+    indexed.into_iter().map(|(i, _)| points[i]).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -1461,13 +1422,12 @@ mod tests {
         }
     }
 
-    // ----------------- Section faces (filled, position-colored) -----------------
+    // ----------------- Section faces (filled, solid-colored) -----------------
     //
     // The face variant ([`polytope4_section_faces`]) shares its geometric core with
-    // [`polytope4_section`] via [`for_each_section_cap`]. The tests below pin the
-    // additional invariants specific to the face variant: triangle count agreement
-    // with the overlay variant, opaque + non-uniform per-vertex coloring, and color
-    // continuity across cell boundaries.
+    // [`polytope4_section`] via [`for_each_section_cap`]. Tests below pin the
+    // invariants specific to the face variant: triangle count agreement with the
+    // overlay variant, and that every vertex carries the caller-provided color.
 
     /// Face triangulation produces the same triangle count as the overlay's triangle
     /// output, since both go through the same cap-iteration core. Agreement here is
@@ -1475,10 +1435,11 @@ mod tests {
     /// one variant relative to the other.
     #[test]
     fn section_faces_triangle_count_matches_section_triangles() {
+        let probe_color = [0.5, 0.5, 0.5, 1.0];
         for polytope in Polytope4::ALL {
             let slice = rye_math::WPlane::new(0.1);
             let (overlay_tri, _) = polytope4_section(polytope, slice);
-            let faces_tri = polytope4_section_faces(polytope, slice);
+            let faces_tri = polytope4_section_faces(polytope, slice, probe_color);
             assert_eq!(
                 faces_tri.indices.len(),
                 overlay_tri.indices.len(),
@@ -1492,76 +1453,21 @@ mod tests {
         }
     }
 
-    /// All face vertices have alpha = 1.0 and at least one non-grey color appears.
-    /// Pins that the position-coloring scheme is actually being applied (a regression
-    /// to a fixed white fill would still produce alpha = 1.0 but only one unique color
-    /// across all vertices).
+    /// Every face vertex carries exactly the color passed to the constructor. Pins
+    /// the "solid per-body color" contract; faceted shading is the rasterizer's job,
+    /// not the mesh's. Catches a regression where the helper accidentally reintroduces
+    /// position-based per-vertex coloring (which would produce a heatmap effect across
+    /// the surface and bleed across body boundaries).
     #[test]
-    fn section_faces_are_opaque_and_position_colored() {
-        // 5-cell midpoint slice produces 4 tetrahedral caps with cap vertices on the
-        // edges of the parent (the 4D edge midpoints), which span enough of the unit
-        // 3-sphere to produce visibly different colors per vertex.
-        let mesh = polytope4_section_faces(Polytope4::Pentatope, rye_math::WPlane::new(0.0));
+    fn section_faces_use_supplied_color_uniformly() {
+        let color = [0.95, 0.55, 0.30, 1.0];
+        let mesh = polytope4_section_faces(Polytope4::Pentatope, rye_math::WPlane::new(0.0), color);
         assert!(!mesh.colors.is_empty(), "section faces must produce colors");
-        for c in &mesh.colors {
-            assert!(
-                (c[3] - 1.0).abs() < 1e-6,
-                "section face vertex must be opaque (alpha = 1.0), got {c:?}"
+        for (i, c) in mesh.colors.iter().enumerate() {
+            assert_eq!(
+                *c, color,
+                "section face vertex {i} has color {c:?}, expected {color:?}"
             );
-        }
-        // At least two distinct colors across the cap vertex set. Catches a
-        // regression where all vertices land on the same color (e.g. a future
-        // refactor accidentally passing the centroid 4D point to every cap vertex).
-        let distinct: std::collections::HashSet<[u32; 3]> = mesh
-            .colors
-            .iter()
-            .map(|c| [c[0].to_bits(), c[1].to_bits(), c[2].to_bits()])
-            .collect();
-        assert!(
-            distinct.len() >= 2,
-            "section face coloring is degenerate: only {} unique color(s)",
-            distinct.len()
-        );
-    }
-
-    /// Cap vertices shared between adjacent cells (i.e., a parent-edge's intersection
-    /// with the slice, which belongs to every cell containing that edge) receive the
-    /// SAME color in every cap. Catches a regression where the cap-vertex color
-    /// depends on cell context rather than the 4D intersection point.
-    #[test]
-    fn section_faces_color_is_continuous_across_cells() {
-        // Tesseract midpoint slice has 6 square caps; each cap-edge of one cap is
-        // shared with exactly one adjacent cap. So cap-vertex coordinates appear in
-        // pairs: two cells, same R³ position, must have the same color.
-        let mesh = polytope4_section_faces(Polytope4::Tesseract, rye_math::WPlane::new(0.0));
-
-        // Bucket cap vertices by R³ position (with quantization to absorb f32 jitter).
-        // For each position, all bucketed colors must agree.
-        use std::collections::HashMap;
-        let mut by_pos: HashMap<[i32; 3], Vec<[f32; 4]>> = HashMap::new();
-        for (v, c) in mesh.vertices.iter().zip(mesh.colors.iter()) {
-            let key = [
-                (v[0] * 1e4).round() as i32,
-                (v[1] * 1e4).round() as i32,
-                (v[2] * 1e4).round() as i32,
-            ];
-            by_pos.entry(key).or_default().push(*c);
-        }
-        for (pos, colors) in &by_pos {
-            // Centroids are unique per cell; only inspect positions that appear in
-            // multiple caps (= cap-perimeter vertices shared between adjacent cells).
-            if colors.len() < 2 {
-                continue;
-            }
-            let first = colors[0];
-            for c in &colors[1..] {
-                for k in 0..4 {
-                    assert!(
-                        (c[k] - first[k]).abs() < 1e-5,
-                        "color discontinuity at shared cap vertex {pos:?}: {first:?} vs {c:?}"
-                    );
-                }
-            }
         }
     }
 }

--- a/crates/rye-render/src/depth.rs
+++ b/crates/rye-render/src/depth.rs
@@ -1,0 +1,97 @@
+//! Swapchain-sized depth-attachment helper for examples that compose multiple raster
+//! passes against a shared depth buffer.
+//!
+//! The crate doesn't take a position on which format to use; callers pass it explicitly so
+//! a demo can switch between `Depth32Float` (highest precision, no stencil), `Depth24Plus`
+//! (conventional), or any other depth-capable format. Sample count must match the color
+//! attachment's MSAA configuration.
+//!
+//! Typical usage in an example's `render` function:
+//!
+//! ```ignore
+//! DepthBuffer::ensure(
+//!     &mut self.depth,
+//!     &rd.device,
+//!     wgpu::TextureFormat::Depth32Float,
+//!     (cfg.width, cfg.height),
+//!     rd.sample_count(),
+//! );
+//! let depth = self.depth.as_ref().expect("ensured above");
+//! // clear pass then raster passes against `depth.view`
+//! ```
+//!
+//! The framework doesn't surface a resize hook on `App`, so [`DepthBuffer::ensure`] checks size +
+//! sample count each frame and recreates the texture only when they change. Holds the
+//! [`wgpu::TextureView`] only; the underlying texture stays alive via wgpu's internal Arc
+//! reference held by the view.
+
+use wgpu::{
+    Device, Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
+    TextureView, TextureViewDescriptor,
+};
+
+/// Owns a depth texture view sized to the swapchain, recreated on resize.
+pub struct DepthBuffer {
+    /// Texture view bound to the depth attachment in [`wgpu::RenderPassDepthStencilAttachment`].
+    pub view: TextureView,
+    /// Format the texture was created with. Stored so [`Self::ensure`] can recreate when
+    /// the caller changes its mind (rare in practice).
+    pub format: TextureFormat,
+    /// Pixel dimensions of the underlying texture. Recreate when these change.
+    size: (u32, u32),
+    /// MSAA sample count. Recreate when this changes (e.g., the runtime negotiates a
+    /// different MSAA level than was requested).
+    sample_count: u32,
+}
+
+impl DepthBuffer {
+    /// Allocate a new depth texture and return its view. Stable until the caller changes
+    /// any of `format`, `size`, or `sample_count`.
+    pub fn new(
+        device: &Device,
+        format: TextureFormat,
+        size: (u32, u32),
+        sample_count: u32,
+    ) -> Self {
+        let texture = device.create_texture(&TextureDescriptor {
+            label: Some("rye-render DepthBuffer"),
+            size: Extent3d {
+                width: size.0,
+                height: size.1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count,
+            dimension: TextureDimension::D2,
+            format,
+            usage: TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&TextureViewDescriptor::default());
+        Self {
+            view,
+            format,
+            size,
+            sample_count,
+        }
+    }
+
+    /// Recreate the depth buffer in-place when its format / size / sample count don't
+    /// match the requested values. No-op when everything already matches. Intended to be
+    /// called once per frame at the top of the render function.
+    pub fn ensure(
+        slot: &mut Option<DepthBuffer>,
+        device: &Device,
+        format: TextureFormat,
+        size: (u32, u32),
+        sample_count: u32,
+    ) {
+        let needs_recreate = match slot {
+            Some(b) => b.format != format || b.size != size || b.sample_count != sample_count,
+            None => true,
+        };
+        if needs_recreate {
+            *slot = Some(DepthBuffer::new(device, format, size, sample_count));
+        }
+    }
+}

--- a/crates/rye-render/src/depth.rs
+++ b/crates/rye-render/src/depth.rs
@@ -20,10 +20,10 @@
 //! // clear pass then raster passes against `depth.view`
 //! ```
 //!
-//! The framework doesn't surface a resize hook on `App`, so [`DepthBuffer::ensure`] checks size +
-//! sample count each frame and recreates the texture only when they change. Holds the
-//! [`wgpu::TextureView`] only; the underlying texture stays alive via wgpu's internal Arc
-//! reference held by the view.
+//! The framework doesn't surface a resize hook on `App`, so [`DepthBuffer::ensure`] checks
+//! size + sample count each frame and recreates the texture only when they change. Holds
+//! the [`wgpu::TextureView`] only; the underlying texture stays alive via wgpu's internal
+//! Arc reference held by the view.
 
 use wgpu::{
     Device, Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
@@ -32,7 +32,7 @@ use wgpu::{
 
 /// Owns a depth texture view sized to the swapchain, recreated on resize.
 pub struct DepthBuffer {
-    /// Texture view bound to the depth attachment in [`wgpu::RenderPassDepthStencilAttachment`].
+    /// Texture view bound to the `wgpu::RenderPassDepthStencilAttachment`.
     pub view: TextureView,
     /// Format the texture was created with. Stored so [`Self::ensure`] can recreate when
     /// the caller changes its mind (rare in practice).

--- a/crates/rye-render/src/lib.rs
+++ b/crates/rye-render/src/lib.rs
@@ -24,7 +24,9 @@ pub use depth::DepthBuffer;
 pub use lattice::Viewport;
 pub use line_raster::{LineRasterNode, LineRasterUniforms};
 pub use raymarch::{GeodesicRayMarchNode, RayMarchNode, RayMarchUniforms};
-pub use triangle_raster::{TriangleRasterNode, TriangleRasterUniforms, TriangleVertex};
+pub use triangle_raster::{
+    FragmentShading, TriangleRasterNode, TriangleRasterUniforms, TriangleVertex,
+};
 
 /// How a rasterizer pipeline interacts with depth. Three states only -- avoids the
 /// invalid-combination problem an `Option<TextureFormat> + bool depth_write` API would

--- a/crates/rye-render/src/lib.rs
+++ b/crates/rye-render/src/lib.rs
@@ -17,7 +17,52 @@ pub mod graph;
 pub mod lattice;
 pub mod line_raster;
 pub mod raymarch;
+pub mod triangle_raster;
 
 pub use lattice::Viewport;
 pub use line_raster::{LineRasterNode, LineRasterUniforms};
 pub use raymarch::{GeodesicRayMarchNode, RayMarchNode, RayMarchUniforms};
+pub use triangle_raster::{TriangleRasterNode, TriangleRasterUniforms, TriangleVertex};
+
+/// How a rasterizer pipeline interacts with depth. Three states only -- avoids the
+/// invalid-combination problem an `Option<TextureFormat> + bool depth_write` API would
+/// have. Shared by [`LineRasterNode`] and [`TriangleRasterNode`].
+///
+/// - [`DepthMode::Off`]: no depth attachment; passes draw on top in submission order.
+///   Useful for HUD-style overlays where occlusion doesn't matter.
+/// - [`DepthMode::ReadWrite`]: standard scene-geometry mode. Per-fragment `depth_compare:
+///   Less` + depth-write enabled; this is how lines and filled triangles behave in
+///   normal 3D rendering.
+/// - [`DepthMode::ReadOnly`]: depth-test against the existing buffer but don't write to
+///   it. Used for alpha-blended overlays that should be occluded by scene geometry
+///   in front of them without burying subsequent draws behind them in depth.
+#[derive(Copy, Clone, Debug)]
+pub enum DepthMode {
+    Off,
+    ReadWrite { format: wgpu::TextureFormat },
+    ReadOnly { format: wgpu::TextureFormat },
+}
+
+impl DepthMode {
+    /// Format of the depth attachment, if any. Used by the pipeline-builder helpers to
+    /// configure the [`wgpu::DepthStencilState`] uniformly.
+    pub fn format(&self) -> Option<wgpu::TextureFormat> {
+        match self {
+            DepthMode::Off => None,
+            DepthMode::ReadWrite { format } | DepthMode::ReadOnly { format } => Some(*format),
+        }
+    }
+
+    /// `true` for any depth-aware mode (read-only or read-write). The pipeline needs a
+    /// depth attachment when this is `true`; execute() validates this against the
+    /// caller's `Option<&TextureView>`.
+    pub fn is_active(&self) -> bool {
+        !matches!(self, DepthMode::Off)
+    }
+
+    /// Whether the pipeline should write depth. `false` for `Off` and `ReadOnly`;
+    /// `true` for `ReadWrite`.
+    pub fn writes(&self) -> bool {
+        matches!(self, DepthMode::ReadWrite { .. })
+    }
+}

--- a/crates/rye-render/src/lib.rs
+++ b/crates/rye-render/src/lib.rs
@@ -12,6 +12,7 @@
 //! The crate stays deliberately small: it hands wgpu primitives to callers rather than
 //! abstracting them behind a higher-level engine API.
 
+pub mod depth;
 pub mod device;
 pub mod graph;
 pub mod lattice;
@@ -19,6 +20,7 @@ pub mod line_raster;
 pub mod raymarch;
 pub mod triangle_raster;
 
+pub use depth::DepthBuffer;
 pub use lattice::Viewport;
 pub use line_raster::{LineRasterNode, LineRasterUniforms};
 pub use raymarch::{GeodesicRayMarchNode, RayMarchNode, RayMarchUniforms};

--- a/crates/rye-render/src/line_raster.rs
+++ b/crates/rye-render/src/line_raster.rs
@@ -273,10 +273,14 @@ impl LineRasterNode {
             depth_stencil: depth.format().map(|format| DepthStencilState {
                 format,
                 depth_write_enabled: depth.writes(),
-                // `Less` is the convention: a fragment writes only if it's closer than what's
-                // already there. The clear value at the start of the frame is `1.0` (far plane);
-                // any rendered fragment passes the test until something nearer overwrites it.
-                depth_compare: CompareFunction::Less,
+                // `LessEqual` rather than the usual `Less`: lines are typically drawn on top
+                // of filled triangles as overlays / outlines / wireframes, and the polygon
+                // outline use case puts the line at *exactly* the polygon's depth. Strict
+                // `Less` would discard the line in that case (`line_depth < tri_depth` fails
+                // when they're equal), making outlines invisible wherever they coincide with
+                // their own polygon. `LessEqual` keeps them visible. Lines geometrically
+                // behind a filled surface still fail the test and are correctly occluded.
+                depth_compare: CompareFunction::LessEqual,
                 stencil: StencilState::default(),
                 bias: wgpu::DepthBiasState::default(),
             }),

--- a/crates/rye-render/src/line_raster.rs
+++ b/crates/rye-render/src/line_raster.rs
@@ -1,7 +1,7 @@
 //! Line rasterizer pipeline. Antialiased line-list rendering composed on top of an existing
-//! color attachment ("HUD overlay" semantics). Lines are quad-expanded in the vertex shader to
-//! give them pixel width and antialiased edges; the fragment shader smoothsteps coverage from
-//! line center to expanded edge.
+//! color attachment. Lines are quad-expanded in the vertex shader to give them pixel width and
+//! antialiased edges; the fragment shader smoothsteps coverage from line center to expanded
+//! edge.
 //!
 //! Lives next to [`crate::raymarch`] modules and is constructed standalone, the same way the
 //! existing `Hyperslice4DNode` is.
@@ -16,16 +16,31 @@
 //! - **Uniform buffer**: `LineRasterUniforms` (view-projection matrix + viewport size).
 //!   Re-uploaded per frame via the camera method.
 //!
+//! ## Depth
+//!
+//! [`LineRasterNode::new`] takes a [`crate::DepthMode`]:
+//!
+//! - `Off`: no depth attachment, lines draw on top in submission order (HUD-style overlay).
+//! - `ReadWrite { format }`: standard scene-geometry depth, `depth_compare: Less` +
+//!   depth-write enabled. Use for opaque line wireframes that should occlude / be
+//!   occluded by other depth-aware geometry.
+//! - `ReadOnly { format }`: depth-test against the existing buffer but don't write. Use
+//!   for alpha-blended overlays that should be occluded by scene geometry in front of
+//!   them without burying subsequent draws behind them.
+//!
+//! When depth is active (`ReadWrite` or `ReadOnly`), [`LineRasterNode::execute`] requires
+//! the matching depth attachment.
+//!
+//! The caller owns the depth texture lifecycle: examples create a swapchain-sized depth
+//! texture, recreate it on resize, and clear it via a dedicated clear pass before the
+//! rasterizer's draw (which uses `LoadOp::Load` for both color and depth).
+//!
 //! ## Current limitations
 //!
-//! - No depth read or write. The overlay always draws on top of the existing scene; useful
-//!   for debug / visualization, not for honest 3D occlusion. Depth-tested compositing is
-//!   additive: add a depth attachment to the render pass and have the raymarcher emit
-//!   `FragDepth`.
-//! - R³ only at v1. R⁴ projection + topology-derived polytope wireframes are additive impls
-//!   on `RasterizableSpace<4>` and `Visualizable<4>`.
-//! - [`Projection<N>::Identity`] only; Orthographic / Perspective / Schlegel / Stereographic /
-//!   Hyperslice variants are open extensions.
+//! - R³ + R⁴ impls only; other dimensions are additive on `RasterizableSpace<N>` and
+//!   `Visualizable<N>`.
+//! - [`Projection<N>`] variants beyond `Identity` + `Orthographic` (Perspective, Schlegel,
+//!   Stereographic, Hyperslice) are open extensions.
 
 use bytemuck::{Pod, Zeroable};
 use glam::{Mat4, Vec2};
@@ -36,11 +51,12 @@ use wgpu::{
     BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor,
     BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor, BlendOperation, BlendState,
     Buffer, BufferBindingType, BufferDescriptor, BufferUsages, ColorTargetState, ColorWrites,
-    CommandEncoderDescriptor, Device, FragmentState, LoadOp, MultisampleState, Operations,
-    PipelineLayoutDescriptor, PrimitiveState, PrimitiveTopology, Queue, RenderPassColorAttachment,
-    RenderPassDescriptor, RenderPipeline, RenderPipelineDescriptor, ShaderModuleDescriptor,
-    ShaderSource, ShaderStages, StoreOp, TextureFormat, VertexAttribute, VertexBufferLayout,
-    VertexFormat, VertexState, VertexStepMode,
+    CommandEncoderDescriptor, CompareFunction, DepthStencilState, Device, FragmentState, LoadOp,
+    MultisampleState, Operations, PipelineLayoutDescriptor, PrimitiveState, PrimitiveTopology,
+    Queue, RenderPassColorAttachment, RenderPassDepthStencilAttachment, RenderPassDescriptor,
+    RenderPipeline, RenderPipelineDescriptor, ShaderModuleDescriptor, ShaderSource, ShaderStages,
+    StencilState, StoreOp, TextureFormat, VertexAttribute, VertexBufferLayout, VertexFormat,
+    VertexState, VertexStepMode,
 };
 
 use crate::device::RenderDevice;
@@ -113,12 +129,26 @@ pub struct LineRasterNode {
     /// Allocated capacity of `instance_buf` in instances. The buffer is re-created if a future
     /// upload exceeds this.
     instance_capacity: u32,
+    /// `true` if the pipeline was created with a depth attachment; [`Self::execute`] then
+    /// requires the matching depth view. Tracks the depth-or-not API contract so callers
+    /// don't silently get mismatched render passes.
+    has_depth: bool,
 }
 
 impl LineRasterNode {
-    /// Construct the pipeline. `surface_format` must match the color attachment at draw time;
-    /// `sample_count` must match the attachment's MSAA sample count.
-    pub fn new(device: &Device, surface_format: TextureFormat, sample_count: u32) -> Self {
+    /// Construct the pipeline.
+    ///
+    /// - `surface_format` must match the color attachment at draw time.
+    /// - `depth`: see [`crate::DepthMode`]. Determines whether the pipeline reads depth,
+    ///   reads + writes depth, or skips it entirely.
+    /// - `sample_count` must match the attachment's MSAA sample count (color and depth
+    ///   must share it when depth is enabled).
+    pub fn new(
+        device: &Device,
+        surface_format: TextureFormat,
+        depth: crate::DepthMode,
+        sample_count: u32,
+    ) -> Self {
         let module = device.create_shader_module(ShaderModuleDescriptor {
             label: Some("line_raster shader"),
             source: ShaderSource::Wgsl(LINE_RASTER_WGSL.into()),
@@ -240,7 +270,16 @@ impl LineRasterNode {
                 topology: PrimitiveTopology::TriangleList,
                 ..Default::default()
             },
-            depth_stencil: None,
+            depth_stencil: depth.format().map(|format| DepthStencilState {
+                format,
+                depth_write_enabled: depth.writes(),
+                // `Less` is the convention: a fragment writes only if it's closer than what's
+                // already there. The clear value at the start of the frame is `1.0` (far plane);
+                // any rendered fragment passes the test until something nearer overwrites it.
+                depth_compare: CompareFunction::Less,
+                stencil: StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
             multisample: MultisampleState {
                 count: sample_count,
                 ..Default::default()
@@ -281,6 +320,7 @@ impl LineRasterNode {
             instance_buf,
             instance_count: 0,
             instance_capacity,
+            has_depth: depth.is_active(),
         }
     }
 
@@ -374,8 +414,32 @@ impl LineRasterNode {
 
     /// Render the uploaded line mesh onto `view`. `LoadOp::Load` preserves the existing color
     /// attachment contents; the rasterizer composes with whatever ran before it (the
-    /// raymarcher's scene render in `rotate_polytopes`).
-    pub fn execute(&self, rd: &RenderDevice, view: &wgpu::TextureView) -> anyhow::Result<()> {
+    /// raymarcher's scene render in `rotate_polytopes`, or a dedicated clear pass).
+    ///
+    /// `depth_view` is required when the pipeline was created with `Some(depth_format)` and
+    /// must be `None` otherwise. Mismatch panics with a descriptive message rather than
+    /// surfacing a less-readable wgpu validation error.
+    pub fn execute(
+        &self,
+        rd: &RenderDevice,
+        view: &wgpu::TextureView,
+        depth_view: Option<&wgpu::TextureView>,
+    ) -> anyhow::Result<()> {
+        match (self.has_depth, depth_view.is_some()) {
+            (true, false) => {
+                panic!(
+                    "LineRasterNode::execute: pipeline was created with a depth format but \
+                     no depth view was provided"
+                )
+            }
+            (false, true) => {
+                panic!(
+                    "LineRasterNode::execute: pipeline was created without a depth format but \
+                     a depth view was provided"
+                )
+            }
+            _ => {}
+        }
         if self.instance_count == 0 {
             return Ok(());
         }
@@ -383,6 +447,18 @@ impl LineRasterNode {
             label: Some("line_raster encoder"),
         });
         {
+            let depth_attachment = depth_view.map(|dv| RenderPassDepthStencilAttachment {
+                view: dv,
+                // `Load` matches the color attachment: the caller is responsible for clearing
+                // depth (typically in the same clear pass that clears color). This lets
+                // multiple LineRasterNode / TriangleRasterNode draws share one depth buffer
+                // within a frame without each clearing it.
+                depth_ops: Some(Operations {
+                    load: LoadOp::Load,
+                    store: StoreOp::Store,
+                }),
+                stencil_ops: None,
+            });
             let mut rp = encoder.begin_render_pass(&RenderPassDescriptor {
                 label: Some("line_raster pass"),
                 color_attachments: &[Some(RenderPassColorAttachment {
@@ -394,7 +470,7 @@ impl LineRasterNode {
                         store: StoreOp::Store,
                     },
                 })],
-                depth_stencil_attachment: None,
+                depth_stencil_attachment: depth_attachment,
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });

--- a/crates/rye-render/src/raymarch/mod.rs
+++ b/crates/rye-render/src/raymarch/mod.rs
@@ -23,6 +23,99 @@ pub use hyperslice4d::{
 };
 pub use polytope_data::{polytope_extended_sdfs_wgsl, polytope_stub_sdfs_wgsl};
 
+/// Bridge a raymarch shape ID (one of the `SHAPE_*` u32 constants re-exported above) to
+/// the corresponding [`rye_physics::polytope::Polytope4`] variant for the six convex
+/// regular polychora. Returns `None` for the smooth-surface SDFs (`SHAPE_3SPHERE`,
+/// `SHAPE_DUOCYLINDER`, `SHAPE_CLIFFORD_TORUS`, `SHAPE_SPHERINDER`) which have no polytope
+/// topology -- the cross-section algorithm and per-vertex coloring don't apply to them.
+///
+/// Low-level bridge for callers that already have a raw `u32`. Higher-level call sites
+/// (catalogs, panel state) should prefer [`RaymarchShape`], which unifies the GPU shape
+/// ID and the polytope topology on one type.
+pub fn polytope4_from_shape_id(shape: u32) -> Option<rye_physics::polytope::Polytope4> {
+    use rye_physics::polytope::Polytope4;
+    Some(match shape {
+        s if s == SHAPE_PENTATOPE => Polytope4::Pentatope,
+        s if s == SHAPE_TESSERACT => Polytope4::Tesseract,
+        s if s == SHAPE_16CELL => Polytope4::Cell16,
+        s if s == SHAPE_24CELL => Polytope4::Cell24,
+        s if s == SHAPE_120CELL => Polytope4::Cell120,
+        s if s == SHAPE_600CELL => Polytope4::Cell600,
+        _ => return None,
+    })
+}
+
+/// All shapes the hyperslice raymarch kernel can render, unified across the polychoral
+/// and smooth-surface families.
+///
+/// - The six convex regular polychora wrap a [`rye_physics::polytope::Polytope4`] so callers
+///   can pull topology + vertex generators alongside the GPU shape ID via
+///   [`RaymarchShape::polytope4`] / [`rye_physics::polytope::Polytope4::topology`].
+/// - The four smooth-surface SDFs (3-sphere, duocylinder, Clifford torus, spherinder) are
+///   their own variants. They have no polytope topology, so [`RaymarchShape::polytope4`]
+///   returns `None` for them.
+///
+/// Use this in app catalogs instead of raw `u32` shape IDs so adding a new shape is
+/// type-checked end-to-end. The raw `u32` for the GPU side comes from
+/// [`RaymarchShape::shape_id`]; if needed, [`From<RaymarchShape> for u32`] supplies the
+/// same conversion via `.into()`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RaymarchShape {
+    /// One of the six convex regular 4-polytopes.
+    Polytope(rye_physics::polytope::Polytope4),
+    /// 4-ball boundary (a 3-sphere SDF; smooth, no topology).
+    ThreeSphere,
+    /// Cartesian product of two disks; smooth.
+    Duocylinder,
+    /// Flat 2-torus embedded in S³; smooth.
+    CliffordTorus,
+    /// Cylinder x line, extended to 4D; smooth.
+    Spherinder,
+}
+
+impl RaymarchShape {
+    /// GPU-side shape index (matches a `SHAPE_*` u32 constant). The hyperslice kernel
+    /// branches on this when computing the SDF for a body.
+    pub fn shape_id(&self) -> u32 {
+        use rye_physics::polytope::Polytope4;
+        match self {
+            RaymarchShape::Polytope(p) => match p {
+                Polytope4::Pentatope => SHAPE_PENTATOPE,
+                Polytope4::Tesseract => SHAPE_TESSERACT,
+                Polytope4::Cell16 => SHAPE_16CELL,
+                Polytope4::Cell24 => SHAPE_24CELL,
+                Polytope4::Cell120 => SHAPE_120CELL,
+                Polytope4::Cell600 => SHAPE_600CELL,
+            },
+            RaymarchShape::ThreeSphere => SHAPE_3SPHERE,
+            RaymarchShape::Duocylinder => SHAPE_DUOCYLINDER,
+            RaymarchShape::CliffordTorus => SHAPE_CLIFFORD_TORUS,
+            RaymarchShape::Spherinder => SHAPE_SPHERINDER,
+        }
+    }
+
+    /// The polytope variant for polychoral shapes, or `None` for smooth-surface shapes
+    /// that don't have a polytope topology.
+    pub fn polytope4(&self) -> Option<rye_physics::polytope::Polytope4> {
+        match self {
+            RaymarchShape::Polytope(p) => Some(*p),
+            _ => None,
+        }
+    }
+}
+
+impl From<rye_physics::polytope::Polytope4> for RaymarchShape {
+    fn from(p: rye_physics::polytope::Polytope4) -> Self {
+        RaymarchShape::Polytope(p)
+    }
+}
+
+impl From<RaymarchShape> for u32 {
+    fn from(s: RaymarchShape) -> u32 {
+        s.shape_id()
+    }
+}
+
 use anyhow::Result;
 use bytemuck::{Pod, Zeroable};
 use wgpu::*;

--- a/crates/rye-render/src/triangle_raster.rs
+++ b/crates/rye-render/src/triangle_raster.rs
@@ -1,0 +1,432 @@
+//! Triangle rasterizer pipeline. Per-vertex color, optional depth attachment,
+//! alpha-blended composition on top of the existing color attachment. Parallel to
+//! [`crate::line_raster::LineRasterNode`] in shape; the two are designed to share a
+//! depth attachment within a frame so filled triangles and outline edges occlude each
+//! other correctly.
+//!
+//! Triangles are native to the rasterizer (no quad expansion); the WGSL is small.
+//!
+//! ## Pipeline shape
+//!
+//! - **Vertex buffer**: per-vertex [`TriangleVertex`] (position in R³ + color).
+//! - **Index buffer**: u32 indices into the vertex buffer.
+//! - **Uniform buffer**: [`TriangleRasterUniforms`] -- just the view-projection matrix.
+//! - **Depth attachment**: opt-in at construction via [`crate::DepthMode`]
+//!   ([`crate::DepthMode::Off`] / [`crate::DepthMode::ReadWrite`] /
+//!   [`crate::DepthMode::ReadOnly`]). Same semantics as
+//!   [`crate::line_raster::LineRasterNode`]: the caller owns the depth texture lifecycle
+//!   and clears it once per frame; [`TriangleRasterNode::execute`] uses `LoadOp::Load`.
+//!
+//! ## Why per-vertex color + no normals
+//!
+//! `TriangleMesh<N>`'s docs spell this out: lighting in R⁴ has no standard convention, so
+//! normals are deliberately omitted at v1. Per-vertex color covers the cross-section /
+//! face-fill / debug-fill use cases the rasterizer was built for. Add normals when a real
+//! consumer (lit shading in a specific Space) demands them.
+
+use bytemuck::{Pod, Zeroable};
+use glam::Mat4;
+use rye_math::{Projection, RasterizableSpace};
+use rye_shape::TriangleMesh;
+use wgpu::{
+    BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor,
+    BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor, BlendOperation, BlendState,
+    Buffer, BufferBindingType, BufferDescriptor, BufferUsages, ColorTargetState, ColorWrites,
+    CommandEncoderDescriptor, CompareFunction, DepthStencilState, Device, FragmentState, LoadOp,
+    MultisampleState, Operations, PipelineLayoutDescriptor, PrimitiveState, PrimitiveTopology,
+    Queue, RenderPassColorAttachment, RenderPassDepthStencilAttachment, RenderPassDescriptor,
+    RenderPipeline, RenderPipelineDescriptor, ShaderModuleDescriptor, ShaderSource, ShaderStages,
+    StencilState, StoreOp, TextureFormat, VertexAttribute, VertexBufferLayout, VertexFormat,
+    VertexState, VertexStepMode,
+};
+
+use crate::device::RenderDevice;
+
+/// Embedded WGSL source. Naga-validated in tests for ABI drift detection.
+const TRIANGLE_RASTER_WGSL: &str = include_str!("triangle_raster.wgsl");
+
+/// Camera uniform handed to the triangle vertex shader. Just the view-projection matrix; no
+/// viewport size (triangles don't need pixel-to-NDC scaling the way the line rasterizer's
+/// quad expansion does). 64 bytes, 16-byte aligned, matches WGSL `CameraUniform` std140
+/// layout exactly.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct TriangleRasterUniforms {
+    /// World-to-clip transform. Bit-identical to whatever the rest of the frame uses.
+    pub view_projection: [[f32; 4]; 4],
+}
+
+impl Default for TriangleRasterUniforms {
+    fn default() -> Self {
+        Self {
+            view_projection: Mat4::IDENTITY.to_cols_array_2d(),
+        }
+    }
+}
+
+/// Per-vertex GPU layout. Position is in R³ (after the upload path projects from R^N via
+/// [`RasterizableSpace::project_point`]); color is RGBA in linear space. 32 bytes per vertex
+/// with explicit padding so the attribute offsets stay stable across compilers.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable, Default)]
+pub struct TriangleVertex {
+    pub position: [f32; 3],
+    pub _pad0: f32,
+    pub color: [f32; 4],
+}
+
+/// Triangle rasterizer node. Parallel to [`crate::line_raster::LineRasterNode`]; both
+/// own their pipeline + buffers and are constructed standalone.
+pub struct TriangleRasterNode {
+    pipeline: RenderPipeline,
+    uniform_buf: Buffer,
+    bind_group: BindGroup,
+
+    /// Per-vertex buffer. Grown on demand by [`Self::upload`].
+    vertex_buf: Buffer,
+    vertex_capacity: u32,
+
+    /// Index buffer (u32). Grown on demand by [`Self::upload`].
+    index_buf: Buffer,
+    index_capacity: u32,
+    /// Number of indices currently uploaded; `0` means [`Self::execute`] is a no-op.
+    index_count: u32,
+
+    /// Tracks whether the pipeline was created with a depth attachment so
+    /// [`Self::execute`] can validate the caller's depth-view argument.
+    has_depth: bool,
+}
+
+impl TriangleRasterNode {
+    /// Construct the pipeline.
+    ///
+    /// - `surface_format` must match the color attachment at draw time.
+    /// - `depth`: see [`crate::DepthMode`]. Determines whether the pipeline reads depth,
+    ///   reads + writes depth, or skips it.
+    /// - `sample_count` must match the attachment's MSAA sample count.
+    pub fn new(
+        device: &Device,
+        surface_format: TextureFormat,
+        depth: crate::DepthMode,
+        sample_count: u32,
+    ) -> Self {
+        let module = device.create_shader_module(ShaderModuleDescriptor {
+            label: Some("triangle_raster shader"),
+            source: ShaderSource::Wgsl(TRIANGLE_RASTER_WGSL.into()),
+        });
+
+        let uniform_buf = device.create_buffer(&BufferDescriptor {
+            label: Some("triangle_raster uniforms"),
+            size: std::mem::size_of::<TriangleRasterUniforms>() as u64,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("triangle_raster bgl"),
+            entries: &[BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::VERTEX_FRAGMENT,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("triangle_raster bg"),
+            layout: &bgl,
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: uniform_buf.as_entire_binding(),
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("triangle_raster pipeline layout"),
+            bind_group_layouts: &[&bgl],
+            push_constant_ranges: &[],
+        });
+
+        // Per-vertex attribute layout: position at offset 0, color at offset 16 (after
+        // the 4-byte _pad0). Matches `TriangleVertex` exactly.
+        let vertex_attrs = [
+            VertexAttribute {
+                format: VertexFormat::Float32x3,
+                offset: 0,
+                shader_location: 0,
+            },
+            VertexAttribute {
+                format: VertexFormat::Float32x4,
+                offset: 16,
+                shader_location: 1,
+            },
+        ];
+        let vertex_layout = VertexBufferLayout {
+            array_stride: std::mem::size_of::<TriangleVertex>() as u64,
+            step_mode: VertexStepMode::Vertex,
+            attributes: &vertex_attrs,
+        };
+
+        let pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("triangle_raster pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: VertexState {
+                module: &module,
+                entry_point: Some("vs_main"),
+                buffers: &[vertex_layout],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(FragmentState {
+                module: &module,
+                entry_point: Some("fs_main"),
+                targets: &[Some(ColorTargetState {
+                    format: surface_format,
+                    blend: Some(BlendState {
+                        color: BlendComponent {
+                            src_factor: BlendFactor::SrcAlpha,
+                            dst_factor: BlendFactor::OneMinusSrcAlpha,
+                            operation: BlendOperation::Add,
+                        },
+                        alpha: BlendComponent {
+                            src_factor: BlendFactor::One,
+                            dst_factor: BlendFactor::OneMinusSrcAlpha,
+                            operation: BlendOperation::Add,
+                        },
+                    }),
+                    write_mask: ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: depth.format().map(|format| DepthStencilState {
+                format,
+                depth_write_enabled: depth.writes(),
+                depth_compare: CompareFunction::Less,
+                stencil: StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: MultisampleState {
+                count: sample_count,
+                ..Default::default()
+            },
+            multiview: None,
+            cache: None,
+        });
+
+        // Buffers start empty; grow on first upload.
+        let vertex_buf = device.create_buffer(&BufferDescriptor {
+            label: Some("triangle_raster vertex buffer"),
+            size: 64,
+            usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let index_buf = device.create_buffer(&BufferDescriptor {
+            label: Some("triangle_raster index buffer"),
+            size: 64,
+            usage: BufferUsages::INDEX | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self {
+            pipeline,
+            uniform_buf,
+            bind_group,
+            vertex_buf,
+            vertex_capacity: 0,
+            index_buf,
+            index_capacity: 0,
+            index_count: 0,
+            has_depth: depth.is_active(),
+        }
+    }
+
+    /// Update the camera uniform. Call once per frame before [`Self::execute`].
+    pub fn set_camera(&self, queue: &Queue, view_projection: Mat4) {
+        let uniforms = TriangleRasterUniforms {
+            view_projection: view_projection.to_cols_array_2d(),
+        };
+        queue.write_buffer(&self.uniform_buf, 0, bytemuck::bytes_of(&uniforms));
+    }
+
+    /// Upload a [`TriangleMesh`] for rendering. Projects each vertex from R^N to R³ via
+    /// [`RasterizableSpace::project_point`]; copies the index list verbatim (already u32 in
+    /// the source).
+    ///
+    /// Vertices and colors must have the same length per the [`TriangleMesh`] invariant;
+    /// indices reference into the vertex array (u32 triples). Empty meshes are no-ops.
+    pub fn upload<S, const N: usize>(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        mesh: &TriangleMesh<N>,
+        projection: &Projection<N>,
+    ) where
+        S: RasterizableSpace<N>,
+    {
+        // Pack per-vertex GPU records.
+        let n_vertices = mesh.vertices.len();
+        assert_eq!(
+            mesh.colors.len(),
+            n_vertices,
+            "TriangleMesh invariant: colors.len() == vertices.len()"
+        );
+        let mut verts: Vec<TriangleVertex> = Vec::with_capacity(n_vertices);
+        for (v, color) in mesh.vertices.iter().zip(mesh.colors.iter()) {
+            let p_native = S::array_to_point(*v);
+            let p3 = S::project_point(p_native, projection);
+            verts.push(TriangleVertex {
+                position: p3.to_array(),
+                _pad0: 0.0,
+                color: *color,
+            });
+        }
+
+        // Flatten triangle indices [u32; 3] into a single index buffer.
+        let mut indices: Vec<u32> = Vec::with_capacity(mesh.indices.len() * 3);
+        for tri in &mesh.indices {
+            indices.extend_from_slice(tri);
+        }
+
+        // Grow buffers if needed; round up to next power of two to amortize re-allocations.
+        if verts.len() as u32 > self.vertex_capacity {
+            let new_cap = (verts.len() as u32).next_power_of_two().max(16);
+            self.vertex_buf = device.create_buffer(&BufferDescriptor {
+                label: Some("triangle_raster vertex buffer"),
+                size: (new_cap as u64) * (std::mem::size_of::<TriangleVertex>() as u64),
+                usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            self.vertex_capacity = new_cap;
+        }
+        if indices.len() as u32 > self.index_capacity {
+            let new_cap = (indices.len() as u32).next_power_of_two().max(16);
+            self.index_buf = device.create_buffer(&BufferDescriptor {
+                label: Some("triangle_raster index buffer"),
+                size: (new_cap as u64) * (std::mem::size_of::<u32>() as u64),
+                usage: BufferUsages::INDEX | BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            self.index_capacity = new_cap;
+        }
+
+        if !verts.is_empty() {
+            queue.write_buffer(&self.vertex_buf, 0, bytemuck::cast_slice(&verts));
+        }
+        if !indices.is_empty() {
+            queue.write_buffer(&self.index_buf, 0, bytemuck::cast_slice(&indices));
+        }
+        self.index_count = indices.len() as u32;
+    }
+
+    /// Draw the uploaded triangles onto `view`. `LoadOp::Load` for both color and depth, same
+    /// as [`crate::line_raster::LineRasterNode::execute`]; multiple raster nodes share one
+    /// cleared color + depth buffer within a frame.
+    ///
+    /// `depth_view` must be `Some` when the pipeline was constructed with a depth format and
+    /// `None` otherwise. Mismatch panics with a descriptive message.
+    pub fn execute(
+        &self,
+        rd: &RenderDevice,
+        view: &wgpu::TextureView,
+        depth_view: Option<&wgpu::TextureView>,
+    ) -> anyhow::Result<()> {
+        match (self.has_depth, depth_view.is_some()) {
+            (true, false) => {
+                panic!(
+                    "TriangleRasterNode::execute: pipeline was created with a depth format but \
+                     no depth view was provided"
+                )
+            }
+            (false, true) => {
+                panic!(
+                    "TriangleRasterNode::execute: pipeline was created without a depth format \
+                     but a depth view was provided"
+                )
+            }
+            _ => {}
+        }
+        if self.index_count == 0 {
+            return Ok(());
+        }
+        let mut encoder = rd.device.create_command_encoder(&CommandEncoderDescriptor {
+            label: Some("triangle_raster encoder"),
+        });
+        {
+            let depth_attachment = depth_view.map(|dv| RenderPassDepthStencilAttachment {
+                view: dv,
+                depth_ops: Some(Operations {
+                    load: LoadOp::Load,
+                    store: StoreOp::Store,
+                }),
+                stencil_ops: None,
+            });
+            let mut rp = encoder.begin_render_pass(&RenderPassDescriptor {
+                label: Some("triangle_raster pass"),
+                color_attachments: &[Some(RenderPassColorAttachment {
+                    view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: Operations {
+                        load: LoadOp::Load,
+                        store: StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: depth_attachment,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            rp.set_pipeline(&self.pipeline);
+            rp.set_bind_group(0, &self.bind_group, &[]);
+            rp.set_vertex_buffer(0, self.vertex_buf.slice(..));
+            rp.set_index_buffer(self.index_buf.slice(..), wgpu::IndexFormat::Uint32);
+            rp.draw_indexed(0..self.index_count, 0, 0..1);
+        }
+        rd.queue.submit(Some(encoder.finish()));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Embedded WGSL parses and validates against naga. Mirrors the line_raster validation
+    /// test; catches drift between the Rust-side vertex layout and the shader's `@location`
+    /// declarations.
+    #[test]
+    fn triangle_raster_wgsl_validates() {
+        let module = naga::front::wgsl::parse_str(TRIANGLE_RASTER_WGSL)
+            .unwrap_or_else(|e| panic!("triangle_raster WGSL parse failed:\n{e}"));
+        let flags = naga::valid::ValidationFlags::all();
+        let caps = naga::valid::Capabilities::empty();
+        naga::valid::Validator::new(flags, caps)
+            .validate(&module)
+            .expect("triangle_raster WGSL must validate");
+    }
+
+    /// `TriangleRasterUniforms` is exactly 64 bytes (one mat4x4, no padding). Drift here means
+    /// the GPU reads the wrong bytes for the view-projection matrix.
+    #[test]
+    fn uniforms_size_matches_wgsl() {
+        assert_eq!(std::mem::size_of::<TriangleRasterUniforms>(), 64);
+        assert_eq!(std::mem::align_of::<TriangleRasterUniforms>(), 4);
+    }
+
+    /// `TriangleVertex` is 32 bytes (12 position + 4 pad + 16 color). Attribute offsets in
+    /// the vertex layout descriptor must match this layout exactly.
+    #[test]
+    fn vertex_size_matches_layout() {
+        assert_eq!(std::mem::size_of::<TriangleVertex>(), 32);
+        let zero = TriangleVertex::default();
+        let base = &zero as *const _ as usize;
+        let color_off = &zero.color as *const _ as usize - base;
+        assert_eq!(color_off, 16);
+    }
+}

--- a/crates/rye-render/src/triangle_raster.rs
+++ b/crates/rye-render/src/triangle_raster.rs
@@ -107,7 +107,7 @@ impl FragmentShading {
     /// shaders embedded in `triangle_raster.wgsl`.
     fn entry_point(self) -> &'static str {
         match self {
-            Self::Flat => "fs_main",
+            Self::Flat => "fs_flat",
             Self::FaceNormalLambert => "fs_lambert",
         }
     }

--- a/crates/rye-render/src/triangle_raster.rs
+++ b/crates/rye-render/src/triangle_raster.rs
@@ -21,8 +21,12 @@
 //!
 //! `TriangleMesh<N>`'s docs spell this out: lighting in R⁴ has no standard convention, so
 //! normals are deliberately omitted at v1. Per-vertex color covers the cross-section /
-//! face-fill / debug-fill use cases the rasterizer was built for. Add normals when a real
-//! consumer (lit shading in a specific Space) demands them.
+//! face-fill / debug-fill use cases the rasterizer was built for. When a caller wants lit
+//! shading (e.g., polychoral cross-section cell caps), [`FragmentShading::FaceNormalLambert`]
+//! computes the face normal in the fragment shader from screen-space derivatives of
+//! world-space position; no normal vertex attribute required. This stays honest to the
+//! "no convention for normals in R^N" invariant: derivatives are local to the projected
+//! R³ surface, computed downstream of [`RasterizableSpace::project_point`].
 
 use bytemuck::{Pod, Zeroable};
 use glam::Mat4;
@@ -75,6 +79,40 @@ pub struct TriangleVertex {
     pub color: [f32; 4],
 }
 
+/// Fragment-shader selector for [`TriangleRasterNode`]. Picked at construction time so
+/// the pipeline state matches the chosen entry point; switching modes after construction
+/// would require a new pipeline (cheap but the caller usually knows up front which path
+/// it wants).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub enum FragmentShading {
+    /// Pass per-vertex color through unmodified. Use for overlays, debug fills, and any
+    /// mesh whose shading is already baked into vertex colors. This is the v1 behavior
+    /// and the default.
+    #[default]
+    Flat,
+    /// Face-normal Lambert. Computes the face normal from screen-space derivatives of
+    /// world-space position in the fragment shader, multiplies the vertex color by
+    /// Lambert intensity + ambient floor. Suitable for faceted surfaces (e.g.,
+    /// polychoral cross-section cell caps) where each triangle is geometrically flat,
+    /// since derivative-based normals are exact for that case.
+    ///
+    /// No normal vertex attribute is required; the [`TriangleMesh`] format does not
+    /// change between modes.
+    FaceNormalLambert,
+}
+
+impl FragmentShading {
+    /// WGSL entry-point name to bind into the fragment stage. Stable across versions;
+    /// callers don't see this string but it's how the pipeline picks between the two
+    /// shaders embedded in `triangle_raster.wgsl`.
+    fn entry_point(self) -> &'static str {
+        match self {
+            Self::Flat => "fs_main",
+            Self::FaceNormalLambert => "fs_lambert",
+        }
+    }
+}
+
 /// Triangle rasterizer node. Parallel to [`crate::line_raster::LineRasterNode`]; both
 /// own their pipeline + buffers and are constructed standalone.
 pub struct TriangleRasterNode {
@@ -103,11 +141,13 @@ impl TriangleRasterNode {
     /// - `surface_format` must match the color attachment at draw time.
     /// - `depth`: see [`crate::DepthMode`]. Determines whether the pipeline reads depth,
     ///   reads + writes depth, or skips it.
+    /// - `shading`: which fragment shader the pipeline binds; see [`FragmentShading`].
     /// - `sample_count` must match the attachment's MSAA sample count.
     pub fn new(
         device: &Device,
         surface_format: TextureFormat,
         depth: crate::DepthMode,
+        shading: FragmentShading,
         sample_count: u32,
     ) -> Self {
         let module = device.create_shader_module(ShaderModuleDescriptor {
@@ -182,7 +222,7 @@ impl TriangleRasterNode {
             },
             fragment: Some(FragmentState {
                 module: &module,
-                entry_point: Some("fs_main"),
+                entry_point: Some(shading.entry_point()),
                 targets: &[Some(ColorTargetState {
                     format: surface_format,
                     blend: Some(BlendState {

--- a/crates/rye-render/src/triangle_raster.wgsl
+++ b/crates/rye-render/src/triangle_raster.wgsl
@@ -47,10 +47,10 @@ fn vs_main(
     return out;
 }
 
-// `fs_flat` retains the name `fs_main` for source-compat with any external WGSL
-// inspection; the lambert entry point is the new addition.
+// Flat pass-through. The vertex shader's interpolated per-vertex color reaches the
+// framebuffer unmodified.
 @fragment
-fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+fn fs_flat(in: VsOut) -> @location(0) vec4<f32> {
     return in.color;
 }
 

--- a/crates/rye-render/src/triangle_raster.wgsl
+++ b/crates/rye-render/src/triangle_raster.wgsl
@@ -1,0 +1,33 @@
+// Triangle rasterizer pipeline. Per-vertex projected position + per-vertex color; fragment
+// shader passes color through. Depth-test / depth-write are configured on the host pipeline
+// when a depth attachment is enabled, not in WGSL.
+//
+// Camera uniform matches `TriangleRasterUniforms` on the host side (Rust); the mat4x4 std140
+// layout puts the matrix at offset 0 with 16-byte alignment, no padding needed.
+
+struct CameraUniform {
+    view_projection: mat4x4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> camera: CameraUniform;
+
+struct VsOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) color: vec4<f32>,
+};
+
+@vertex
+fn vs_main(
+    @location(0) position: vec3<f32>,
+    @location(1) color: vec4<f32>,
+) -> VsOut {
+    var out: VsOut;
+    out.clip_pos = camera.view_projection * vec4<f32>(position, 1.0);
+    out.color = color;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    return in.color;
+}

--- a/crates/rye-render/src/triangle_raster.wgsl
+++ b/crates/rye-render/src/triangle_raster.wgsl
@@ -1,9 +1,23 @@
-// Triangle rasterizer pipeline. Per-vertex projected position + per-vertex color; fragment
-// shader passes color through. Depth-test / depth-write are configured on the host pipeline
-// when a depth attachment is enabled, not in WGSL.
+// Triangle rasterizer pipeline. Per-vertex projected position + per-vertex color.
 //
-// Camera uniform matches `TriangleRasterUniforms` on the host side (Rust); the mat4x4 std140
-// layout puts the matrix at offset 0 with 16-byte alignment, no padding needed.
+// Two fragment entry points; the host picks one at pipeline construction via
+// `FragmentShading`:
+//
+// - `fs_flat`: pass-through, returns the interpolated per-vertex color unmodified. The
+//   v1 behavior. Suitable for unlit overlays, debug fills, and meshes that already carry
+//   their shading baked into per-vertex color.
+// - `fs_lambert`: face-normal Lambert. Computes the normal from screen-space derivatives
+//   of the interpolated world-space position (`dpdx`/`dpdy`), so the mesh doesn't need a
+//   normal attribute. The geometry is assumed to be faceted (each triangle = one flat
+//   face); derivative-based normals are exact for that case. Used for polychoral
+//   cross-section cell caps, where the cross-section is a polyhedron and faceted shading
+//   is honest to the geometry.
+//
+// Depth-test / depth-write are configured on the host pipeline when a depth attachment
+// is enabled, not in WGSL.
+//
+// Camera uniform matches `TriangleRasterUniforms` on the host side (Rust); the mat4x4
+// std140 layout puts the matrix at offset 0 with 16-byte alignment, no padding needed.
 
 struct CameraUniform {
     view_projection: mat4x4<f32>,
@@ -14,6 +28,11 @@ struct CameraUniform {
 struct VsOut {
     @builtin(position) clip_pos: vec4<f32>,
     @location(0) color: vec4<f32>,
+    // World-space position, interpolated per-fragment. Only `fs_lambert` reads it (to
+    // derive face normals via `dpdx`/`dpdy`); `fs_flat` ignores it. The varying costs
+    // ~12 bytes per vertex of interpolator bandwidth and is free for `fs_flat` callers
+    // since their VS work doesn't change.
+    @location(1) world_pos: vec3<f32>,
 };
 
 @vertex
@@ -24,10 +43,48 @@ fn vs_main(
     var out: VsOut;
     out.clip_pos = camera.view_projection * vec4<f32>(position, 1.0);
     out.color = color;
+    out.world_pos = position;
     return out;
 }
 
+// `fs_flat` retains the name `fs_main` for source-compat with any external WGSL
+// inspection; the lambert entry point is the new addition.
 @fragment
 fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     return in.color;
+}
+
+// Face-normal Lambert with a fixed key light + ambient floor.
+//
+// Normal comes from `cross(dpdx(p), dpdy(p))` on the interpolated world-space position;
+// for a flat triangle this is exactly the face normal regardless of vertex ordering
+// (the `normalize` handles the sign). Faceted shading shows cell boundaries as visible
+// creases, which matches what a polychoral cross-section actually looks like.
+//
+// Light direction is hardcoded in world space; tunable visual constants only. Diffuse
+// only (no specular). Polychoral caps are flat-faced and specular highlights would
+// emphasize that they're rasterized rather than smooth, which we don't want.
+@fragment
+fn fs_lambert(in: VsOut) -> @location(0) vec4<f32> {
+    let dpdx_p = dpdx(in.world_pos);
+    let dpdy_p = dpdy(in.world_pos);
+    let n = normalize(cross(dpdx_p, dpdy_p));
+
+    // Key light direction (world space, normalised). Comes from upper-front-right;
+    // chosen so all 6 polychora have at least one face well-lit from the default
+    // camera orbit angle. Not user-configurable at v1.
+    let key_dir = normalize(vec3<f32>(0.55, 0.85, 0.45));
+
+    // Two-sided Lambert: `abs(dot)` rather than `max(dot, 0)` because the cross-section
+    // mesh is single-sided geometry whose outward face direction is arbitrary (the
+    // triangulator doesn't reason about which side of the cell cap faces the inhabitant).
+    // Two-sided avoids one half of the polytope going pitch-black depending on which
+    // way we happened to wind the triangles.
+    let intensity = abs(dot(n, key_dir));
+
+    // Ambient floor keeps shadowed faces visible without washing out the lit ones.
+    let ambient = 0.30;
+    let lambert = ambient + (1.0 - ambient) * intensity;
+
+    return vec4<f32>(in.color.rgb * lambert, in.color.a);
 }

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -40,7 +40,7 @@ use rye_app::{egui, run_with_config, App, Camera, FrameCtx, OrbitController, Run
 use rye_egui::{Console, ConsoleWriter};
 use rye_math::{EuclideanR3, EuclideanR4, Projection, WPlane};
 use rye_physics::polytope::{polytope_section_with_vertices, Polytope4};
-use rye_render::{device::RenderDevice, DepthMode, LineRasterNode, TriangleRasterNode};
+use rye_render::{device::RenderDevice, DepthBuffer, DepthMode, LineRasterNode, TriangleRasterNode};
 use rye_shape::{LineMesh, TriangleMesh};
 use winit::window::WindowAttributes;
 
@@ -53,61 +53,6 @@ const POLYTOPE_SCALE: f32 = 2.5;
 /// choice: 32-bit float depth, no stencil. Universally supported, plenty of precision for
 /// the demo's near=0.1 / far=100 frustum.
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
-
-/// Swapchain-sized depth attachment shared by the R³ and R⁴ line raster passes. Recreated
-/// on resize via [`DepthBuffer::ensure`]. Owned by the example (not the render node) so
-/// future multi-pass compositions (filled triangles, point markers) can share or separate
-/// depth without reaching into the rasterizer node's internals.
-///
-/// Holds the [`wgpu::TextureView`] only; the underlying texture stays alive via wgpu's
-/// internal Arc reference held by the view.
-struct DepthBuffer {
-    view: wgpu::TextureView,
-    size: (u32, u32),
-    sample_count: u32,
-}
-
-impl DepthBuffer {
-    fn create(device: &wgpu::Device, size: (u32, u32), sample_count: u32) -> Self {
-        let texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("raster_test depth"),
-            size: wgpu::Extent3d {
-                width: size.0,
-                height: size.1,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count,
-            dimension: wgpu::TextureDimension::D2,
-            format: DEPTH_FORMAT,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            view_formats: &[],
-        });
-        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-        Self {
-            view,
-            size,
-            sample_count,
-        }
-    }
-
-    /// Recreate if the swapchain has resized or the sample count has changed. No-op when
-    /// dimensions match. Called once per frame at the top of `render`.
-    fn ensure(
-        slot: &mut Option<DepthBuffer>,
-        device: &wgpu::Device,
-        size: (u32, u32),
-        sample_count: u32,
-    ) {
-        let needs_recreate = match slot {
-            Some(b) => b.size != size || b.sample_count != sample_count,
-            None => true,
-        };
-        if needs_recreate {
-            *slot = Some(DepthBuffer::create(device, size, sample_count));
-        }
-    }
-}
 
 /// Angular speeds (rad/s) of the animated 4D rotation applied to polytope vertices before
 /// drop-w projection. Two independent simple rotations: `XW_RATE` rotates in the xw plane
@@ -562,6 +507,7 @@ impl Demo {
         DepthBuffer::ensure(
             &mut self.depth,
             &rd.device,
+            DEPTH_FORMAT,
             (cfg.width, cfg.height),
             rd.sample_count(),
         );

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -316,12 +316,14 @@ impl Demo {
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
             depth_mode,
+            rye_render::FragmentShading::Flat,
             ctx.rd.sample_count(),
         );
         let section_triangles = TriangleRasterNode::new(
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
             depth_mode,
+            rye_render::FragmentShading::Flat,
             ctx.rd.sample_count(),
         );
         let section_edges = LineRasterNode::new(

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -39,7 +39,7 @@ use glam::{Mat4, Vec2, Vec3, Vec4};
 use rye_app::{egui, run_with_config, App, Camera, FrameCtx, OrbitController, RunConfig, SetupCtx};
 use rye_egui::{Console, ConsoleWriter};
 use rye_math::{EuclideanR3, EuclideanR4, Projection, WPlane};
-use rye_physics::polytope::{polytope_section_with_vertices, Polytope4};
+use rye_physics::polytope::{polytope_section_overlay_with_vertices, Polytope4};
 use rye_render::{
     device::RenderDevice, DepthBuffer, DepthMode, LineRasterNode, TriangleRasterNode,
 };
@@ -269,7 +269,7 @@ struct Demo {
     triangle_raster: TriangleRasterNode,
     /// Triangle rasterizer for the active polytope's cross-section caps (filled). Translucent
     /// white per-cell triangulation produced by
-    /// [`rye_physics::polytope::polytope_section_with_vertices`].
+    /// [`rye_physics::polytope::polytope_section_overlay_with_vertices`].
     section_triangles: TriangleRasterNode,
     /// Line rasterizer for the active polytope's cross-section perimeter (bright cyan edges
     /// around each cap polygon). Same pipeline shape as `line_raster_r3`.
@@ -435,7 +435,7 @@ impl Demo {
                         )
                     })
                     .collect();
-                polytope_section_with_vertices(
+                polytope_section_overlay_with_vertices(
                     topo.edges,
                     topo.cells,
                     &world_vertices,
@@ -672,6 +672,22 @@ impl RasterTestApp {
                         "600cell",
                     ],
                     |d, name| {
+                        // Bare invocation cycles through the polytope list in declared order
+                        // (off, 5cell, tesseract, 16cell, 24cell, 120cell, 600cell), wrapping.
+                        let Some(name) = name else {
+                            let next = match d.polytope {
+                                None => Some(Polytope4::Pentatope),
+                                Some(Polytope4::Pentatope) => Some(Polytope4::Tesseract),
+                                Some(Polytope4::Tesseract) => Some(Polytope4::Cell16),
+                                Some(Polytope4::Cell16) => Some(Polytope4::Cell24),
+                                Some(Polytope4::Cell24) => Some(Polytope4::Cell120),
+                                Some(Polytope4::Cell120) => Some(Polytope4::Cell600),
+                                Some(Polytope4::Cell600) => None,
+                            };
+                            d.polytope = next;
+                            d.dirty = true;
+                            return Ok(());
+                        };
                         d.polytope = match name.to_ascii_lowercase().as_str() {
                             "off" | "none" => None,
                             "5cell" | "5-cell" | "pentatope" => Some(Polytope4::Pentatope),

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -16,9 +16,13 @@
 //! ## Console commands
 //!
 //! - `tests <target> <value>`: select what renders. `<target>` is one of:
-//!   - `all`, `axes`, `cube`, `widths`, `gradient`, `tilted`: toggle that R³ category;
-//!     `<value>` is `on` or `off`. Use `tests all off` to clear the R³ scene when you only
-//!     want to see the R⁴ polytope.
+//!   - `all`, `axes`, `cube`, `widths`, `gradient`, `tilted`, `triangles`, `section`:
+//!     toggle that category; `<value>` is `on` or `off`. Use `tests all off` to clear
+//!     everything when you only want to see the R⁴ polytope. `triangles` enables a
+//!     filled-triangle pair (red in front, cyan behind the cube) that exercises depth-test
+//!     correctness between the line and triangle pipelines. `section` overlays the active
+//!     polytope's cross-section at world `w = 0` (translucent caps + bright cyan
+//!     perimeter edges); requires a polytope to be set via `tests polytope <name>`.
 //!   - `polytope`: set the R⁴ polytope overlay. `<value>` is one of `5cell`, `tesseract`,
 //!     `16cell`, `24cell`, `120cell`, `600cell` (hyphenated aliases accepted) or `off`. The
 //!     wireframe projects to R³ via `Orthographic { drop_axis: 3 }`, scaled 2.5x, with an
@@ -31,19 +35,79 @@
 use std::borrow::Cow;
 
 use anyhow::Result;
-use glam::{Mat4, Vec2, Vec3};
+use glam::{Mat4, Vec2, Vec3, Vec4};
 use rye_app::{egui, run_with_config, App, Camera, FrameCtx, OrbitController, RunConfig, SetupCtx};
 use rye_egui::{Console, ConsoleWriter};
-use rye_math::{EuclideanR3, EuclideanR4, Projection};
-use rye_physics::polytope::Polytope4;
-use rye_render::{device::RenderDevice, LineRasterNode};
-use rye_shape::LineMesh;
+use rye_math::{EuclideanR3, EuclideanR4, Projection, WPlane};
+use rye_physics::polytope::{polytope_section_with_vertices, Polytope4};
+use rye_render::{device::RenderDevice, DepthMode, LineRasterNode, TriangleRasterNode};
+use rye_shape::{LineMesh, TriangleMesh};
 use winit::window::WindowAttributes;
 
 /// R⁴ scale factor for the polytope wireframe. Polytope vertices live on the unit
 /// 3-sphere; scaling up to 2.5 makes the wireframe comfortably visible alongside the R³
 /// test scene without overflowing the cube's ±1.5 extent.
 const POLYTOPE_SCALE: f32 = 2.5;
+
+/// Depth-buffer format for the line raster passes. `Depth32Float` is the simplest precise
+/// choice: 32-bit float depth, no stencil. Universally supported, plenty of precision for
+/// the demo's near=0.1 / far=100 frustum.
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+
+/// Swapchain-sized depth attachment shared by the R³ and R⁴ line raster passes. Recreated
+/// on resize via [`DepthBuffer::ensure`]. Owned by the example (not the render node) so
+/// future multi-pass compositions (filled triangles, point markers) can share or separate
+/// depth without reaching into the rasterizer node's internals.
+///
+/// Holds the [`wgpu::TextureView`] only; the underlying texture stays alive via wgpu's
+/// internal Arc reference held by the view.
+struct DepthBuffer {
+    view: wgpu::TextureView,
+    size: (u32, u32),
+    sample_count: u32,
+}
+
+impl DepthBuffer {
+    fn create(device: &wgpu::Device, size: (u32, u32), sample_count: u32) -> Self {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("raster_test depth"),
+            size: wgpu::Extent3d {
+                width: size.0,
+                height: size.1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count,
+            dimension: wgpu::TextureDimension::D2,
+            format: DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            view,
+            size,
+            sample_count,
+        }
+    }
+
+    /// Recreate if the swapchain has resized or the sample count has changed. No-op when
+    /// dimensions match. Called once per frame at the top of `render`.
+    fn ensure(
+        slot: &mut Option<DepthBuffer>,
+        device: &wgpu::Device,
+        size: (u32, u32),
+        sample_count: u32,
+    ) {
+        let needs_recreate = match slot {
+            Some(b) => b.size != size || b.sample_count != sample_count,
+            None => true,
+        };
+        if needs_recreate {
+            *slot = Some(DepthBuffer::create(device, size, sample_count));
+        }
+    }
+}
 
 /// Angular speeds (rad/s) of the animated 4D rotation applied to polytope vertices before
 /// drop-w projection. Two independent simple rotations: `XW_RATE` rotates in the xw plane
@@ -68,7 +132,8 @@ fn rotate_4d(p: [f32; 4], t: f32) -> [f32; 4] {
     ]
 }
 
-/// Test-scene toggles. Each maps to a category in [`build_mesh`].
+/// Test-scene toggles. Each maps to a category in [`build_mesh`] (lines) or
+/// [`build_triangle_mesh`] (filled triangles).
 #[derive(Clone, Copy, Debug)]
 struct Toggles {
     axes: bool,
@@ -76,6 +141,17 @@ struct Toggles {
     widths: bool,
     gradient: bool,
     tilted: bool,
+    /// Two opaque filled triangles in the XY plane at z = +2 (red) and z = -2 (cyan). The
+    /// camera sits at z = +8 looking at the origin, so the red triangle is in front of the
+    /// cube wireframe and the cyan triangle behind it. With depth enabled, the cube edges
+    /// must occlude the cyan triangle and the red triangle must occlude the cube edges
+    /// behind it. Visual gate for depth-test correctness between line and triangle pipelines.
+    triangles: bool,
+    /// Overlay the active R⁴ polytope's cross-section at world `w = 0` (post-rotation,
+    /// post-scaling). Translucent white triangles + bright cyan perimeter edges; the cap
+    /// geometry changes shape as the polytope rotates. Off by default since it requires
+    /// a polytope to be active (`polytope <name>`).
+    section: bool,
 }
 
 impl Default for Toggles {
@@ -86,6 +162,8 @@ impl Default for Toggles {
             widths: true,
             gradient: true,
             tilted: true,
+            triangles: false,
+            section: false,
         }
     }
 }
@@ -194,6 +272,42 @@ fn build_mesh(t: Toggles) -> LineMesh<3> {
     mesh
 }
 
+/// Build the optional filled-triangle test scene from the current toggles. Currently just two
+/// triangles flanking the cube along the z-axis -- the smoke test for piece 2's depth-test
+/// correctness. Returns an empty mesh when `t.triangles` is off so the rasterizer is a no-op.
+fn build_triangle_mesh(t: Toggles) -> TriangleMesh<3> {
+    let mut mesh: TriangleMesh<3> = TriangleMesh::default();
+    if !t.triangles {
+        return mesh;
+    }
+
+    // Red triangle in front of the cube (closer to camera at z=8 looking at origin).
+    let red = [0.90_f32, 0.30, 0.30, 1.0];
+    let base = mesh.vertices.len() as u32;
+    mesh.vertices.push([-2.0, -1.5, 2.0]);
+    mesh.vertices.push([2.0, -1.5, 2.0]);
+    mesh.vertices.push([0.0, 1.5, 2.0]);
+    mesh.colors.push(red);
+    mesh.colors.push(red);
+    mesh.colors.push(red);
+    mesh.indices.push([base, base + 1, base + 2]);
+
+    // Cyan triangle behind the cube. Same screen-space silhouette so depth ordering is the
+    // only thing distinguishing front from back -- if the cube's back-face edges fail to
+    // occlude the cyan triangle, depth isn't working.
+    let cyan = [0.30_f32, 0.80, 0.90, 1.0];
+    let base = mesh.vertices.len() as u32;
+    mesh.vertices.push([-2.0, -1.5, -2.0]);
+    mesh.vertices.push([2.0, -1.5, -2.0]);
+    mesh.vertices.push([0.0, 1.5, -2.0]);
+    mesh.colors.push(cyan);
+    mesh.colors.push(cyan);
+    mesh.colors.push(cyan);
+    mesh.indices.push([base, base + 1, base + 2]);
+
+    mesh
+}
+
 struct Demo {
     space: EuclideanR3,
     camera: Camera<EuclideanR3>,
@@ -203,6 +317,19 @@ struct Demo {
     /// R⁴ rasterizer for the optional polytope wireframe overlay. Separate from the R³ node
     /// so both pipelines can render in sequence against the same color attachment.
     line_raster_r4: LineRasterNode,
+    /// Triangle rasterizer for the filled-triangle test pair (`tests triangles on|off`). Smoke
+    /// test for depth-test correctness between line and triangle pipelines.
+    triangle_raster: TriangleRasterNode,
+    /// Triangle rasterizer for the active polytope's cross-section caps (filled). Translucent
+    /// white per-cell triangulation produced by
+    /// [`rye_physics::polytope::polytope_section_with_vertices`].
+    section_triangles: TriangleRasterNode,
+    /// Line rasterizer for the active polytope's cross-section perimeter (bright cyan edges
+    /// around each cap polygon). Same pipeline shape as `line_raster_r3`.
+    section_edges: LineRasterNode,
+    /// Shared depth attachment for all line + triangle raster passes. Lazily created on the
+    /// first frame and recreated on resize via [`DepthBuffer::ensure`].
+    depth: Option<DepthBuffer>,
     toggles: Toggles,
     /// Active R⁴ polytope. `None` disables the R⁴ overlay entirely; `Some(p)` uploads `p`'s
     /// `Visualizable<4>` line mesh through the `Orthographic { drop_axis: 3 }` (drop-w)
@@ -223,14 +350,37 @@ struct Demo {
 
 impl Demo {
     fn new(ctx: &mut SetupCtx<'_>) -> Result<Self> {
+        let depth_mode = DepthMode::ReadWrite {
+            format: DEPTH_FORMAT,
+        };
         let line_raster_r3 = LineRasterNode::new(
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
+            depth_mode,
             ctx.rd.sample_count(),
         );
         let line_raster_r4 = LineRasterNode::new(
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
+            depth_mode,
+            ctx.rd.sample_count(),
+        );
+        let triangle_raster = TriangleRasterNode::new(
+            &ctx.rd.device,
+            ctx.rd.surface_bundle.config.format,
+            depth_mode,
+            ctx.rd.sample_count(),
+        );
+        let section_triangles = TriangleRasterNode::new(
+            &ctx.rd.device,
+            ctx.rd.surface_bundle.config.format,
+            depth_mode,
+            ctx.rd.sample_count(),
+        );
+        let section_edges = LineRasterNode::new(
+            &ctx.rd.device,
+            ctx.rd.surface_bundle.config.format,
+            depth_mode,
             ctx.rd.sample_count(),
         );
 
@@ -245,6 +395,10 @@ impl Demo {
             orbit,
             line_raster_r3,
             line_raster_r4,
+            triangle_raster,
+            section_triangles,
+            section_edges,
+            depth: None,
             toggles: Toggles::default(),
             polytope: None,
             samples: 1,
@@ -265,6 +419,14 @@ impl Demo {
             &r3_mesh,
             &Projection::Identity,
             self.samples,
+        );
+
+        let tri_mesh = build_triangle_mesh(self.toggles);
+        self.triangle_raster.upload::<EuclideanR3, 3>(
+            &rd.device,
+            &rd.queue,
+            &tri_mesh,
+            &Projection::Identity,
         );
 
         // R⁴ polytope wireframe (if enabled). Vertices are first rotated in R⁴ (so
@@ -303,6 +465,49 @@ impl Demo {
                 self.samples,
             );
         }
+
+        // Cross-section overlay (if enabled, and we actually have a polytope). The section
+        // is taken at world `w = 0` against the SAME rotated + scaled vertex set the
+        // wireframe renders from, so the cap geometry traces the wireframe's current
+        // silhouette at the slice plane. Both outputs are R³ world-space meshes.
+        let (sec_tri, sec_edges) = match (self.toggles.section, self.polytope) {
+            (true, Some(p)) => {
+                let topo = p.topology();
+                let world_vertices: Vec<Vec4> = topo
+                    .vertices
+                    .iter()
+                    .map(|v| {
+                        let rotated = rotate_4d(v.to_array(), self.time);
+                        Vec4::new(
+                            rotated[0] * POLYTOPE_SCALE,
+                            rotated[1] * POLYTOPE_SCALE,
+                            rotated[2] * POLYTOPE_SCALE,
+                            rotated[3] * POLYTOPE_SCALE,
+                        )
+                    })
+                    .collect();
+                polytope_section_with_vertices(
+                    topo.edges,
+                    topo.cells,
+                    &world_vertices,
+                    WPlane::new(0.0),
+                )
+            }
+            _ => (TriangleMesh::<3>::default(), LineMesh::<3>::default()),
+        };
+        self.section_triangles.upload::<EuclideanR3, 3>(
+            &rd.device,
+            &rd.queue,
+            &sec_tri,
+            &Projection::Identity,
+        );
+        self.section_edges.upload::<EuclideanR3, 3>(
+            &rd.device,
+            &rd.queue,
+            &sec_edges,
+            &Projection::Identity,
+            self.samples,
+        );
 
         self.dirty = false;
     }
@@ -347,12 +552,23 @@ impl Demo {
             .set_camera(&rd.queue, view_proj, vp_size);
         self.line_raster_r4
             .set_camera(&rd.queue, view_proj, vp_size);
+        self.triangle_raster.set_camera(&rd.queue, view_proj);
+        self.section_triangles.set_camera(&rd.queue, view_proj);
+        self.section_edges
+            .set_camera(&rd.queue, view_proj, vp_size);
 
-        // Clear the framebuffer to a dark slate so the lines are visible. The rasterizer's
-        // pass uses LoadOp::Load, so we need a prior pass to clear; do it inline here via a
-        // bare-bones encoder. (In a real demo, this clear would come from whatever scene
-        // pass runs before the rasterizer; in this test example the rasterizer IS the
-        // scene.)
+        // Lazy / resize-aware depth buffer. The framework doesn't surface a resize hook to
+        // App; comparing dimensions each frame is cheap and avoids the extra trait method.
+        DepthBuffer::ensure(
+            &mut self.depth,
+            &rd.device,
+            (cfg.width, cfg.height),
+            rd.sample_count(),
+        );
+        let depth = self.depth.as_ref().expect("ensured above");
+
+        // Clear color + depth in one pass. The rasterizer's draw uses LoadOp::Load for both
+        // attachments, so both R³ and R⁴ line passes share the same cleared depth buffer.
         let mut clear_encoder = rd
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -375,15 +591,29 @@ impl Demo {
                         store: wgpu::StoreOp::Store,
                     },
                 })],
-                depth_stencil_attachment: None,
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &depth.view,
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: wgpu::StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }),
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });
         }
         rd.queue.submit(Some(clear_encoder.finish()));
 
-        self.line_raster_r3.execute(rd, view)?;
-        self.line_raster_r4.execute(rd, view)?;
+        self.line_raster_r3.execute(rd, view, Some(&depth.view))?;
+        self.triangle_raster.execute(rd, view, Some(&depth.view))?;
+        self.line_raster_r4.execute(rd, view, Some(&depth.view))?;
+        // Section overlay last so its bright cyan edges sit on top of any wireframe edges
+        // that share screen-space pixels; depth-test still occludes section pieces behind
+        // the cube + the R³ scene geometry.
+        self.section_triangles
+            .execute(rd, view, Some(&depth.view))?;
+        self.section_edges.execute(rd, view, Some(&depth.view))?;
         Ok(())
     }
 }
@@ -420,6 +650,8 @@ impl RasterTestApp {
                         d.toggles.widths = v;
                         d.toggles.gradient = v;
                         d.toggles.tilted = v;
+                        d.toggles.triangles = v;
+                        d.toggles.section = v;
                         d.dirty = true;
                         Ok(())
                     },
@@ -449,6 +681,24 @@ impl RasterTestApp {
                     d.dirty = true;
                     Ok(())
                 })
+                .toggle(
+                    "triangles",
+                    "toggle the filled-triangle pair (depth-test smoke test)",
+                    |d, v| {
+                        d.toggles.triangles = v;
+                        d.dirty = true;
+                        Ok(())
+                    },
+                )
+                .toggle(
+                    "section",
+                    "overlay active polytope's cross-section at world w=0",
+                    |d, v| {
+                        d.toggles.section = v;
+                        d.dirty = true;
+                        Ok(())
+                    },
+                )
                 .choice(
                     "polytope",
                     "set R⁴ polytope overlay (or `off` to clear it)",

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -40,7 +40,9 @@ use rye_app::{egui, run_with_config, App, Camera, FrameCtx, OrbitController, Run
 use rye_egui::{Console, ConsoleWriter};
 use rye_math::{EuclideanR3, EuclideanR4, Projection, WPlane};
 use rye_physics::polytope::{polytope_section_with_vertices, Polytope4};
-use rye_render::{device::RenderDevice, DepthBuffer, DepthMode, LineRasterNode, TriangleRasterNode};
+use rye_render::{
+    device::RenderDevice, DepthBuffer, DepthMode, LineRasterNode, TriangleRasterNode,
+};
 use rye_shape::{LineMesh, TriangleMesh};
 use winit::window::WindowAttributes;
 
@@ -499,8 +501,7 @@ impl Demo {
             .set_camera(&rd.queue, view_proj, vp_size);
         self.triangle_raster.set_camera(&rd.queue, view_proj);
         self.section_triangles.set_camera(&rd.queue, view_proj);
-        self.section_edges
-            .set_camera(&rd.queue, view_proj, vp_size);
+        self.section_edges.set_camera(&rd.queue, view_proj, vp_size);
 
         // Lazy / resize-aware depth buffer. The framework doesn't surface a resize hook to
         // App; comparing dimensions each frame is cheap and avoids the extra trait method.

--- a/examples/raster_test/main.rs
+++ b/examples/raster_test/main.rs
@@ -594,39 +594,50 @@ impl RasterTestApp {
                     "all",
                     "toggle every R³ raster-test category at once",
                     |d, v| {
-                        d.toggles.axes = v;
-                        d.toggles.cube = v;
-                        d.toggles.widths = v;
-                        d.toggles.gradient = v;
-                        d.toggles.tilted = v;
-                        d.toggles.triangles = v;
-                        d.toggles.section = v;
+                        // Bare `tests all` flips based on whether anything is off;
+                        // explicit on|off sets every category at once.
+                        let on = v.unwrap_or(
+                            !(d.toggles.axes
+                                && d.toggles.cube
+                                && d.toggles.widths
+                                && d.toggles.gradient
+                                && d.toggles.tilted
+                                && d.toggles.triangles
+                                && d.toggles.section),
+                        );
+                        d.toggles.axes = on;
+                        d.toggles.cube = on;
+                        d.toggles.widths = on;
+                        d.toggles.gradient = on;
+                        d.toggles.tilted = on;
+                        d.toggles.triangles = on;
+                        d.toggles.section = on;
                         d.dirty = true;
                         Ok(())
                     },
                 )
                 .toggle("axes", "toggle world-axes (R/G/B basis vectors)", |d, v| {
-                    d.toggles.axes = v;
+                    d.toggles.axes = v.unwrap_or(!d.toggles.axes);
                     d.dirty = true;
                     Ok(())
                 })
                 .toggle("cube", "toggle unit-cube wireframe", |d, v| {
-                    d.toggles.cube = v;
+                    d.toggles.cube = v.unwrap_or(!d.toggles.cube);
                     d.dirty = true;
                     Ok(())
                 })
                 .toggle("widths", "toggle width-sweep horizontal lines", |d, v| {
-                    d.toggles.widths = v;
+                    d.toggles.widths = v.unwrap_or(!d.toggles.widths);
                     d.dirty = true;
                     Ok(())
                 })
                 .toggle("gradient", "toggle red-to-blue gradient line", |d, v| {
-                    d.toggles.gradient = v;
+                    d.toggles.gradient = v.unwrap_or(!d.toggles.gradient);
                     d.dirty = true;
                     Ok(())
                 })
                 .toggle("tilted", "toggle tilted-line fan", |d, v| {
-                    d.toggles.tilted = v;
+                    d.toggles.tilted = v.unwrap_or(!d.toggles.tilted);
                     d.dirty = true;
                     Ok(())
                 })
@@ -634,7 +645,7 @@ impl RasterTestApp {
                     "triangles",
                     "toggle the filled-triangle pair (depth-test smoke test)",
                     |d, v| {
-                        d.toggles.triangles = v;
+                        d.toggles.triangles = v.unwrap_or(!d.toggles.triangles);
                         d.dirty = true;
                         Ok(())
                     },
@@ -643,7 +654,7 @@ impl RasterTestApp {
                     "section",
                     "overlay active polytope's cross-section at world w=0",
                     |d, v| {
-                        d.toggles.section = v;
+                        d.toggles.section = v.unwrap_or(!d.toggles.section);
                         d.dirty = true;
                         Ok(())
                     },

--- a/examples/rotate_polytopes/catalog.rs
+++ b/examples/rotate_polytopes/catalog.rs
@@ -9,21 +9,20 @@
 
 use anyhow::{anyhow, Result};
 use rye_app::egui;
-use rye_render::raymarch::{
-    SHAPE_120CELL, SHAPE_16CELL, SHAPE_24CELL, SHAPE_3SPHERE, SHAPE_600CELL, SHAPE_CLIFFORD_TORUS,
-    SHAPE_DUOCYLINDER, SHAPE_PENTATOPE, SHAPE_SPHERINDER, SHAPE_TESSERACT,
-};
+use rye_physics::polytope::Polytope4;
+use rye_render::raymarch::RaymarchShape;
 
-/// One polytope's metadata: shape index in the kernel's table, per-body fragment color
-/// (driven into `BodyUniform.color` on the GPU side, NOT the panel's card color; those
-/// are uniformly grey in the redesigned UI), short display label, and long mathematical
-/// name shown in card tooltips. The long name uses the `pentachoron` / `tesseract` /
+/// One polytope's metadata: typed shape identifier ([`RaymarchShape`], unifying the GPU
+/// SDF shape ID with the optional polytope topology), per-body fragment color (driven
+/// into `BodyUniform.color` on the GPU side, NOT the panel's card color; those are
+/// uniformly grey in the redesigned UI), short display label, and long mathematical name
+/// shown in card tooltips. The long name uses the `pentachoron` / `tesseract` /
 /// `hexadecachoron` family; the `*-plex` aliases (pentaplex, dodecaplex, ...) are
 /// deliberately avoided since "plex" is dimension-generalized rather than being the
 /// actual 4D name.
 #[derive(Copy, Clone, PartialEq)]
 pub(crate) struct ShapeEntry {
-    pub(crate) shape: u32,
+    pub(crate) shape: RaymarchShape,
     pub(crate) body_color: [f32; 3],
     pub(crate) label: &'static str,
     pub(crate) long_name: &'static str,
@@ -34,25 +33,25 @@ pub(crate) struct ShapeEntry {
 /// triple; visually contrasting shapes left-to-right.
 pub(crate) const DEFAULT_ROW: &[ShapeEntry] = &[
     ShapeEntry {
-        shape: SHAPE_24CELL,
+        shape: RaymarchShape::Polytope(Polytope4::Cell24),
         body_color: [0.95, 0.45, 0.85],
         label: "24-cell",
         long_name: "icositetrachoron",
     },
     ShapeEntry {
-        shape: SHAPE_PENTATOPE,
+        shape: RaymarchShape::Polytope(Polytope4::Pentatope),
         body_color: [0.95, 0.55, 0.30],
         label: "5-cell",
         long_name: "pentachoron",
     },
     ShapeEntry {
-        shape: SHAPE_16CELL,
+        shape: RaymarchShape::Polytope(Polytope4::Cell16),
         body_color: [0.55, 0.95, 0.40],
         label: "16-cell",
         long_name: "hexadecachoron",
     },
     ShapeEntry {
-        shape: SHAPE_TESSERACT,
+        shape: RaymarchShape::Polytope(Polytope4::Tesseract),
         body_color: [0.30, 0.55, 0.95],
         label: "8-cell",
         long_name: "tesseract",
@@ -66,61 +65,61 @@ pub(crate) const DEFAULT_ROW: &[ShapeEntry] = &[
 /// space).
 pub(crate) const SHAPE_CATALOG: &[ShapeEntry] = &[
     ShapeEntry {
-        shape: SHAPE_PENTATOPE,
+        shape: RaymarchShape::Polytope(Polytope4::Pentatope),
         body_color: [0.95, 0.55, 0.30],
         label: "5-cell",
         long_name: "pentachoron",
     },
     ShapeEntry {
-        shape: SHAPE_TESSERACT,
+        shape: RaymarchShape::Polytope(Polytope4::Tesseract),
         body_color: [0.30, 0.55, 0.95],
         label: "8-cell",
         long_name: "tesseract",
     },
     ShapeEntry {
-        shape: SHAPE_16CELL,
+        shape: RaymarchShape::Polytope(Polytope4::Cell16),
         body_color: [0.55, 0.95, 0.40],
         label: "16-cell",
         long_name: "hexadecachoron",
     },
     ShapeEntry {
-        shape: SHAPE_24CELL,
+        shape: RaymarchShape::Polytope(Polytope4::Cell24),
         body_color: [0.95, 0.45, 0.85],
         label: "24-cell",
         long_name: "icositetrachoron",
     },
     ShapeEntry {
-        shape: SHAPE_120CELL,
+        shape: RaymarchShape::Polytope(Polytope4::Cell120),
         body_color: [0.40, 0.85, 0.85],
         label: "120-cell",
         long_name: "hecatonicosachoron",
     },
     ShapeEntry {
-        shape: SHAPE_600CELL,
+        shape: RaymarchShape::Polytope(Polytope4::Cell600),
         body_color: [0.95, 0.85, 0.40],
         label: "600-cell",
         long_name: "hexacosichoron",
     },
     ShapeEntry {
-        shape: SHAPE_3SPHERE,
+        shape: RaymarchShape::ThreeSphere,
         body_color: [0.85, 0.40, 0.40],
         label: "3-sphere",
         long_name: "hypersphere (4-ball)",
     },
     ShapeEntry {
-        shape: SHAPE_DUOCYLINDER,
+        shape: RaymarchShape::Duocylinder,
         body_color: [0.60, 0.45, 0.90],
         label: "duocyl",
         long_name: "duocylinder (D² × D²)",
     },
     ShapeEntry {
-        shape: SHAPE_CLIFFORD_TORUS,
+        shape: RaymarchShape::CliffordTorus,
         body_color: [0.70, 0.85, 0.35],
         label: "clifford",
         long_name: "Clifford torus tube",
     },
     ShapeEntry {
-        shape: SHAPE_SPHERINDER,
+        shape: RaymarchShape::Spherinder,
         body_color: [0.85, 0.55, 0.75],
         label: "spherinder",
         long_name: "spherinder (B³ × interval)",

--- a/examples/rotate_polytopes/filmstrip.rs
+++ b/examples/rotate_polytopes/filmstrip.rs
@@ -6,7 +6,8 @@
 //! overlay drawn on top of the rendered scene.
 
 use rye_app::egui;
-use rye_render::raymarch::{SHAPE_120CELL, SHAPE_600CELL};
+use rye_physics::polytope::Polytope4;
+use rye_render::raymarch::RaymarchShape;
 
 use crate::catalog::render_shape_catalog_menu;
 use crate::consts::BODY_SIZE;
@@ -138,8 +139,10 @@ impl Demo {
     /// since `render_shapes_section` (where the warning otherwise
     /// lives) is hidden in this view.
     pub(crate) fn render_filmstrip_body(&mut self, ui: &mut egui::Ui) {
-        let heavy =
-            self.strip_subject.shape == SHAPE_120CELL || self.strip_subject.shape == SHAPE_600CELL;
+        let heavy = matches!(
+            self.strip_subject.shape,
+            RaymarchShape::Polytope(Polytope4::Cell120 | Polytope4::Cell600)
+        );
         if heavy {
             ui.colored_label(
                 egui::Color32::from_rgb(242, 130, 70),

--- a/examples/rotate_polytopes/main.rs
+++ b/examples/rotate_polytopes/main.rs
@@ -60,7 +60,7 @@ use rye_egui::Console;
 use rye_math::WPlane;
 use rye_math::{Bivector, EuclideanR3, Rotor, Rotor4};
 use rye_physics::polytope::{
-    polytope_section_faces_with_vertices, polytope_section_with_vertices, vertex_color_by_position,
+    polytope_section_faces_append, polytope_section_overlay_with_vertices, vertex_color_by_position,
 };
 use rye_render::{
     device::RenderDevice,
@@ -228,6 +228,8 @@ impl Demo {
             wireframe_color_mode: WireframeColorMode::default(),
             section_faces,
             section_faces_depth: None,
+            section_world_vertices_scratch: Vec::new(),
+            section_faces_mesh_scratch: rye_shape::TriangleMesh::<3>::default(),
             surface_raster_enabled: true,
             row,
             w_slice: initial_w,
@@ -705,53 +707,57 @@ impl Demo {
     /// algorithm then runs on these world vertices against the demo's `w_slice`,
     /// producing R³ geometry that composes with the camera the SDF raymarcher uses.
     ///
-    /// Depth: each polychoral cap polygon is fan-triangulated, with sub-triangles
-    /// sharing a centroid. They don't self-occlude (all on the same slice hyperplane)
-    /// but caps from *different* polychoral bodies in the row can occlude each other,
-    /// so the depth attachment is sized + cleared once here.
+    /// Depth: within a single cap, the fan triangles are coplanar (the cap is a 2D
+    /// polygon in R³) and don't occlude one another. Different caps within one
+    /// polytope, and caps across different polychoral bodies, all project to
+    /// different camera depths after the view-projection step, so they DO require a
+    /// depth attachment to resolve front-to-back occlusion correctly. The shared
+    /// depth buffer is ensured + cleared at the top of the Shapes-view render path
+    /// (see `Demo::ensure_and_clear_shared_depth`); this pass writes into it.
     fn render_section_faces(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> Result<()> {
         let cfg = &rd.surface_bundle.config;
         let n = self.row.len();
 
-        let mut combined = rye_shape::TriangleMesh::<3>::default();
+        // Reuse the per-Demo scratch mesh; capacity grows once to fit the largest
+        // polychoron and stays there. Each frame's `clear()` keeps the underlying
+        // allocations.
+        let combined = &mut self.section_faces_mesh_scratch;
+        combined.vertices.clear();
+        combined.colors.clear();
+        combined.indices.clear();
+
         for (slot, entry) in self.row.iter().enumerate() {
             let Some(polytope) = entry.shape.polytope4() else {
                 continue;
             };
             let topo = polytope.topology();
             let bp = Vec4::from_array(body_position(slot, n));
-            let world_vertices: Vec<Vec4> = topo
-                .vertices
-                .iter()
-                .map(|v| bp + BODY_SIZE * self.rot_state.apply(*v))
-                .collect();
+
+            // Reusable scratch for per-body world-space vertices. Same growth pattern
+            // as `combined` above.
+            self.section_world_vertices_scratch.clear();
+            self.section_world_vertices_scratch.extend(
+                topo.vertices
+                    .iter()
+                    .map(|v| bp + BODY_SIZE * self.rot_state.apply(*v)),
+            );
 
             // Match the SDF's per-body solid coloring: every cap of this polychoron
             // uses the body's identity color from the catalog. Per-face Lambert in the
             // fragment shader adds the geometric depth; the underlying color is flat.
             let [r, g, b] = entry.body_color;
-            let body_mesh = polytope_section_faces_with_vertices(
+            polytope_section_faces_append(
                 topo.edges,
                 topo.cells,
-                &world_vertices,
+                &self.section_world_vertices_scratch,
                 WPlane::new(self.w_slice),
                 [r, g, b, 1.0],
+                combined,
             );
-
-            // Concatenate: append vertices + colors verbatim, indices are offset by
-            // the pre-append vertex count. This keeps the combined mesh a single
-            // upload regardless of how many polychoral bodies are in the row.
-            let base = combined.vertices.len() as u32;
-            combined.vertices.extend_from_slice(&body_mesh.vertices);
-            combined.colors.extend_from_slice(&body_mesh.colors);
-            for [a, b, c] in &body_mesh.indices {
-                combined.indices.push([base + a, base + b, base + c]);
-            }
         }
 
-        if combined.vertices.is_empty() {
-            return Ok(());
-        }
+        // Empty mesh handling lives in `TriangleRasterNode::execute` (it short-circuits
+        // when `index_count == 0`); no need for a redundant early-return here.
 
         // Camera matches the SDF raymarcher's effective view-projection (same as the
         // wireframe overlay uses), so pixel-aligned composition over the SDF pass.
@@ -773,7 +779,7 @@ impl Demo {
         self.section_faces.upload::<EuclideanR3, 3>(
             &rd.device,
             &rd.queue,
-            &combined,
+            combined,
             &rye_math::Projection::Identity,
         );
         self.section_faces.execute(rd, view, Some(&depth.view))?;
@@ -838,10 +844,10 @@ impl Demo {
             // Cross-section perimeter edges only. The SDF raymarcher renders the section
             // as a solid volume; we just need to outline the boundaries between adjacent
             // cell caps (each cap contributes one face of the 3D section polytope).
-            // `polytope_section_with_vertices` returns `(triangles, perimeter)`; we
+            // `polytope_section_overlay_with_vertices` returns `(triangles, perimeter)`; we
             // discard the filled triangles since they would obscure the SDF without
             // adding information.
-            let (_tri, mut perim) = polytope_section_with_vertices(
+            let (_tri, mut perim) = polytope_section_overlay_with_vertices(
                 topo.edges,
                 topo.cells,
                 &world_vertices,
@@ -1088,13 +1094,18 @@ impl RotatePolytopesApp {
                 )
                 .choice(
                     "color",
-                    "base RGB for parent edges: unique (default) or active",
+                    "base RGB for parent edges (bare cycles): unique (default) or active",
                     &["unique", "active"],
                     |d, name| {
-                        d.wireframe_color_mode =
-                            WireframeColorMode::from_token(name).ok_or_else(|| {
-                                anyhow!("unknown color mode `{name}` (try unique|active)")
-                            })?;
+                        d.wireframe_color_mode = match name {
+                            Some(n) => WireframeColorMode::from_token(n).ok_or_else(|| {
+                                anyhow!("unknown color mode `{n}` (try unique|active)")
+                            })?,
+                            None => match d.wireframe_color_mode {
+                                WireframeColorMode::Unique => WireframeColorMode::Active,
+                                WireframeColorMode::Active => WireframeColorMode::Unique,
+                            },
+                        };
                         Ok(())
                     },
                 ),

--- a/examples/rotate_polytopes/main.rs
+++ b/examples/rotate_polytopes/main.rs
@@ -90,7 +90,7 @@ mod ui;
 use active::combo_name;
 use catalog::{parse_row_from_args, SHAPE_CATALOG};
 use consts::{BODY_SIZE, BODY_Y, T_SCRUB_RATE, T_SLIDER_INITIAL, W_RANGE, W_SCRUB_RATE};
-use state::{body_position, Demo, RotationMode, ViewMode};
+use state::{body_position, Demo, RotationMode, ViewMode, WireframeColorMode};
 
 #[cfg(test)]
 use catalog::{parse_shape_name, ShapeEntry, DEFAULT_ROW};
@@ -158,21 +158,32 @@ impl Demo {
             .collect();
         node.set_bodies(&bodies);
 
-        // Overlay raster pipelines. No depth attachment: the SDF raymarcher renders the
-        // active section as a solid volume on its own, and the rasterizer's job here is
-        // to outline boundaries between cell caps + show the full polytope wireframe on
-        // top, not to compose another opaque layer. With everything in DepthMode::Off
-        // the passes draw in submission order over the SDF.
+        // Section perimeter (cyan outlines): depth-test ReadOnly against the shared
+        // section-faces depth attachment. With multiple polychora in a row, polytope A's
+        // perimeter must be occluded by polytope B's filled caps when A sits behind B.
+        // `LineRasterNode` uses `CompareFunction::LessEqual`, so a perimeter line sitting
+        // at exactly its own cap's depth still passes the test and draws on top, keeping
+        // the intended "outline of this cap" visual.
         let section_edges = LineRasterNode::new(
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
-            DepthMode::Off,
+            DepthMode::ReadOnly {
+                format: SECTION_FACES_DEPTH_FORMAT,
+            },
             ctx.rd.sample_count(),
         );
+        // Parent wireframe: depth-test ReadOnly against the shared section-faces depth
+        // attachment. Lines whose projected R³ position sits behind a section cap get
+        // occluded by it; lines in front draw over. No depth-write so the wireframe
+        // doesn't muddy the depth buffer for any downstream pass. In SDF mode the
+        // depth buffer is cleared per frame but no pass writes to it, so the test
+        // trivially passes everywhere -- the SDF visual stays unchanged.
         let parent_wireframe = LineRasterNode::new(
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
-            DepthMode::Off,
+            DepthMode::ReadOnly {
+                format: SECTION_FACES_DEPTH_FORMAT,
+            },
             ctx.rd.sample_count(),
         );
 
@@ -214,6 +225,7 @@ impl Demo {
             parent_wireframe,
             wireframe_enabled: false,
             wireframe_nearest_active: true,
+            wireframe_color_mode: WireframeColorMode::default(),
             section_faces,
             section_faces_depth: None,
             surface_raster_enabled: true,
@@ -620,11 +632,13 @@ impl Demo {
             }
             self.node.flush_uniforms(&rd.queue);
             self.node.execute_in_viewport(rd, view, viewport)?;
-            // Rasterized polychoral cross-section faces (when toggled). Runs after the
-            // SDF pass and *before* the wireframe overlay so the dim wireframe edges
-            // sit on top of the filled caps. Polychoral SDF bodies are already inert
-            // in this mode (see `Demo::sdf_body_for_slot`), so the SDF didn't draw
-            // them; the raster pass is their visible surface.
+            // Shared depth attachment for the rasterized section pass + the parent
+            // wireframe's depth-test. Ensured + cleared once per Shapes-view frame so
+            // the order is: SDF (color only) -> section_faces (writes depth + color
+            // when raster mode is on) -> wireframe (tests depth, no write). In SDF
+            // mode no pass writes depth, so the cleared `1.0` buffer makes every
+            // wireframe fragment pass the depth-test trivially -- visual unchanged.
+            self.ensure_and_clear_shared_depth(rd)?;
             if self.surface_raster_enabled {
                 self.render_section_faces(rd, view)?;
             }
@@ -636,6 +650,50 @@ impl Demo {
             }
             Ok(())
         }
+    }
+
+    /// Ensure the shared section-faces depth attachment exists at the current
+    /// swapchain size + sample count, then clear it to `1.0`. Called once per
+    /// Shapes-view frame at the top of the rasterizer chain.
+    ///
+    /// The buffer is shared between `section_faces` (which writes depth when raster
+    /// mode is on) and `parent_wireframe` (which depth-tests against it without
+    /// writing). Sharing means we pay one ensure + one clear per frame regardless of
+    /// surface mode.
+    fn ensure_and_clear_shared_depth(&mut self, rd: &RenderDevice) -> Result<()> {
+        let cfg = &rd.surface_bundle.config;
+        DepthBuffer::ensure(
+            &mut self.section_faces_depth,
+            &rd.device,
+            SECTION_FACES_DEPTH_FORMAT,
+            (cfg.width, cfg.height),
+            rd.sample_count(),
+        );
+        let depth = self
+            .section_faces_depth
+            .as_ref()
+            .expect("ensure() guarantees Some");
+        let mut encoder = rd
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("shared depth clear"),
+            });
+        let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("shared depth clear pass"),
+            color_attachments: &[],
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &depth.view,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(1.0),
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        rd.queue.submit(Some(encoder.finish()));
+        Ok(())
     }
 
     /// Build a combined section-faces mesh across every polychoral body in `self.row`,
@@ -703,45 +761,13 @@ impl Demo {
         let proj_mat = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
         let view_proj = proj_mat * view_mat;
 
-        // Depth attachment: lazily sized + recreated on resize / sample-count change.
-        DepthBuffer::ensure(
-            &mut self.section_faces_depth,
-            &rd.device,
-            SECTION_FACES_DEPTH_FORMAT,
-            (cfg.width, cfg.height),
-            rd.sample_count(),
-        );
+        // The shared depth attachment is ensured + cleared once per frame by
+        // `ensure_and_clear_shared_depth` at the top of the Shapes-view render path;
+        // here we just consume the view for the triangle pass's depth-write.
         let depth = self
             .section_faces_depth
             .as_ref()
-            .expect("ensure() guarantees Some");
-
-        // Clear the depth attachment via a no-op clear pass before the triangle draw.
-        // `TriangleRasterNode::execute` uses LoadOp::Load on depth so it preserves
-        // previous draws within the frame; we want each frame's section faces to
-        // start with a fresh depth buffer (no inter-frame ghost depth values).
-        {
-            let mut encoder = rd
-                .device
-                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("section_faces depth clear"),
-                });
-            let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("section_faces depth clear pass"),
-                color_attachments: &[],
-                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                    view: &depth.view,
-                    depth_ops: Some(wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(1.0),
-                        store: wgpu::StoreOp::Store,
-                    }),
-                    stencil_ops: None,
-                }),
-                timestamp_writes: None,
-                occlusion_query_set: None,
-            });
-            rd.queue.submit(Some(encoder.finish()));
-        }
+            .expect("shared depth buffer must be ensured before section_faces");
 
         self.section_faces.set_camera(&rd.queue, view_proj);
         self.section_faces.upload::<EuclideanR3, 3>(
@@ -784,7 +810,13 @@ impl Demo {
         const PARENT_ALPHA_DIM: f32 = 0.10;
         const PARENT_ALPHA_BRIGHT: f32 = 0.85;
         const PARENT_WIDTH: f32 = 1.2;
+        // Active-mode palette. Green for edges in any currently-intersected cell;
+        // neutral gray for the rest. Chosen for clear binary contrast against the
+        // grayish-blue scene backdrop and the dim ground checkerboard.
+        const ACTIVE_GREEN: [f32; 4] = [0.40, 1.00, 0.55, 1.0];
+        const INACTIVE_GRAY: [f32; 4] = [0.55, 0.55, 0.58, 1.0];
         let nearest_active = self.wireframe_nearest_active;
+        let color_mode = self.wireframe_color_mode;
 
         for (slot, entry) in self.row.iter().enumerate() {
             let Some(polytope) = entry.shape.polytope4() else {
@@ -859,19 +891,47 @@ impl Demo {
                 best
             };
 
-            // Parent wireframe: every polytope edge as a world-R³ line, colored by
-            // position-derived RGB from the canonical (unit-circumradius) vertex set so
-            // adjacent edges share their endpoint colors and the polytope's symmetry
-            // shows as smooth color gradients across the wireframe (same scheme as
-            // [`Polytope4::lines_colored_by_position`]). Alpha modulated per-edge by the
-            // `nearest-active` strength when that toggle is on; uniform otherwise.
+            // Active-mode binary classification: an edge is "active" if at least one of
+            // its containing cells has the slice strictly between its w-range endpoints
+            // (i.e., the slice is currently producing a cap from that cell). Uses the
+            // same `edges-in-cell` membership rule as `edge_strength`; threshold is
+            // `cell_strength > 0.0`, which corresponds exactly to `w_min < w_slice <
+            // w_max` after the `(1 - dist / half_extent)` clamp.
+            let edge_is_active = |i: u32, j: u32| -> bool {
+                topo.cells
+                    .iter()
+                    .zip(cell_strengths.iter())
+                    .any(|(cell, &s)| s > 0.0 && cell.contains(&i) && cell.contains(&j))
+            };
+
+            // Parent wireframe: every polytope edge as a world-R³ line. Base RGB is
+            // picked by `wireframe_color_mode`:
+            // - `Unique`: per-vertex position-derived RGB from the canonical vertex
+            //   set so each vertex gets a distinct hue from its 4D coordinates and
+            //   the polytope's symmetry shows as smooth gradients (same scheme as
+            //   `Polytope4::lines_colored_by_position`).
+            // - `Active`: binary green/gray by cell-activity (see `edge_is_active`).
+            // Alpha is then modulated per-edge by the `nearest-active` strength (when
+            // that toggle is on) or held uniform.
             for &[i, j] in topo.edges {
                 let ia = i as usize;
                 let ja = j as usize;
                 let a = world_vertices[ia];
                 let b = world_vertices[ja];
-                let mut color_a = vertex_color_by_position(topo.vertices[ia]);
-                let mut color_b = vertex_color_by_position(topo.vertices[ja]);
+                let (mut color_a, mut color_b) = match color_mode {
+                    WireframeColorMode::Unique => (
+                        vertex_color_by_position(topo.vertices[ia]),
+                        vertex_color_by_position(topo.vertices[ja]),
+                    ),
+                    WireframeColorMode::Active => {
+                        let c = if edge_is_active(i, j) {
+                            ACTIVE_GREEN
+                        } else {
+                            INACTIVE_GRAY
+                        };
+                        (c, c)
+                    }
+                };
                 let alpha = if nearest_active {
                     let s = edge_strength(i, j);
                     PARENT_ALPHA_DIM + (PARENT_ALPHA_BRIGHT - PARENT_ALPHA_DIM) * s
@@ -917,11 +977,19 @@ impl Demo {
         self.parent_wireframe
             .set_camera(&rd.queue, view_proj, vp_size);
 
-        // Section perimeter edges then dim parent wireframe, both depth-off. The SDF
-        // pass renders solid bodies underneath; the overlay just adds line context on
-        // top in submission order.
-        self.section_edges.execute(rd, view, None)?;
-        self.parent_wireframe.execute(rd, view, None)?;
+        // Section perimeter edges then dim parent wireframe. Both depth-test (no write)
+        // against the shared section-faces depth attachment so lines behind a cap get
+        // correctly occluded across polytopes in a row. The shared buffer is ensured +
+        // cleared earlier in the frame; here we just borrow the view. In SDF mode no
+        // pass writes depth, so the cleared `1.0` buffer makes every fragment pass the
+        // test, preserving the historical visual.
+        let depth_view = self
+            .section_faces_depth
+            .as_ref()
+            .map(|b| &b.view)
+            .expect("shared depth buffer must be ensured before wireframe overlay");
+        self.section_edges.execute(rd, view, Some(depth_view))?;
+        self.parent_wireframe.execute(rd, view, Some(depth_view))?;
         Ok(())
     }
 
@@ -998,65 +1066,38 @@ impl RotatePolytopesApp {
                 Ok(())
             },
         ));
-        // Cross-section + parent-wireframe overlay. Tab-complete cycles through:
-        //   wireframe on               -- enable the overlay
-        //   wireframe off              -- disable
-        //   wireframe nearest-active on|off -- toggle the per-cell alpha gradient that
-        //                                     highlights cells the slice is currently
-        //                                     deep into
-        // Bare `wireframe` (no args) flips the main on/off.
+        // Cross-section + parent-wireframe overlay. Tab-completion is context-aware
+        // via [`SubcommandSet`]: each subcommand's value slot lists only that
+        // subcommand's choices. Bare invocations flip:
+        //   `wireframe`                 -> flips main on/off
+        //   `wireframe nearest-active`  -> flips the alpha gradient toggle
+        //   `wireframe color <mode>`    -> sets the color mode
         c.register(
-            rye_egui::cmd(
-                "wireframe",
-                "wireframe + cross-section overlay (see `help wireframe`)",
-                |args, demo: &mut Demo, _out| match args.first().copied() {
-                    Some("on") => {
-                        demo.wireframe_enabled = true;
+            rye_egui::subcommands::<Demo>("wireframe", "wireframe + cross-section overlay")
+                .on_bare(|d| {
+                    d.wireframe_enabled = !d.wireframe_enabled;
+                    Ok(())
+                })
+                .toggle(
+                    "nearest-active",
+                    "per-edge alpha gradient by cell-crossing strength (bare flips)",
+                    |d, v| {
+                        d.wireframe_nearest_active = v.unwrap_or(!d.wireframe_nearest_active);
                         Ok(())
-                    }
-                    Some("off") => {
-                        demo.wireframe_enabled = false;
-                        Ok(())
-                    }
-                    Some("nearest-active") => match args.get(1).copied() {
-                        Some("on") => {
-                            demo.wireframe_nearest_active = true;
-                            Ok(())
-                        }
-                        Some("off") => {
-                            demo.wireframe_nearest_active = false;
-                            Ok(())
-                        }
-                        Some(other) => Err(anyhow!(
-                            "unknown arg `{other}` for `wireframe nearest-active` (try on|off)"
-                        )),
-                        None => Err(anyhow!("usage: wireframe nearest-active <on|off>")),
                     },
-                    Some(other) => Err(anyhow!(
-                        "unknown arg `{other}` (try on|off|nearest-active)"
-                    )),
-                    None => {
-                        demo.wireframe_enabled = !demo.wireframe_enabled;
+                )
+                .choice(
+                    "color",
+                    "base RGB for parent edges: unique (default) or active",
+                    &["unique", "active"],
+                    |d, name| {
+                        d.wireframe_color_mode =
+                            WireframeColorMode::from_token(name).ok_or_else(|| {
+                                anyhow!("unknown color mode `{name}` (try unique|active)")
+                            })?;
                         Ok(())
-                    }
-                },
-            )
-            .with_args(&[&["on", "off", "nearest-active"], &["on", "off"]])
-            .with_long_help(
-                "Cross-section + parent-wireframe overlay on top of the SDF raymarch.\n\
-                 \n\
-                 The SDF already fills the active 3D cross-section (the polyhedron an\n\
-                 inhabitant at w = w_slice would see). The wireframe overlay adds:\n\
-                 - cyan perimeter edges tracing the boundaries between adjacent cell caps\n\
-                 - the parent polytope's full edge graph drop-w projected to R³\n\
-                 \n\
-                 subcommands:\n  \
-                 on              enable the overlay\n  \
-                 off             disable\n  \
-                 nearest-active  <on|off>  toggle the per-edge alpha gradient that\n                                  highlights cells whose midpoint w is near the\n                                  current slice. ON by default. When ON, edges of\n                                  cells the slice is deep in glow at high alpha;\n                                  edges of unaffected cells fade to ~0.10 alpha,\n                                  visualizing the slice's path through the polytope.\n\
-                 \n\
-                 With no args, `wireframe` flips the main on/off.",
-            ),
+                    },
+                ),
         );
 
         // Polychoral surface renderer: SDF raymarch vs rasterized section faces.

--- a/examples/rotate_polytopes/main.rs
+++ b/examples/rotate_polytopes/main.rs
@@ -59,14 +59,21 @@ use rye_app::{egui, run_with_config, App, Camera, FrameCtx, OrbitController, Run
 use rye_egui::Console;
 use rye_math::WPlane;
 use rye_math::{Bivector, EuclideanR3, Rotor, Rotor4};
-use rye_physics::polytope::{polytope_section_with_vertices, vertex_color_by_position};
+use rye_physics::polytope::{
+    polytope_section_faces_with_vertices, polytope_section_with_vertices, vertex_color_by_position,
+};
 use rye_render::{
     device::RenderDevice,
     raymarch::{
         polytope_extended_sdfs_wgsl, BodyUniform, Hyperslice4DNode, HYPERSLICE_KERNEL_WGSL,
     },
-    DepthMode, LineRasterNode, Viewport,
+    DepthBuffer, DepthMode, LineRasterNode, TriangleRasterNode, Viewport,
 };
+
+/// Depth-attachment format for the rasterized section-faces pass. 32-bit float gives
+/// enough precision to depth-sort cell caps from the 600-cell (which can have ~24
+/// active caps within tenths of a unit of camera-z) without artifacting.
+const SECTION_FACES_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 use rye_scene::{Scene4, SceneNode4};
 use rye_shape::LineMesh;
 use winit::window::WindowAttributes;
@@ -126,18 +133,27 @@ impl Demo {
             ctx.rd.sample_count(),
         );
 
+        // Initial body uniforms for the SDF kernel. With the surface default flipped to
+        // raster, polychoral entries are emitted as `BodyUniform::default()` (kind =
+        // Invalid) so the kernel skips them; the section-faces rasterizer draws them
+        // instead. Mirrors `Demo::sdf_body_for_slot` for the initial upload; subsequent
+        // re-uploads go through that helper directly.
         let n = row.len();
         let bodies: Vec<BodyUniform> = row
             .iter()
             .enumerate()
             .map(|(slot, entry)| {
-                BodyUniform::polytope_with_rotor(
-                    body_position(slot, n),
-                    entry.shape.shape_id(),
-                    BODY_SIZE,
-                    Rotor4::IDENTITY,
-                    entry.body_color,
-                )
+                if entry.shape.polytope4().is_some() {
+                    BodyUniform::default()
+                } else {
+                    BodyUniform::polytope_with_rotor(
+                        body_position(slot, n),
+                        entry.shape.shape_id(),
+                        BODY_SIZE,
+                        Rotor4::IDENTITY,
+                        entry.body_color,
+                    )
+                }
             })
             .collect();
         node.set_bodies(&bodies);
@@ -157,6 +173,21 @@ impl Demo {
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
             DepthMode::Off,
+            ctx.rd.sample_count(),
+        );
+
+        // Rasterized cross-section faces: filled cell-caps with face-normal Lambert
+        // shading. Uses a depth attachment so caps from different cells of the same
+        // polychoron occlude each other correctly when projected to camera space. The
+        // depth buffer is sized + cleared per-frame inside the render path (only when
+        // `surface_raster_enabled`); see `Demo::render_section_faces` in this file.
+        let section_faces = TriangleRasterNode::new(
+            &ctx.rd.device,
+            ctx.rd.surface_bundle.config.format,
+            DepthMode::ReadWrite {
+                format: SECTION_FACES_DEPTH_FORMAT,
+            },
+            rye_render::FragmentShading::FaceNormalLambert,
             ctx.rd.sample_count(),
         );
 
@@ -183,6 +214,9 @@ impl Demo {
             parent_wireframe,
             wireframe_enabled: false,
             wireframe_nearest_active: true,
+            section_faces,
+            section_faces_depth: None,
+            surface_raster_enabled: true,
             row,
             w_slice: initial_w,
             slider_up_held: false,
@@ -586,6 +620,14 @@ impl Demo {
             }
             self.node.flush_uniforms(&rd.queue);
             self.node.execute_in_viewport(rd, view, viewport)?;
+            // Rasterized polychoral cross-section faces (when toggled). Runs after the
+            // SDF pass and *before* the wireframe overlay so the dim wireframe edges
+            // sit on top of the filled caps. Polychoral SDF bodies are already inert
+            // in this mode (see `Demo::sdf_body_for_slot`), so the SDF didn't draw
+            // them; the raster pass is their visible surface.
+            if self.surface_raster_enabled {
+                self.render_section_faces(rd, view)?;
+            }
             // Cross-section + parent-wireframe overlay (when toggled). Only in Shapes
             // view since Filmstrip's per-cell viewport composition would require
             // per-cell depth-clear + per-cell uploads that aren't worth the v1 plumbing.
@@ -594,6 +636,122 @@ impl Demo {
             }
             Ok(())
         }
+    }
+
+    /// Build a combined section-faces mesh across every polychoral body in `self.row`,
+    /// upload it, clear the section-faces depth attachment, and execute the triangle
+    /// raster pass. No-op when no polychoral body is present in the row.
+    ///
+    /// Per-body world transform mirrors `render_wireframe_overlay`: canonical vertices
+    /// `v` become `body_position + BODY_SIZE * rot_state.apply(v)`. The section
+    /// algorithm then runs on these world vertices against the demo's `w_slice`,
+    /// producing R³ geometry that composes with the camera the SDF raymarcher uses.
+    ///
+    /// Depth: each polychoral cap polygon is fan-triangulated, with sub-triangles
+    /// sharing a centroid. They don't self-occlude (all on the same slice hyperplane)
+    /// but caps from *different* polychoral bodies in the row can occlude each other,
+    /// so the depth attachment is sized + cleared once here.
+    fn render_section_faces(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> Result<()> {
+        let cfg = &rd.surface_bundle.config;
+        let n = self.row.len();
+
+        let mut combined = rye_shape::TriangleMesh::<3>::default();
+        for (slot, entry) in self.row.iter().enumerate() {
+            let Some(polytope) = entry.shape.polytope4() else {
+                continue;
+            };
+            let topo = polytope.topology();
+            let bp = Vec4::from_array(body_position(slot, n));
+            let world_vertices: Vec<Vec4> = topo
+                .vertices
+                .iter()
+                .map(|v| bp + BODY_SIZE * self.rot_state.apply(*v))
+                .collect();
+
+            // Match the SDF's per-body solid coloring: every cap of this polychoron
+            // uses the body's identity color from the catalog. Per-face Lambert in the
+            // fragment shader adds the geometric depth; the underlying color is flat.
+            let [r, g, b] = entry.body_color;
+            let body_mesh = polytope_section_faces_with_vertices(
+                topo.edges,
+                topo.cells,
+                &world_vertices,
+                WPlane::new(self.w_slice),
+                [r, g, b, 1.0],
+            );
+
+            // Concatenate: append vertices + colors verbatim, indices are offset by
+            // the pre-append vertex count. This keeps the combined mesh a single
+            // upload regardless of how many polychoral bodies are in the row.
+            let base = combined.vertices.len() as u32;
+            combined.vertices.extend_from_slice(&body_mesh.vertices);
+            combined.colors.extend_from_slice(&body_mesh.colors);
+            for [a, b, c] in &body_mesh.indices {
+                combined.indices.push([base + a, base + b, base + c]);
+            }
+        }
+
+        if combined.vertices.is_empty() {
+            return Ok(());
+        }
+
+        // Camera matches the SDF raymarcher's effective view-projection (same as the
+        // wireframe overlay uses), so pixel-aligned composition over the SDF pass.
+        let view_dir = self.camera.view();
+        let aspect = cfg.width as f32 / cfg.height as f32;
+        let view_mat = Mat4::look_to_rh(view_dir.position, view_dir.forward, view_dir.up);
+        let proj_mat = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
+        let view_proj = proj_mat * view_mat;
+
+        // Depth attachment: lazily sized + recreated on resize / sample-count change.
+        DepthBuffer::ensure(
+            &mut self.section_faces_depth,
+            &rd.device,
+            SECTION_FACES_DEPTH_FORMAT,
+            (cfg.width, cfg.height),
+            rd.sample_count(),
+        );
+        let depth = self
+            .section_faces_depth
+            .as_ref()
+            .expect("ensure() guarantees Some");
+
+        // Clear the depth attachment via a no-op clear pass before the triangle draw.
+        // `TriangleRasterNode::execute` uses LoadOp::Load on depth so it preserves
+        // previous draws within the frame; we want each frame's section faces to
+        // start with a fresh depth buffer (no inter-frame ghost depth values).
+        {
+            let mut encoder = rd
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("section_faces depth clear"),
+                });
+            let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("section_faces depth clear pass"),
+                color_attachments: &[],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &depth.view,
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: wgpu::StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            rd.queue.submit(Some(encoder.finish()));
+        }
+
+        self.section_faces.set_camera(&rd.queue, view_proj);
+        self.section_faces.upload::<EuclideanR3, 3>(
+            &rd.device,
+            &rd.queue,
+            &combined,
+            &rye_math::Projection::Identity,
+        );
+        self.section_faces.execute(rd, view, Some(&depth.view))?;
+        Ok(())
     }
 
     /// Build the three overlay meshes (section triangles, section perimeter edges, parent
@@ -898,6 +1056,45 @@ impl RotatePolytopesApp {
                  nearest-active  <on|off>  toggle the per-edge alpha gradient that\n                                  highlights cells whose midpoint w is near the\n                                  current slice. ON by default. When ON, edges of\n                                  cells the slice is deep in glow at high alpha;\n                                  edges of unaffected cells fade to ~0.10 alpha,\n                                  visualizing the slice's path through the polytope.\n\
                  \n\
                  With no args, `wireframe` flips the main on/off.",
+            ),
+        );
+
+        // Polychoral surface renderer: SDF raymarch vs rasterized section faces.
+        c.register(
+            rye_egui::cmd(
+                "surface",
+                "polychoral surface: SDF raymarch or rasterized section faces",
+                |args, demo: &mut Demo, _out| {
+                    let next = match args.first().copied() {
+                        Some("sdf") => false,
+                        Some("raster") => true,
+                        Some(other) => {
+                            return Err(anyhow!("unknown arg `{other}` (try sdf|raster)"));
+                        }
+                        None => !demo.surface_raster_enabled,
+                    };
+                    if next != demo.surface_raster_enabled {
+                        demo.surface_raster_enabled = next;
+                        // Flip redirects polychoral bodies between SDF and the raster
+                        // pipeline. `rebuild_bodies` re-emits the SDF body list,
+                        // marking the polychora inert in raster mode (or live again
+                        // in SDF mode).
+                        demo.rebuild_bodies();
+                    }
+                    Ok(())
+                },
+            )
+            .with_args(&[&["sdf", "raster"]])
+            .with_long_help(
+                "Selects how the six regular convex 4-polytopes (5-cell, tesseract,\n\
+                 16-cell, 24-cell, 120-cell, 600-cell) are rendered.\n\
+                 \n\
+                 subcommands:\n  \
+                 raster  Rasterized cross-section cell-caps (the default). Face-normal\n                         Lambert lit, per-body solid color. Much faster for the\n                         120-cell + 600-cell and exact (no SDF approximation).\n  \
+                 sdf     SDF raymarch. The historical pre-rasterizer path; smoother\n                         shading but the 120-cell and 600-cell carry a face-plane\n                         approximation BUG. Kept for visual comparison.\n\
+                 \n\
+                 Smooth-surface shapes (Clifford torus, duocylinder, spherinder, 3-sphere)\n\
+                 ignore this toggle and always render via the SDF.",
             ),
         );
 

--- a/examples/rotate_polytopes/main.rs
+++ b/examples/rotate_polytopes/main.rs
@@ -54,17 +54,20 @@
 //!   `octahedron`, `cuboctahedron`, `dodecahedron`, `icosahedron`).
 
 use anyhow::{anyhow, Result};
-use glam::{Vec3, Vec4};
+use glam::{Mat4, Vec2, Vec3, Vec4};
 use rye_app::{egui, run_with_config, App, Camera, FrameCtx, OrbitController, RunConfig, SetupCtx};
 use rye_egui::Console;
 use rye_math::{Bivector, EuclideanR3, Rotor, Rotor4};
+use rye_math::WPlane;
+use rye_physics::polytope::{polytope_section_with_vertices, vertex_color_by_position};
 use rye_render::{
     device::RenderDevice,
     raymarch::{
         polytope_extended_sdfs_wgsl, BodyUniform, Hyperslice4DNode, HYPERSLICE_KERNEL_WGSL,
     },
-    Viewport,
+    DepthMode, LineRasterNode, Viewport,
 };
+use rye_shape::LineMesh;
 use rye_scene::{Scene4, SceneNode4};
 use winit::window::WindowAttributes;
 
@@ -130,7 +133,7 @@ impl Demo {
             .map(|(slot, entry)| {
                 BodyUniform::polytope_with_rotor(
                     body_position(slot, n),
-                    entry.shape,
+                    entry.shape.shape_id(),
                     BODY_SIZE,
                     Rotor4::IDENTITY,
                     entry.body_color,
@@ -138,6 +141,24 @@ impl Demo {
             })
             .collect();
         node.set_bodies(&bodies);
+
+        // Overlay raster pipelines. No depth attachment: the SDF raymarcher renders the
+        // active section as a solid volume on its own, and the rasterizer's job here is
+        // to outline boundaries between cell caps + show the full polytope wireframe on
+        // top, not to compose another opaque layer. With everything in DepthMode::Off
+        // the passes draw in submission order over the SDF.
+        let section_edges = LineRasterNode::new(
+            &ctx.rd.device,
+            ctx.rd.surface_bundle.config.format,
+            DepthMode::Off,
+            ctx.rd.sample_count(),
+        );
+        let parent_wireframe = LineRasterNode::new(
+            &ctx.rd.device,
+            ctx.rd.surface_bundle.config.format,
+            DepthMode::Off,
+            ctx.rd.sample_count(),
+        );
 
         let mut camera = Camera::<EuclideanR3>::at_origin();
         camera.position = Vec3::new(0.0, 3.0, 9.0);
@@ -158,6 +179,9 @@ impl Demo {
             camera,
             orbit,
             node,
+            section_edges,
+            parent_wireframe,
+            overlay_enabled: false,
             row,
             w_slice: initial_w,
             slider_up_held: false,
@@ -540,7 +564,7 @@ impl Demo {
                     };
                     let body = BodyUniform::polytope_with_rotor(
                         [0.0, BODY_Y, 0.0, 0.0],
-                        entry.shape,
+                        entry.shape.shape_id(),
                         BODY_SIZE,
                         cell_rotor,
                         entry.body_color,
@@ -560,8 +584,137 @@ impl Demo {
                 u.viewport_origin = [viewport.x as f32, viewport.y as f32];
             }
             self.node.flush_uniforms(&rd.queue);
-            self.node.execute_in_viewport(rd, view, viewport)
+            self.node.execute_in_viewport(rd, view, viewport)?;
+            // Cross-section + parent-wireframe overlay (when toggled). Only in Shapes
+            // view since Filmstrip's per-cell viewport composition would require
+            // per-cell depth-clear + per-cell uploads that aren't worth the v1 plumbing.
+            if self.overlay_enabled {
+                self.render_section_overlay(rd, view)?;
+            }
+            Ok(())
         }
+    }
+
+    /// Build the three overlay meshes (section triangles, section perimeter edges, parent
+    /// wireframe) from the current row + rotor + w_slice, upload them, clear the overlay
+    /// depth buffer, and execute the three raster passes on top of the existing SDF render.
+    ///
+    /// Per-body transform: each canonical Polytope4 vertex `v` becomes the world Vec4
+    /// `body.position + BODY_SIZE * rot_state.apply(v)`. The section algorithm then runs
+    /// on these world vertices against the demo's `w_slice`, producing geometry in world
+    /// R³ that composes cleanly with the SDF camera frame.
+    ///
+    /// Non-polychoral shapes (Clifford torus, duocylinder, etc.) in the row are skipped:
+    /// they have no [`rye_physics::polytope::Polytope4`] mapping and the cross-section
+    /// algorithm doesn't apply to smooth surfaces.
+    fn render_section_overlay(
+        &mut self,
+        rd: &RenderDevice,
+        view: &wgpu::TextureView,
+    ) -> Result<()> {
+        let cfg = &rd.surface_bundle.config;
+        let n = self.row.len();
+
+        // Build combined meshes across the entire row.
+        let mut section_edges = LineMesh::<3>::default();
+        let mut parent_lines = LineMesh::<3>::default();
+        // Dim alpha so the wireframe reads as a "structure-context" overlay rather than
+        // competing with the bright section perimeter edges.
+        const PARENT_ALPHA: f32 = 0.55;
+        const PARENT_WIDTH: f32 = 1.2;
+
+        for (slot, entry) in self.row.iter().enumerate() {
+            let Some(polytope) = entry.shape.polytope4() else {
+                continue;
+            };
+            let topo = polytope.topology();
+            let body_pos = body_position(slot, n);
+            let bp = Vec4::from_array(body_pos);
+            // Transform canonical vertices into world Vec4 coords. Same shape transform
+            // the SDF kernel applies (`body_position + body_size * rotor.apply(v)`), so
+            // the rasterized geometry sits at the same world-space position as the
+            // raymarched SDF.
+            let world_vertices: Vec<Vec4> = topo
+                .vertices
+                .iter()
+                .map(|v| bp + BODY_SIZE * self.rot_state.apply(*v))
+                .collect();
+
+            // Cross-section perimeter edges only. The SDF raymarcher renders the section
+            // as a solid volume; we just need to outline the boundaries between adjacent
+            // cell caps (each cap contributes one face of the 3D section polytope).
+            // `polytope_section_with_vertices` returns `(triangles, perimeter)`; we
+            // discard the filled triangles since they would obscure the SDF without
+            // adding information.
+            let (_tri, mut perim) = polytope_section_with_vertices(
+                topo.edges,
+                topo.cells,
+                &world_vertices,
+                WPlane::new(self.w_slice),
+            );
+            section_edges.segments.append(&mut perim.segments);
+            section_edges.colors.append(&mut perim.colors);
+            section_edges.widths.append(&mut perim.widths);
+
+            // Parent wireframe: every polytope edge as a world-R³ line, colored by
+            // position-derived RGB from the canonical (unit-circumradius) vertex set so
+            // adjacent edges share their endpoint colors and the polytope's symmetry
+            // shows as smooth color gradients across the wireframe (same scheme as
+            // [`Polytope4::lines_colored_by_position`]). Alpha is dimmed uniformly so
+            // the wireframe sits visually behind the bright section perimeter.
+            for &[i, j] in topo.edges {
+                let ia = i as usize;
+                let ja = j as usize;
+                let a = world_vertices[ia];
+                let b = world_vertices[ja];
+                let mut color_a = vertex_color_by_position(topo.vertices[ia]);
+                let mut color_b = vertex_color_by_position(topo.vertices[ja]);
+                color_a[3] = PARENT_ALPHA;
+                color_b[3] = PARENT_ALPHA;
+                parent_lines
+                    .segments
+                    .push(([a.x, a.y, a.z], [b.x, b.y, b.z]));
+                parent_lines.colors.push((color_a, color_b));
+                parent_lines.widths.push(PARENT_WIDTH);
+            }
+        }
+
+        // Upload (each call is a no-op when its mesh is empty).
+        self.section_edges.upload::<EuclideanR3, 3>(
+            &rd.device,
+            &rd.queue,
+            &section_edges,
+            &rye_math::Projection::Identity,
+            1,
+        );
+        self.parent_wireframe.upload::<EuclideanR3, 3>(
+            &rd.device,
+            &rd.queue,
+            &parent_lines,
+            &rye_math::Projection::Identity,
+            1,
+        );
+
+        // Camera. Build the same view+projection matrix the SDF raymarcher uses
+        // implicitly via its ray basis, so the rasterized overlay aligns pixel-for-pixel
+        // with the raymarched scene.
+        let view_dir = self.camera.view();
+        let aspect = cfg.width as f32 / cfg.height as f32;
+        let view_mat = Mat4::look_to_rh(view_dir.position, view_dir.forward, view_dir.up);
+        let proj_mat = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
+        let view_proj = proj_mat * view_mat;
+        let vp_size = Vec2::new(cfg.width as f32, cfg.height as f32);
+        self.section_edges
+            .set_camera(&rd.queue, view_proj, vp_size);
+        self.parent_wireframe
+            .set_camera(&rd.queue, view_proj, vp_size);
+
+        // Section perimeter edges then dim parent wireframe, both depth-off. The SDF
+        // pass renders solid bodies underneath; the overlay just adds line context on
+        // top in submission order.
+        self.section_edges.execute(rd, view, None)?;
+        self.parent_wireframe.execute(rd, view, None)?;
+        Ok(())
     }
 
     pub(crate) fn title(&self, _fps: f32) -> std::borrow::Cow<'static, str> {
@@ -637,6 +790,26 @@ impl RotatePolytopesApp {
                 Ok(())
             },
         ));
+        // Cross-section + parent-wireframe overlay. Off by default; toggle with
+        // `overlay on` / `overlay off` / bare `overlay` to flip.
+        c.register(
+            rye_egui::cmd(
+                "overlay",
+                "toggle cross-section + parent-wireframe overlay (on|off; no arg = toggle)",
+                |args, demo: &mut Demo, _out| {
+                    demo.overlay_enabled = match args.first().copied() {
+                        Some("on") => true,
+                        Some("off") => false,
+                        Some(other) => {
+                            return Err(anyhow!("unknown arg `{other}` (try on|off)"))
+                        }
+                        None => !demo.overlay_enabled,
+                    };
+                    Ok(())
+                },
+            )
+            .with_args(&[&["on", "off"]]),
+        );
 
         // Framework-provided capture: `capture png [pre|post|both] [dir]`,
         // `capture frames [pre|post|both] [dir]`, `capture stop`. Bound to F12 (one-shot)

--- a/examples/rotate_polytopes/main.rs
+++ b/examples/rotate_polytopes/main.rs
@@ -57,8 +57,8 @@ use anyhow::{anyhow, Result};
 use glam::{Mat4, Vec2, Vec3, Vec4};
 use rye_app::{egui, run_with_config, App, Camera, FrameCtx, OrbitController, RunConfig, SetupCtx};
 use rye_egui::Console;
-use rye_math::{Bivector, EuclideanR3, Rotor, Rotor4};
 use rye_math::WPlane;
+use rye_math::{Bivector, EuclideanR3, Rotor, Rotor4};
 use rye_physics::polytope::{polytope_section_with_vertices, vertex_color_by_position};
 use rye_render::{
     device::RenderDevice,
@@ -67,8 +67,8 @@ use rye_render::{
     },
     DepthMode, LineRasterNode, Viewport,
 };
-use rye_shape::LineMesh;
 use rye_scene::{Scene4, SceneNode4};
+use rye_shape::LineMesh;
 use winit::window::WindowAttributes;
 
 mod active;
@@ -181,7 +181,8 @@ impl Demo {
             node,
             section_edges,
             parent_wireframe,
-            overlay_enabled: false,
+            wireframe_enabled: false,
+            wireframe_nearest_active: true,
             row,
             w_slice: initial_w,
             slider_up_held: false,
@@ -588,8 +589,8 @@ impl Demo {
             // Cross-section + parent-wireframe overlay (when toggled). Only in Shapes
             // view since Filmstrip's per-cell viewport composition would require
             // per-cell depth-clear + per-cell uploads that aren't worth the v1 plumbing.
-            if self.overlay_enabled {
-                self.render_section_overlay(rd, view)?;
+            if self.wireframe_enabled {
+                self.render_wireframe_overlay(rd, view)?;
             }
             Ok(())
         }
@@ -607,7 +608,7 @@ impl Demo {
     /// Non-polychoral shapes (Clifford torus, duocylinder, etc.) in the row are skipped:
     /// they have no [`rye_physics::polytope::Polytope4`] mapping and the cross-section
     /// algorithm doesn't apply to smooth surfaces.
-    fn render_section_overlay(
+    fn render_wireframe_overlay(
         &mut self,
         rd: &RenderDevice,
         view: &wgpu::TextureView,
@@ -618,10 +619,14 @@ impl Demo {
         // Build combined meshes across the entire row.
         let mut section_edges = LineMesh::<3>::default();
         let mut parent_lines = LineMesh::<3>::default();
-        // Dim alpha so the wireframe reads as a "structure-context" overlay rather than
-        // competing with the bright section perimeter edges.
-        const PARENT_ALPHA: f32 = 0.55;
+        // Uniform-alpha endpoints when `nearest-active` is off; the active-mode mapping
+        // interpolates between DIM (cells the slice misses entirely) and BRIGHT (cells
+        // the slice is at the midpoint of).
+        const PARENT_ALPHA_UNIFORM: f32 = 0.55;
+        const PARENT_ALPHA_DIM: f32 = 0.10;
+        const PARENT_ALPHA_BRIGHT: f32 = 0.85;
         const PARENT_WIDTH: f32 = 1.2;
+        let nearest_active = self.wireframe_nearest_active;
 
         for (slot, entry) in self.row.iter().enumerate() {
             let Some(polytope) = entry.shape.polytope4() else {
@@ -656,12 +661,52 @@ impl Demo {
             section_edges.colors.append(&mut perim.colors);
             section_edges.widths.append(&mut perim.widths);
 
+            // Per-cell "crossing strength" in [0, 1]: 1 when `w_slice` is at the cell's
+            // w-midpoint (cap face is widest), 0 when the slice is at the cell's w-boundary
+            // or outside it entirely. A linear w-midpoint proxy avoids computing actual
+            // cap areas while giving the same visual gradient: cells the slice is *deep
+            // in* peak in brightness, cells the slice barely touches taper to dim.
+            let cell_strengths: Vec<f32> = topo
+                .cells
+                .iter()
+                .map(|cell| {
+                    let (w_min, w_max) = cell
+                        .iter()
+                        .map(|&i| world_vertices[i as usize].w)
+                        .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), w| {
+                            (lo.min(w), hi.max(w))
+                        });
+                    let half_extent = (w_max - w_min) * 0.5;
+                    if half_extent <= 0.0 {
+                        return 0.0;
+                    }
+                    let mid = (w_min + w_max) * 0.5;
+                    let dist = (self.w_slice - mid).abs();
+                    (1.0 - dist / half_extent).clamp(0.0, 1.0)
+                })
+                .collect();
+
+            // Per-edge brightness: max strength across cells the edge belongs to. An edge
+            // belongs to a cell when both endpoints sit in that cell's vertex list. This
+            // lets a single edge "light up" as soon as ANY containing cell is being
+            // crossed deep; doesn't require the slice to specifically hit the cell whose
+            // boundary the edge sits on.
+            let edge_strength = |i: u32, j: u32| -> f32 {
+                let mut best = 0.0_f32;
+                for (cell, strength) in topo.cells.iter().zip(cell_strengths.iter()) {
+                    if cell.contains(&i) && cell.contains(&j) && *strength > best {
+                        best = *strength;
+                    }
+                }
+                best
+            };
+
             // Parent wireframe: every polytope edge as a world-R³ line, colored by
             // position-derived RGB from the canonical (unit-circumradius) vertex set so
             // adjacent edges share their endpoint colors and the polytope's symmetry
             // shows as smooth color gradients across the wireframe (same scheme as
-            // [`Polytope4::lines_colored_by_position`]). Alpha is dimmed uniformly so
-            // the wireframe sits visually behind the bright section perimeter.
+            // [`Polytope4::lines_colored_by_position`]). Alpha modulated per-edge by the
+            // `nearest-active` strength when that toggle is on; uniform otherwise.
             for &[i, j] in topo.edges {
                 let ia = i as usize;
                 let ja = j as usize;
@@ -669,8 +714,14 @@ impl Demo {
                 let b = world_vertices[ja];
                 let mut color_a = vertex_color_by_position(topo.vertices[ia]);
                 let mut color_b = vertex_color_by_position(topo.vertices[ja]);
-                color_a[3] = PARENT_ALPHA;
-                color_b[3] = PARENT_ALPHA;
+                let alpha = if nearest_active {
+                    let s = edge_strength(i, j);
+                    PARENT_ALPHA_DIM + (PARENT_ALPHA_BRIGHT - PARENT_ALPHA_DIM) * s
+                } else {
+                    PARENT_ALPHA_UNIFORM
+                };
+                color_a[3] = alpha;
+                color_b[3] = alpha;
                 parent_lines
                     .segments
                     .push(([a.x, a.y, a.z], [b.x, b.y, b.z]));
@@ -704,8 +755,7 @@ impl Demo {
         let proj_mat = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
         let view_proj = proj_mat * view_mat;
         let vp_size = Vec2::new(cfg.width as f32, cfg.height as f32);
-        self.section_edges
-            .set_camera(&rd.queue, view_proj, vp_size);
+        self.section_edges.set_camera(&rd.queue, view_proj, vp_size);
         self.parent_wireframe
             .set_camera(&rd.queue, view_proj, vp_size);
 
@@ -790,25 +840,65 @@ impl RotatePolytopesApp {
                 Ok(())
             },
         ));
-        // Cross-section + parent-wireframe overlay. Off by default; toggle with
-        // `overlay on` / `overlay off` / bare `overlay` to flip.
+        // Cross-section + parent-wireframe overlay. Tab-complete cycles through:
+        //   wireframe on               -- enable the overlay
+        //   wireframe off              -- disable
+        //   wireframe nearest-active on|off -- toggle the per-cell alpha gradient that
+        //                                     highlights cells the slice is currently
+        //                                     deep into
+        // Bare `wireframe` (no args) flips the main on/off.
         c.register(
             rye_egui::cmd(
-                "overlay",
-                "toggle cross-section + parent-wireframe overlay (on|off; no arg = toggle)",
-                |args, demo: &mut Demo, _out| {
-                    demo.overlay_enabled = match args.first().copied() {
-                        Some("on") => true,
-                        Some("off") => false,
-                        Some(other) => {
-                            return Err(anyhow!("unknown arg `{other}` (try on|off)"))
+                "wireframe",
+                "wireframe + cross-section overlay (see `help wireframe`)",
+                |args, demo: &mut Demo, _out| match args.first().copied() {
+                    Some("on") => {
+                        demo.wireframe_enabled = true;
+                        Ok(())
+                    }
+                    Some("off") => {
+                        demo.wireframe_enabled = false;
+                        Ok(())
+                    }
+                    Some("nearest-active") => match args.get(1).copied() {
+                        Some("on") => {
+                            demo.wireframe_nearest_active = true;
+                            Ok(())
                         }
-                        None => !demo.overlay_enabled,
-                    };
-                    Ok(())
+                        Some("off") => {
+                            demo.wireframe_nearest_active = false;
+                            Ok(())
+                        }
+                        Some(other) => Err(anyhow!(
+                            "unknown arg `{other}` for `wireframe nearest-active` (try on|off)"
+                        )),
+                        None => Err(anyhow!("usage: wireframe nearest-active <on|off>")),
+                    },
+                    Some(other) => Err(anyhow!(
+                        "unknown arg `{other}` (try on|off|nearest-active)"
+                    )),
+                    None => {
+                        demo.wireframe_enabled = !demo.wireframe_enabled;
+                        Ok(())
+                    }
                 },
             )
-            .with_args(&[&["on", "off"]]),
+            .with_args(&[&["on", "off", "nearest-active"], &["on", "off"]])
+            .with_long_help(
+                "Cross-section + parent-wireframe overlay on top of the SDF raymarch.\n\
+                 \n\
+                 The SDF already fills the active 3D cross-section (the polyhedron an\n\
+                 inhabitant at w = w_slice would see). The wireframe overlay adds:\n\
+                 - cyan perimeter edges tracing the boundaries between adjacent cell caps\n\
+                 - the parent polytope's full edge graph drop-w projected to R³\n\
+                 \n\
+                 subcommands:\n  \
+                 on              enable the overlay\n  \
+                 off             disable\n  \
+                 nearest-active  <on|off>  toggle the per-edge alpha gradient that\n                                  highlights cells whose midpoint w is near the\n                                  current slice. ON by default. When ON, edges of\n                                  cells the slice is deep in glow at high alpha;\n                                  edges of unaffected cells fade to ~0.10 alpha,\n                                  visualizing the slice's path through the polytope.\n\
+                 \n\
+                 With no args, `wireframe` flips the main on/off.",
+            ),
         );
 
         // Framework-provided capture: `capture png [pre|post|both] [dir]`,

--- a/examples/rotate_polytopes/shapes.rs
+++ b/examples/rotate_polytopes/shapes.rs
@@ -12,7 +12,8 @@ use rye_egui::{
     },
     media::add_button,
 };
-use rye_render::raymarch::{SHAPE_120CELL, SHAPE_600CELL};
+use rye_physics::polytope::Polytope4;
+use rye_render::raymarch::RaymarchShape;
 
 use crate::catalog::{render_shape_catalog_menu, ShapeEntry};
 use crate::consts::{CARD_ITEM_SPACING_X, CONTROL_H, CONTROL_W, MAX_ROW_LEN, SHAPE_CARD_WIDTH};
@@ -25,10 +26,12 @@ impl Demo {
     /// Apply/Clear in `Composer`).
     pub(crate) fn render_shapes_section(&mut self, ui: &mut egui::Ui) {
         ui.separator();
-        let has_heavy = self
-            .row
-            .iter()
-            .any(|e| e.shape == SHAPE_120CELL || e.shape == SHAPE_600CELL);
+        let has_heavy = self.row.iter().any(|e| {
+            matches!(
+                e.shape,
+                RaymarchShape::Polytope(Polytope4::Cell120 | Polytope4::Cell600)
+            )
+        });
         if has_heavy {
             ui.colored_label(
                 egui::Color32::from_rgb(242, 130, 70),

--- a/examples/rotate_polytopes/shapes.rs
+++ b/examples/rotate_polytopes/shapes.rs
@@ -26,16 +26,21 @@ impl Demo {
     /// Apply/Clear in `Composer`).
     pub(crate) fn render_shapes_section(&mut self, ui: &mut egui::Ui) {
         ui.separator();
-        let has_heavy = self.row.iter().any(|e| {
-            matches!(
-                e.shape,
-                RaymarchShape::Polytope(Polytope4::Cell120 | Polytope4::Cell600)
-            )
-        });
-        if has_heavy {
+        // Only the SDF raymarch path is heavy on the 120/600-cell (~24 KB of const face-
+        // normal data + per-pixel Wolfe-greedy projection); the rasterized section-faces
+        // path keeps both polychora at vsync regardless of how many are in the row, so
+        // the warning is irrelevant when `surface_raster_enabled`.
+        let has_heavy_sdf = !self.surface_raster_enabled
+            && self.row.iter().any(|e| {
+                matches!(
+                    e.shape,
+                    RaymarchShape::Polytope(Polytope4::Cell120 | Polytope4::Cell600)
+                )
+            });
+        if has_heavy_sdf {
             ui.colored_label(
                 egui::Color32::from_rgb(242, 130, 70),
-                "120/600-cell SDFs are heavy; expect <60 fps.",
+                "120/600-cell SDFs are heavy; expect <60 fps. Try `surface raster`.",
             );
         }
         let mut row_changed = false;

--- a/examples/rotate_polytopes/state.rs
+++ b/examples/rotate_polytopes/state.rs
@@ -50,6 +50,38 @@ pub(crate) enum ViewMode {
     Filmstrip,
 }
 
+/// How the parent-wireframe edges are colored. Orthogonal to the alpha-modulation
+/// toggle [`Demo::wireframe_nearest_active`]: the color mode picks the hue, the
+/// nearest-active toggle then modulates alpha on top.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub(crate) enum WireframeColorMode {
+    /// Per-vertex RGB from [`rye_physics::polytope::vertex_color_by_position`]: a
+    /// continuous color field over the polytope's vertex set that flows smoothly
+    /// across the edge graph and reveals symmetry as color gradients. Every vertex
+    /// picks up a distinct hue from its 4D coordinates, so the polytope reads as a
+    /// stylized colorful identity rather than a uniform mass of edges.
+    #[default]
+    Unique,
+    /// Binary green/gray by cell activity: edges that belong to at least one cell
+    /// the slice is *currently* intersecting are bright green; all other edges are
+    /// dim neutral gray. Reads as "which cells of the polytope am I looking at right
+    /// now" at a glance, complementing the gradient `nearest-active` mode (which is
+    /// continuous and shows *how strongly* each cell is being crossed).
+    Active,
+}
+
+impl WireframeColorMode {
+    /// Parse a console-arg spelling (`unique` or `active`). Returns `None` for any
+    /// other input; the caller surfaces a usage error.
+    pub(crate) fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "unique" => Some(WireframeColorMode::Unique),
+            "active" => Some(WireframeColorMode::Active),
+            _ => None,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // RotorTerm + display helpers
 // ---------------------------------------------------------------------------
@@ -232,15 +264,26 @@ pub(crate) struct Demo {
     /// each moment. When `false`, every edge uses the same uniform dim alpha (the
     /// previous behavior).
     pub(crate) wireframe_nearest_active: bool,
+    /// Base RGB for wireframe edges. Orthogonal to [`Self::wireframe_nearest_active`]:
+    /// the color mode picks the hue, the nearest-active toggle then modulates alpha on
+    /// top.
+    pub(crate) wireframe_color_mode: WireframeColorMode,
     /// Filled-faces rasterizer for the cross-section of every polychoral body. When
     /// [`Self::surface_raster_enabled`] is `true`, this replaces the SDF raymarch for the
     /// six regular convex 4-polytopes: the SDF gets `BodyUniform::default()` for those
     /// slots (which the kernel skips) and the section's filled cell-caps come through
-    /// here instead. Per-vertex position-colored, face-normal Lambert lit, opaque.
+    /// here instead. Per-body solid color + face-normal Lambert in the fragment shader.
     pub(crate) section_faces: rye_render::TriangleRasterNode,
-    /// Depth attachment for [`Self::section_faces`]. Sized to the swapchain on first frame
-    /// and recreated on resize via [`rye_render::DepthBuffer::ensure`]. None until the
-    /// first frame in raster mode; ignored entirely in SDF mode.
+    /// Shared depth attachment for the rasterizer chain in Shapes view. Sized to the
+    /// swapchain and recreated on resize via [`rye_render::DepthBuffer::ensure`].
+    ///
+    /// Cleared once per frame at the top of the Shapes-view render path
+    /// ([`crate::Demo::ensure_and_clear_shared_depth`]). Two passes consume it:
+    /// - `section_faces` writes depth + color when raster mode is on (no-op in SDF
+    ///   mode, so the buffer stays at the cleared `1.0` value).
+    /// - `parent_wireframe` reads depth (no write) so lines behind a section cap are
+    ///   correctly occluded. In SDF mode the cleared depth makes every wireframe
+    ///   fragment pass the test trivially, preserving the historical visual.
     pub(crate) section_faces_depth: Option<rye_render::DepthBuffer>,
     /// Selects how the six regular convex 4-polytopes are rendered:
     /// - `true` (default): rasterized filled cross-section cell caps via

--- a/examples/rotate_polytopes/state.rs
+++ b/examples/rotate_polytopes/state.rs
@@ -232,6 +232,27 @@ pub(crate) struct Demo {
     /// each moment. When `false`, every edge uses the same uniform dim alpha (the
     /// previous behavior).
     pub(crate) wireframe_nearest_active: bool,
+    /// Filled-faces rasterizer for the cross-section of every polychoral body. When
+    /// [`Self::surface_raster_enabled`] is `true`, this replaces the SDF raymarch for the
+    /// six regular convex 4-polytopes: the SDF gets `BodyUniform::default()` for those
+    /// slots (which the kernel skips) and the section's filled cell-caps come through
+    /// here instead. Per-vertex position-colored, face-normal Lambert lit, opaque.
+    pub(crate) section_faces: rye_render::TriangleRasterNode,
+    /// Depth attachment for [`Self::section_faces`]. Sized to the swapchain on first frame
+    /// and recreated on resize via [`rye_render::DepthBuffer::ensure`]. None until the
+    /// first frame in raster mode; ignored entirely in SDF mode.
+    pub(crate) section_faces_depth: Option<rye_render::DepthBuffer>,
+    /// Selects how the six regular convex 4-polytopes are rendered:
+    /// - `true` (default): rasterized filled cross-section cell caps via
+    ///   [`Self::section_faces`]. Much faster for the 120-cell + 600-cell, exact (no
+    ///   Wolfe-greedy approximation), sidesteps the cell120/600 face-plane BUG in
+    ///   `rye_physics::euclidean_r4`.
+    /// - `false`: SDF raymarch in [`Self::node`]. The historical pre-rasterizer
+    ///   behavior, kept available behind the console toggle for visual comparison.
+    ///
+    /// Smooth-surface shapes (Clifford torus, duocylinder, etc.) ignore this toggle and
+    /// always render via the SDF; they have no polytope topology to section.
+    pub(crate) surface_raster_enabled: bool,
     /// Polytope row built at startup from `--shapes` CLI args (or `DEFAULT_ROW`); drives
     /// both the body uniforms and per-body label lookups in the overlay.
     pub(crate) row: Vec<ShapeEntry>,
@@ -374,40 +395,47 @@ impl Demo {
         }
     }
 
+    /// Build the SDF body uniform for a single row entry, with surface-raster opt-out:
+    /// when raster mode is on AND the entry has polytope topology, the returned uniform
+    /// is `BodyUniform::default()` (kind = Invalid), which the kernel's dispatch chain
+    /// skips. The slot is preserved (so the visual layout doesn't shift); the polychoral
+    /// surface is rendered separately via [`Self::section_faces`] in `main.rs`.
+    ///
+    /// Smooth-surface shapes (Clifford torus, etc.) ignore the raster toggle and always
+    /// produce a live SDF body.
+    fn sdf_body_for_slot(&self, slot: usize, n: usize, rotor: Rotor4) -> BodyUniform {
+        let entry = &self.row[slot];
+        if self.surface_raster_enabled && entry.shape.polytope4().is_some() {
+            return BodyUniform::default();
+        }
+        BodyUniform::polytope_with_rotor(
+            body_position(slot, n),
+            entry.shape.shape_id(),
+            BODY_SIZE,
+            rotor,
+            entry.body_color,
+        )
+    }
+
     /// Drive every body in the row with the same rotor, lets the user directly compare
     /// slice signatures under identical 4D motion.
     pub(crate) fn write_all(&mut self, rotor: Rotor4) {
         let n = self.row.len();
-        for (slot, entry) in self.row.iter().enumerate() {
-            let body = BodyUniform::polytope_with_rotor(
-                body_position(slot, n),
-                entry.shape.shape_id(),
-                BODY_SIZE,
-                rotor,
-                entry.body_color,
-            );
+        for slot in 0..n {
+            let body = self.sdf_body_for_slot(slot, n, rotor);
             self.node.set_body(slot, body);
         }
     }
 
     /// Re-emit every body's uniform from the current row + rotor state. Called after row
-    /// mutations (add/remove/reorder) to resync the GPU side to what the panel shows.
+    /// mutations (add/remove/reorder), rotor changes during spin, and surface-mode
+    /// toggles (since flipping `surface_raster_enabled` redirects polychora between the
+    /// SDF and the raster pipelines).
     pub(crate) fn rebuild_bodies(&mut self) {
         let n = self.row.len();
         let rotor = self.rot_state;
-        let bodies: Vec<BodyUniform> = self
-            .row
-            .iter()
-            .enumerate()
-            .map(|(slot, entry)| {
-                BodyUniform::polytope_with_rotor(
-                    body_position(slot, n),
-                    entry.shape.shape_id(),
-                    BODY_SIZE,
-                    rotor,
-                    entry.body_color,
-                )
-            })
+        let bodies: Vec<BodyUniform> = (0..n)
+            .map(|slot| self.sdf_body_for_slot(slot, n, rotor))
             .collect();
         self.node.set_bodies(&bodies);
     }

--- a/examples/rotate_polytopes/state.rs
+++ b/examples/rotate_polytopes/state.rs
@@ -221,9 +221,17 @@ pub(crate) struct Demo {
     /// which slice is currently shown.
     pub(crate) parent_wireframe: rye_render::LineRasterNode,
     /// Whether the cross-section + parent-wireframe overlay renders. Off by default so
-    /// the existing SDF-only demo is unchanged; toggle via the `overlay on|off` console
+    /// the existing SDF-only demo is unchanged; toggle via the `wireframe on|off` console
     /// subcommand.
-    pub(crate) overlay_enabled: bool,
+    pub(crate) wireframe_enabled: bool,
+    /// When `true`, parent-wireframe edges are alpha-graded by how close the current
+    /// `w_slice` is to the midpoint of each cell they belong to: edges of cells the slice
+    /// is *deep in* glow at full alpha, edges of cells the slice doesn't touch fade to the
+    /// dim "context" alpha. As the slice scrubs, brightness propagates through the
+    /// wireframe as a wave, visually identifying which cells are contributing caps at
+    /// each moment. When `false`, every edge uses the same uniform dim alpha (the
+    /// previous behavior).
+    pub(crate) wireframe_nearest_active: bool,
     /// Polytope row built at startup from `--shapes` CLI args (or `DEFAULT_ROW`); drives
     /// both the body uniforms and per-body label lookups in the overlay.
     pub(crate) row: Vec<ShapeEntry>,
@@ -446,4 +454,3 @@ impl Demo {
         self.write_all(Rotor4::IDENTITY);
     }
 }
-

--- a/examples/rotate_polytopes/state.rs
+++ b/examples/rotate_polytopes/state.rs
@@ -211,6 +211,19 @@ pub(crate) struct Demo {
     pub(crate) camera: Camera<EuclideanR3>,
     pub(crate) orbit: OrbitController<EuclideanR3>,
     pub(crate) node: Hyperslice4DNode,
+    /// Rasterizer node for the cross-section perimeter (bright cyan edges around each
+    /// cap polygon). Filled caps are NOT drawn -- the SDF raymarcher already renders the
+    /// section polytope as a solid volume, so the rasterizer's job is to outline the
+    /// boundaries between adjacent cell contributions, not to fill them.
+    pub(crate) section_edges: rye_render::LineRasterNode,
+    /// Rasterizer node for the dim "parent wireframe" overlay: the full polytope's edge
+    /// graph (per body) projected via drop-w. Conveys polytope structure independent of
+    /// which slice is currently shown.
+    pub(crate) parent_wireframe: rye_render::LineRasterNode,
+    /// Whether the cross-section + parent-wireframe overlay renders. Off by default so
+    /// the existing SDF-only demo is unchanged; toggle via the `overlay on|off` console
+    /// subcommand.
+    pub(crate) overlay_enabled: bool,
     /// Polytope row built at startup from `--shapes` CLI args (or `DEFAULT_ROW`); drives
     /// both the body uniforms and per-body label lookups in the overlay.
     pub(crate) row: Vec<ShapeEntry>,
@@ -360,7 +373,7 @@ impl Demo {
         for (slot, entry) in self.row.iter().enumerate() {
             let body = BodyUniform::polytope_with_rotor(
                 body_position(slot, n),
-                entry.shape,
+                entry.shape.shape_id(),
                 BODY_SIZE,
                 rotor,
                 entry.body_color,
@@ -381,7 +394,7 @@ impl Demo {
             .map(|(slot, entry)| {
                 BodyUniform::polytope_with_rotor(
                     body_position(slot, n),
-                    entry.shape,
+                    entry.shape.shape_id(),
                     BODY_SIZE,
                     rotor,
                     entry.body_color,
@@ -433,3 +446,4 @@ impl Demo {
         self.write_all(Rotor4::IDENTITY);
     }
 }
+

--- a/examples/rotate_polytopes/state.rs
+++ b/examples/rotate_polytopes/state.rs
@@ -285,6 +285,12 @@ pub(crate) struct Demo {
     ///   correctly occluded. In SDF mode the cleared depth makes every wireframe
     ///   fragment pass the test trivially, preserving the historical visual.
     pub(crate) section_faces_depth: Option<rye_render::DepthBuffer>,
+    /// Scratch buffers reused across frames + bodies inside `render_section_faces` to
+    /// avoid per-body heap allocations on the 240 fps hot path. Both are cleared at
+    /// the start of each invocation; capacity grows monotonically with the largest
+    /// polychoron's vertex / triangle count seen so far.
+    pub(crate) section_world_vertices_scratch: Vec<glam::Vec4>,
+    pub(crate) section_faces_mesh_scratch: rye_shape::TriangleMesh<3>,
     /// Selects how the six regular convex 4-polytopes are rendered:
     /// - `true` (default): rasterized filled cross-section cell caps via
     ///   [`Self::section_faces`]. Much faster for the 120-cell + 600-cell, exact (no


### PR DESCRIPTION
Triangle rasterizer + cross-section primitive. The six convex regular polychora now render via topology-derived section faces (~2.2× SDF on a 4090 laptop with all six in a row); SDF stays available behind `surface sdf` for visual comparison.

Verify:
- `cargo test --workspace` (540 passing)
- `cargo run --release --example rotate_polytopes -- --shapes 5-cell,8-cell,16-cell,24-cell,120-cell,600-cell`, then toggle `surface sdf`/`raster`, `wireframe`, `wireframe color`