### PR TITLE
Perspective4D + SurfaceMode { Raster, Sdf, Off } + wireframe perimeter toggle

### DIFF
--- a/crates/rye-math/src/rasterizable.rs
+++ b/crates/rye-math/src/rasterizable.rs
@@ -45,9 +45,13 @@ use crate::{EuclideanR3, EuclideanR4};
 ///   view is `Orthographic { drop_axis: 3 }` (drop `w`); other axis choices show alternative
 ///   3-flat slices. For `N == 3` this can drop one axis to produce a 2D-looking projection
 ///   (used later for Flatland-style reveals).
+/// - [`Perspective4D`](Self::Perspective4D): R⁴ pinhole projection from a viewer at
+///   `w = focal_distance` looking in -w. Produces the canonical "cube within a cube"
+///   tesseract view; drop-w renders axis-aligned polytopes as degenerate flat shapes because
+///   every pair of w-opposite vertices collapses to the same R³ point, and Perspective4D
+///   separates them.
 ///
-/// Future variants under consideration: R⁴-specific `Schlegel`, `Stereographic`,
-/// `Hyperslice`, and 4D `Perspective`.
+/// Future variants under consideration: R⁴-specific `Schlegel`, `Stereographic`, `Hyperslice`.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Projection<const N: usize> {
     /// Pass through: take the first 3 components, zero-pad if `N < 3`, truncate if `N > 3`.
@@ -62,6 +66,26 @@ pub enum Projection<const N: usize> {
     ///
     /// Out-of-range `drop_axis` (>= `N`) returns `Vec3::ZERO`.
     Orthographic { drop_axis: usize },
+
+    /// 4D pinhole projection from a viewer at `(0, 0, 0, focal_distance)` looking in the -w
+    /// direction. A point `(x, y, z, w)` maps to `(x, y, z) * scale` where
+    /// `scale = focal_distance / (focal_distance - w)`. Points at `w = 0` are unchanged;
+    /// positive-w points (closer to the viewer in 4D) scale up; negative-w points scale down.
+    /// For a unit-circumradius polytope (vertices in `[-1, 1]^4`) this produces the classical
+    /// "cube within a cube" tesseract view: the +w face renders as the outer cube, the -w
+    /// face as the inner cube, connecting edges as the frustum.
+    ///
+    /// **Precondition: `focal_distance > max(w)` across every input vertex.** Otherwise the
+    /// denominator goes through zero (singularity at the viewer's eye) or negative (the
+    /// projection flips inside-out). The impl clamps the denominator to a small positive
+    /// epsilon rather than panicking, so a bad parameter degrades gracefully instead of NaN-
+    /// ing the upload, but the resulting picture is meaningless.
+    ///
+    /// Only meaningful for `N == 4`; impls for other `N` return `Vec3::ZERO`.
+    Perspective4D {
+        /// Viewer position along the w-axis. Typical value for unit polytopes: `2.0`.
+        focal_distance: f32,
+    },
 }
 
 /// A flat or curved space that can drive the rasterizer pipeline: provides projection from its
@@ -121,6 +145,9 @@ impl RasterizableSpace<3> for EuclideanR3 {
                 2 => Vec3::new(point.x, point.y, 0.0),
                 _ => Vec3::ZERO,
             },
+            // Perspective4D is meaningful only for `N == 4`; on R³ there's no w axis to
+            // project from. Per the enum contract, return zero rather than panic.
+            Projection::Perspective4D { .. } => Vec3::ZERO,
         }
     }
 
@@ -154,6 +181,17 @@ impl RasterizableSpace<4> for EuclideanR4 {
                 3 => Vec3::new(point.x, point.y, point.z),
                 _ => Vec3::ZERO,
             },
+            Projection::Perspective4D { focal_distance } => {
+                // Pinhole from viewer at `(0, 0, 0, focal_distance)` looking in -w. The
+                // denominator clamp guards against zero / negative values: callers should
+                // pick `focal_distance > max(w)` so the clamp never engages on legitimate
+                // input, but clamping lets a misconfigured projection degrade visibly
+                // rather than emit NaN through the rest of the upload path. The `1e-4`
+                // floor matches `EDGE_PARALLEL_EPSILON`'s order of magnitude.
+                let denom = (focal_distance - point.w).max(1e-4);
+                let scale = focal_distance / denom;
+                Vec3::new(point.x, point.y, point.z) * scale
+            }
         }
     }
 
@@ -298,6 +336,75 @@ mod tests {
         assert_eq!(pj(3), Vec3::new(1.0, 2.0, 3.0));
         // Out-of-range falls back to zero per the doc contract.
         assert_eq!(pj(4), Vec3::ZERO);
+    }
+
+    /// `Projection::Perspective4D` projects a `w = 0` point unchanged: the viewer sits at
+    /// `(0, 0, 0, focal_distance)` and a point on the `w = 0` 3-flat is at perpendicular
+    /// distance `focal_distance` from the eye, giving `scale = focal_distance / focal_distance
+    /// = 1`. Pins the boundary case where Perspective4D collapses to Identity.
+    #[test]
+    fn r4_perspective4d_w_zero_is_unchanged() {
+        let p = Vec4::new(1.0, 2.0, 3.0, 0.0);
+        let proj = Projection::Perspective4D {
+            focal_distance: 2.0,
+        };
+        let got = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+        assert_eq!(got, Vec3::new(1.0, 2.0, 3.0));
+    }
+
+    /// `Projection::Perspective4D` on the tesseract's w-extreme vertices produces the
+    /// canonical "cube within a cube" scale relationship: the +w face renders as the outer
+    /// (larger) cube and the -w face as the inner (smaller) cube. Pins the qualitative
+    /// behavior the demo depends on by checking the two end scales and their ratio.
+    #[test]
+    fn r4_perspective4d_cube_within_cube_scaling() {
+        let focal = 2.0;
+        let proj = Projection::Perspective4D {
+            focal_distance: focal,
+        };
+        let near = Vec4::new(0.5, 0.5, 0.5, 0.5);
+        let far = Vec4::new(0.5, 0.5, 0.5, -0.5);
+        let pn = <EuclideanR4 as RasterizableSpace<4>>::project_point(near, &proj);
+        let pf = <EuclideanR4 as RasterizableSpace<4>>::project_point(far, &proj);
+        // Scale at w=+0.5 is `2 / (2 - 0.5) = 4/3`; at w=-0.5 is `2 / 2.5 = 4/5`. Each R³
+        // component scales by the same factor, so the ratio of magnitudes is `(4/3)/(4/5) = 5/3`.
+        let r_near = (pn.length() / 0.5_f32.mul_add(3.0_f32.sqrt(), 0.0)).abs(); // |near|/|input|
+        let r_far = (pf.length() / 0.5_f32.mul_add(3.0_f32.sqrt(), 0.0)).abs();
+        assert!((r_near - 4.0 / 3.0).abs() < 1e-5, "near scale {r_near}");
+        assert!((r_far - 4.0 / 5.0).abs() < 1e-5, "far scale {r_far}");
+        // Outer cube (|+w face|) > inner cube (|-w face|).
+        assert!(pn.length() > pf.length(), "near={pn:?} far={pf:?}");
+    }
+
+    /// `Projection::Perspective4D` clamps the denominator rather than dividing by zero or
+    /// going negative. A point at the viewer's eye (`w == focal_distance`) would naively
+    /// produce infinite scale; the impl returns a finite (large) result instead so a single
+    /// misconfigured vertex doesn't NaN the entire upload buffer.
+    #[test]
+    fn r4_perspective4d_at_viewer_clamps_finite() {
+        let p = Vec4::new(0.1, 0.2, 0.3, 2.0);
+        let proj = Projection::Perspective4D {
+            focal_distance: 2.0,
+        };
+        let got = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+        for c in [got.x, got.y, got.z] {
+            assert!(
+                c.is_finite(),
+                "expected finite output at viewer, got {got:?}"
+            );
+        }
+    }
+
+    /// `Projection::Perspective4D` on R³ falls back to `Vec3::ZERO` per the enum's
+    /// "unsupported variant returns zero" contract (R³ has no w axis to project from).
+    #[test]
+    fn r3_perspective4d_returns_zero() {
+        let p = Vec3::new(1.0, 2.0, 3.0);
+        let proj = Projection::Perspective4D {
+            focal_distance: 2.0,
+        };
+        let got = <EuclideanR3 as RasterizableSpace<3>>::project_point(p, &proj);
+        assert_eq!(got, Vec3::ZERO);
     }
 
     /// `tessellate_segment` on R⁴ is plain lerp (since `EuclideanR4` is flat). Each sample

--- a/examples/rotate_polytopes/main.rs
+++ b/examples/rotate_polytopes/main.rs
@@ -74,6 +74,30 @@ use rye_render::{
 /// enough precision to depth-sort cell caps from the 600-cell (which can have ~24
 /// active caps within tenths of a unit of camera-z) without artifacting.
 const SECTION_FACES_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+
+/// Uniform R³ scale factor that `projection` applies to a 4D point with `w = w_slice`.
+/// For `Projection::Identity` (drop-w) the result is `1.0`; for `Projection::Perspective4D`
+/// it's `focal_distance / (focal_distance - w_slice)`, clamped against the same epsilon
+/// the impl uses internally. Used by the wireframe overlay to translate section caps (whose
+/// vertices all share `w = w_slice`) into the perspective-scaled R³ frame without re-running
+/// the cap algorithm in 4D.
+fn perspective_scale_at_w(w_slice: f32, projection: &rye_math::Projection<4>) -> f32 {
+    match *projection {
+        rye_math::Projection::Identity | rye_math::Projection::Orthographic { .. } => 1.0,
+        rye_math::Projection::Perspective4D { focal_distance } => {
+            focal_distance / (focal_distance - w_slice).max(1e-4)
+        }
+    }
+}
+
+/// Map a body-local R³ point to world R³: scale by `section_scale` (the perspective scale at
+/// the cap's w-coordinate) then translate by the body's R³ position. Cap rendering uses this
+/// because the cross-section algorithm internally drops w and emits body-local R³; the world
+/// transform happens here.
+fn local_r3_to_world(p: [f32; 3], section_scale: f32, body_pos_r3: Vec3) -> [f32; 3] {
+    let scaled = Vec3::from_array(p) * section_scale;
+    (scaled + body_pos_r3).to_array()
+}
 use rye_scene::{Scene4, SceneNode4};
 use rye_shape::LineMesh;
 use winit::window::WindowAttributes;
@@ -90,7 +114,10 @@ mod ui;
 use active::combo_name;
 use catalog::{parse_row_from_args, SHAPE_CATALOG};
 use consts::{BODY_SIZE, BODY_Y, T_SCRUB_RATE, T_SLIDER_INITIAL, W_RANGE, W_SCRUB_RATE};
-use state::{body_position, Demo, RotationMode, ViewMode, WireframeColorMode};
+use state::{
+    body_position, Demo, RotationMode, SurfaceMode, ViewMode, WireframeColorMode,
+    WireframeProjection,
+};
 
 #[cfg(test)]
 use catalog::{parse_shape_name, ShapeEntry, DEFAULT_ROW};
@@ -191,7 +218,7 @@ impl Demo {
         // shading. Uses a depth attachment so caps from different cells of the same
         // polychoron occlude each other correctly when projected to camera space. The
         // depth buffer is sized + cleared per-frame inside the render path (only when
-        // `surface_raster_enabled`); see `Demo::render_section_faces` in this file.
+        // surface mode is `Raster`); see `Demo::render_section_faces` in this file.
         let section_faces = TriangleRasterNode::new(
             &ctx.rd.device,
             ctx.rd.surface_bundle.config.format,
@@ -225,12 +252,14 @@ impl Demo {
             parent_wireframe,
             wireframe_enabled: false,
             wireframe_nearest_active: true,
+            wireframe_perimeter: true,
             wireframe_color_mode: WireframeColorMode::default(),
+            wireframe_projection: WireframeProjection::default(),
             section_faces,
             section_faces_depth: None,
             section_world_vertices_scratch: Vec::new(),
             section_faces_mesh_scratch: rye_shape::TriangleMesh::<3>::default(),
-            surface_raster_enabled: true,
+            surface_mode: SurfaceMode::default(),
             row,
             w_slice: initial_w,
             slider_up_held: false,
@@ -641,7 +670,7 @@ impl Demo {
             // mode no pass writes depth, so the cleared `1.0` buffer makes every
             // wireframe fragment pass the depth-test trivially -- visual unchanged.
             self.ensure_and_clear_shared_depth(rd)?;
-            if self.surface_raster_enabled {
+            if matches!(self.surface_mode, SurfaceMode::Raster) {
                 self.render_section_faces(rd, view)?;
             }
             // Cross-section + parent-wireframe overlay (when toggled). Only in Shapes
@@ -726,26 +755,37 @@ impl Demo {
         combined.colors.clear();
         combined.indices.clear();
 
+        // Same perspective scaling logic the wireframe path uses (see render_wireframe_overlay):
+        // section the body in body-local 4D, then translate the produced R³ caps by the body's
+        // R³ position with the active perspective scale at the slice's w. With drop-w this
+        // collapses to identity scaling; with Perspective4D the cap scales by
+        // `focal / (focal - w_slice)`.
+        let wireframe_projection = self.wireframe_projection.to_projection();
+        let section_scale = perspective_scale_at_w(self.w_slice, &wireframe_projection);
+
         for (slot, entry) in self.row.iter().enumerate() {
             let Some(polytope) = entry.shape.polytope4() else {
                 continue;
             };
             let topo = polytope.topology();
-            let bp = Vec4::from_array(body_position(slot, n));
+            let body_pos = body_position(slot, n);
+            let body_pos_r3 = Vec3::new(body_pos[0], body_pos[1], body_pos[2]);
 
-            // Reusable scratch for per-body world-space vertices. Same growth pattern
-            // as `combined` above.
+            // Body-local 4D scratch (rotor-rotated, scaled, NO world translate). Same
+            // rationale as the wireframe path: keep the body's R³ position out of the 4D
+            // perspective math so it doesn't get scaled by `focal / (focal - w)`.
             self.section_world_vertices_scratch.clear();
             self.section_world_vertices_scratch.extend(
                 topo.vertices
                     .iter()
-                    .map(|v| bp + BODY_SIZE * self.rot_state.apply(*v)),
+                    .map(|v| BODY_SIZE * self.rot_state.apply(*v)),
             );
 
-            // Match the SDF's per-body solid coloring: every cap of this polychoron
-            // uses the body's identity color from the catalog. Per-face Lambert in the
-            // fragment shader adds the geometric depth; the underlying color is flat.
+            // Match the SDF's per-body solid coloring: every cap of this polychoron uses
+            // the body's identity color from the catalog. Per-face Lambert in the fragment
+            // shader adds the geometric depth; the underlying color is flat.
             let [r, g, b] = entry.body_color;
+            let start = combined.vertices.len();
             polytope_section_faces_append(
                 topo.edges,
                 topo.cells,
@@ -754,6 +794,12 @@ impl Demo {
                 [r, g, b, 1.0],
                 combined,
             );
+            // Translate this body's body-local cap vertices into world R³. Indices were
+            // emitted with the correct vertex offset already (the `_append` API handles
+            // that internally); only the vertex positions need rebasing.
+            for v in &mut combined.vertices[start..] {
+                *v = local_r3_to_world(*v, section_scale, body_pos_r3);
+            }
         }
 
         // Empty mesh handling lives in `TriangleRasterNode::execute` (it short-circuits
@@ -823,6 +869,9 @@ impl Demo {
         const INACTIVE_GRAY: [f32; 4] = [0.55, 0.55, 0.58, 1.0];
         let nearest_active = self.wireframe_nearest_active;
         let color_mode = self.wireframe_color_mode;
+        // Resolve once per frame; same projection applied to every body's wireframe so all
+        // bodies share a consistent R³ embedding.
+        let wireframe_projection = self.wireframe_projection.to_projection();
 
         for (slot, entry) in self.row.iter().enumerate() {
             let Some(polytope) = entry.shape.polytope4() else {
@@ -830,32 +879,43 @@ impl Demo {
             };
             let topo = polytope.topology();
             let body_pos = body_position(slot, n);
-            let bp = Vec4::from_array(body_pos);
-            // Transform canonical vertices into world Vec4 coords. Same shape transform
-            // the SDF kernel applies (`body_position + body_size * rotor.apply(v)`), so
-            // the rasterized geometry sits at the same world-space position as the
-            // raymarched SDF.
-            let world_vertices: Vec<Vec4> = topo
+            // Body's R³ position. The body sits at body_pos.w = 0 in 4D, so the perspective
+            // projection at this body's location collapses to a pure R³ translation; doing
+            // the projection in body-local 4D and translating in R³ AFTER is the only way
+            // to keep the body's apparent x-position stable when Perspective4D scales the
+            // (x, y, z) channel by `focal / (focal - w)`.
+            let body_pos_r3 = Vec3::new(body_pos[0], body_pos[1], body_pos[2]);
+            // Body-local 4D vertices: rotor-rotated, scaled, NO world translate yet. The
+            // translate happens after the chosen `wireframe_projection` maps each vertex
+            // from R⁴ to R³.
+            let local_vertices: Vec<Vec4> = topo
                 .vertices
                 .iter()
-                .map(|v| bp + BODY_SIZE * self.rot_state.apply(*v))
+                .map(|v| BODY_SIZE * self.rot_state.apply(*v))
                 .collect();
 
-            // Cross-section perimeter edges only. The SDF raymarcher renders the section
-            // as a solid volume; we just need to outline the boundaries between adjacent
-            // cell caps (each cap contributes one face of the 3D section polytope).
-            // `polytope_section_overlay_with_vertices` returns `(triangles, perimeter)`; we
-            // discard the filled triangles since they would obscure the SDF without
-            // adding information.
-            let (_tri, mut perim) = polytope_section_overlay_with_vertices(
-                topo.edges,
-                topo.cells,
-                &world_vertices,
-                WPlane::new(self.w_slice),
-            );
-            section_edges.segments.append(&mut perim.segments);
-            section_edges.colors.append(&mut perim.colors);
-            section_edges.widths.append(&mut perim.widths);
+            // Cross-section perimeter edges. The cyan outlines bound each cell cap on the
+            // slice; gated by `wireframe_perimeter` so users can show the parent edge graph
+            // on its own. `polytope_section_overlay_with_vertices` uses drop-w internally,
+            // so its R³ output is in body-local frame; we apply the perspective scale at
+            // w_slice (uniform across the cap because every cap point shares the slice's w)
+            // and translate to world R³.
+            if self.wireframe_perimeter {
+                let section_scale = perspective_scale_at_w(self.w_slice, &wireframe_projection);
+                let (_tri, mut perim) = polytope_section_overlay_with_vertices(
+                    topo.edges,
+                    topo.cells,
+                    &local_vertices,
+                    WPlane::new(self.w_slice),
+                );
+                for (a, b) in &mut perim.segments {
+                    *a = local_r3_to_world(*a, section_scale, body_pos_r3);
+                    *b = local_r3_to_world(*b, section_scale, body_pos_r3);
+                }
+                section_edges.segments.append(&mut perim.segments);
+                section_edges.colors.append(&mut perim.colors);
+                section_edges.widths.append(&mut perim.widths);
+            }
 
             // Per-cell "crossing strength" in [0, 1]: 1 when `w_slice` is at the cell's
             // w-midpoint (cap face is widest), 0 when the slice is at the cell's w-boundary
@@ -868,7 +928,7 @@ impl Demo {
                 .map(|cell| {
                     let (w_min, w_max) = cell
                         .iter()
-                        .map(|&i| world_vertices[i as usize].w)
+                        .map(|&i| local_vertices[i as usize].w)
                         .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), w| {
                             (lo.min(w), hi.max(w))
                         });
@@ -922,8 +982,8 @@ impl Demo {
             for &[i, j] in topo.edges {
                 let ia = i as usize;
                 let ja = j as usize;
-                let a = world_vertices[ia];
-                let b = world_vertices[ja];
+                let a = local_vertices[ia];
+                let b = local_vertices[ja];
                 let (mut color_a, mut color_b) = match color_mode {
                     WireframeColorMode::Unique => (
                         vertex_color_by_position(topo.vertices[ia]),
@@ -946,9 +1006,23 @@ impl Demo {
                 };
                 color_a[3] = alpha;
                 color_b[3] = alpha;
-                parent_lines
-                    .segments
-                    .push(([a.x, a.y, a.z], [b.x, b.y, b.z]));
+                // Project 4D endpoints to R³ through the active wireframe projection (in
+                // body-local frame), then translate by `body_pos_r3` to land in world R³.
+                // For DropW the projection is identity-on-(x, y, z); for Perspective4D each
+                // component scales by `focal / (focal - w)`.
+                let a3_local =
+                    <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+                        a,
+                        &wireframe_projection,
+                    );
+                let b3_local =
+                    <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+                        b,
+                        &wireframe_projection,
+                    );
+                let a3 = a3_local + body_pos_r3;
+                let b3 = b3_local + body_pos_r3;
+                parent_lines.segments.push((a3.to_array(), b3.to_array()));
                 parent_lines.colors.push((color_a, color_b));
                 parent_lines.widths.push(PARENT_WIDTH);
             }
@@ -1092,6 +1166,14 @@ impl RotatePolytopesApp {
                         Ok(())
                     },
                 )
+                .toggle(
+                    "perimeter",
+                    "cyan cross-section perimeter outlines (bare flips)",
+                    |d, v| {
+                        d.wireframe_perimeter = v.unwrap_or(!d.wireframe_perimeter);
+                        Ok(())
+                    },
+                )
                 .choice(
                     "color",
                     "base RGB for parent edges (bare cycles): unique (default) or active",
@@ -1108,45 +1190,64 @@ impl RotatePolytopesApp {
                         };
                         Ok(())
                     },
+                )
+                .choice(
+                    "perspective",
+                    "wireframe 4D->R³ projection (bare cycles): drop-w (default) or w-depth",
+                    &["drop-w", "w-depth"],
+                    |d, name| {
+                        d.wireframe_projection = match name {
+                            Some(n) => WireframeProjection::from_token(n).ok_or_else(|| {
+                                anyhow!("unknown projection `{n}` (try drop-w|w-depth)")
+                            })?,
+                            None => match d.wireframe_projection {
+                                WireframeProjection::DropW => WireframeProjection::WDepth,
+                                WireframeProjection::WDepth => WireframeProjection::DropW,
+                            },
+                        };
+                        Ok(())
+                    },
                 ),
         );
 
-        // Polychoral surface renderer: SDF raymarch vs rasterized section faces.
+        // Polychoral surface renderer: raster (default) / SDF / off. Bare `surface` is
+        // shorthand for "off" so the user can hide cap fills quickly when inspecting the
+        // wireframe and cross-section perimeter on their own. Explicit `surface raster`
+        // and `surface sdf` set those modes; `surface off` is the same as bare.
         c.register(
             rye_egui::cmd(
                 "surface",
-                "polychoral surface: SDF raymarch or rasterized section faces",
+                "polychoral surface mode: raster | sdf | off (bare = off)",
                 |args, demo: &mut Demo, _out| {
                     let next = match args.first().copied() {
-                        Some("sdf") => false,
-                        Some("raster") => true,
-                        Some(other) => {
-                            return Err(anyhow!("unknown arg `{other}` (try sdf|raster)"));
-                        }
-                        None => !demo.surface_raster_enabled,
+                        Some(token) => SurfaceMode::from_token(token).ok_or_else(|| {
+                            anyhow!("unknown arg `{token}` (try raster|sdf|off)")
+                        })?,
+                        None => SurfaceMode::Off,
                     };
-                    if next != demo.surface_raster_enabled {
-                        demo.surface_raster_enabled = next;
-                        // Flip redirects polychoral bodies between SDF and the raster
-                        // pipeline. `rebuild_bodies` re-emits the SDF body list,
-                        // marking the polychora inert in raster mode (or live again
-                        // in SDF mode).
+                    if next != demo.surface_mode {
+                        demo.surface_mode = next;
+                        // Re-emit the SDF body list: switching INTO Sdf mode makes the
+                        // polychora live in the kernel, switching OUT marks them inert.
                         demo.rebuild_bodies();
                     }
                     Ok(())
                 },
             )
-            .with_args(&[&["sdf", "raster"]])
+            .with_args(&[&["raster", "sdf", "off"]])
             .with_long_help(
-                "Selects how the six regular convex 4-polytopes (5-cell, tesseract,\n\
-                 16-cell, 24-cell, 120-cell, 600-cell) are rendered.\n\
+                "Selects how the six regular convex 4-polytopes (5-cell, tesseract, 16-cell,\n\
+                 24-cell, 120-cell, 600-cell) are rendered.\n\
                  \n\
                  subcommands:\n  \
-                 raster  Rasterized cross-section cell-caps (the default). Face-normal\n                         Lambert lit, per-body solid color. Much faster for the\n                         120-cell + 600-cell and exact (no SDF approximation).\n  \
-                 sdf     SDF raymarch. The historical pre-rasterizer path; smoother\n                         shading but the 120-cell and 600-cell carry a face-plane\n                         approximation BUG. Kept for visual comparison.\n\
+                 raster  Rasterized cross-section cell-caps (the default). Face-normal Lambert\n                         lit, per-body solid color. Much faster for the 120-cell + 600-cell\n                         and exact (no SDF approximation).\n  \
+                 sdf     SDF raymarch. The historical pre-rasterizer path; smoother shading\n                         but the 120-cell and 600-cell carry a face-plane approximation BUG.\n                         Kept for visual comparison.\n  \
+                 off     No surface rendered. Wireframe overlay + cross-section perimeter\n                         stay visible if enabled; the cap interiors are blank. Useful for\n                         inspecting the wireframe on its own.\n\
+                 \n\
+                 Bare `surface` (no argument) is shorthand for `surface off`.\n\
                  \n\
                  Smooth-surface shapes (Clifford torus, duocylinder, spherinder, 3-sphere)\n\
-                 ignore this toggle and always render via the SDF.",
+                 ignore this and always render via the SDF; they have no rasterizer path.",
             ),
         );
 

--- a/examples/rotate_polytopes/shapes.rs
+++ b/examples/rotate_polytopes/shapes.rs
@@ -27,10 +27,10 @@ impl Demo {
     pub(crate) fn render_shapes_section(&mut self, ui: &mut egui::Ui) {
         ui.separator();
         // Only the SDF raymarch path is heavy on the 120/600-cell (~24 KB of const face-
-        // normal data + per-pixel Wolfe-greedy projection); the rasterized section-faces
-        // path keeps both polychora at vsync regardless of how many are in the row, so
-        // the warning is irrelevant when `surface_raster_enabled`.
-        let has_heavy_sdf = !self.surface_raster_enabled
+        // normal data + per-pixel Wolfe-greedy projection); the rasterized path keeps both
+        // polychora at vsync regardless of how many are in the row, and Off doesn't render
+        // their surface at all, so the warning only fires when `surface sdf` is active.
+        let has_heavy_sdf = self.surface_mode.uses_sdf_for_polychora()
             && self.row.iter().any(|e| {
                 matches!(
                     e.shape,

--- a/examples/rotate_polytopes/state.rs
+++ b/examples/rotate_polytopes/state.rs
@@ -50,6 +50,88 @@ pub(crate) enum ViewMode {
     Filmstrip,
 }
 
+/// How the six regular convex 4-polytopes have their surface rendered.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub(crate) enum SurfaceMode {
+    /// Rasterized filled cross-section cell-caps. The default. Much faster for the 120-cell
+    /// and 600-cell than the SDF, exact (no Wolfe-greedy approximation), and sidesteps the
+    /// cell120/600 face-plane BUG in `rye_physics::euclidean_r4`.
+    #[default]
+    Raster,
+    /// SDF raymarch via [`Demo::node`]. The pre-rasterizer behavior, kept for visual
+    /// comparison. Slower on the 120/600-cell and carries the documented face-plane BUG.
+    Sdf,
+    /// No surface rendered for the polychora. The wireframe overlay (if enabled) still
+    /// shows the polytope's edge graph, but the cap interiors stay empty. Useful for
+    /// inspecting the wireframe + cross-section perimeter on their own without the cap
+    /// fill competing for attention.
+    Off,
+}
+
+impl SurfaceMode {
+    /// Parse the console-arg spelling. Returns `None` for any other input.
+    pub(crate) fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "raster" => Some(SurfaceMode::Raster),
+            "sdf" => Some(SurfaceMode::Sdf),
+            "off" => Some(SurfaceMode::Off),
+            _ => None,
+        }
+    }
+
+    /// `true` when the polychoral SDF dispatch needs to be live (so that body uniforms
+    /// stay populated for the kernel). False for Raster (the rasterizer draws those
+    /// polytopes) and Off (nothing draws them).
+    pub(crate) fn uses_sdf_for_polychora(self) -> bool {
+        matches!(self, SurfaceMode::Sdf)
+    }
+}
+
+/// How the parent wireframe's 4D vertex positions project to R³ for rendering.
+/// Independent of the cross-section's projection (which is always drop-w because the
+/// slice IS a 3-flat and drop-w is the inhabitant's natural view of it).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub(crate) enum WireframeProjection {
+    /// Axis-aligned drop-w: `(x, y, z, w) -> (x, y, z)`. The default. Collapses every
+    /// pair of w-opposite vertices to the same R³ point, so axis-aligned polytopes
+    /// (especially the tesseract) render as visually degenerate "flat" shapes; the
+    /// 5-cell and 24-cell read more naturally because their cells aren't w-aligned.
+    #[default]
+    DropW,
+    /// 4D pinhole perspective from a viewer at `(0, 0, 0, focal_distance)` looking
+    /// in -w. Produces the classical "cube within a cube" tesseract view: +w face
+    /// renders as the outer (larger) shape, -w face as the inner (smaller) shape,
+    /// connecting edges as the frustum lines. Brings axis-aligned polytopes to life
+    /// at the cost of slight distortion on the polytopes that already read well
+    /// under drop-w.
+    WDepth,
+}
+
+impl WireframeProjection {
+    /// Parse the console-arg spelling. Hyphens because the console grammar lexes on
+    /// whitespace and `drop-w` / `w-depth` read as single tokens.
+    pub(crate) fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "drop-w" => Some(WireframeProjection::DropW),
+            "w-depth" => Some(WireframeProjection::WDepth),
+            _ => None,
+        }
+    }
+
+    /// Resolve to a [`rye_math::Projection<4>`]. The focal distance is hardcoded to
+    /// `2.0`, sized to comfortably exceed the unit-circumradius polytope's w-extent
+    /// after the demo's `BODY_SIZE` scaling, so the perspective denominator never
+    /// approaches zero in normal use.
+    pub(crate) fn to_projection(self) -> rye_math::Projection<4> {
+        match self {
+            WireframeProjection::DropW => rye_math::Projection::Identity,
+            WireframeProjection::WDepth => rye_math::Projection::Perspective4D {
+                focal_distance: 2.0,
+            },
+        }
+    }
+}
+
 /// How the parent-wireframe edges are colored. Orthogonal to the alpha-modulation
 /// toggle [`Demo::wireframe_nearest_active`]: the color mode picks the hue, the
 /// nearest-active toggle then modulates alpha on top.
@@ -264,10 +346,19 @@ pub(crate) struct Demo {
     /// each moment. When `false`, every edge uses the same uniform dim alpha (the
     /// previous behavior).
     pub(crate) wireframe_nearest_active: bool,
+    /// Whether the cyan section-perimeter outlines render. Independent of the parent
+    /// wireframe edges; turning this off leaves the polytope's full edge graph visible
+    /// but hides the cap-boundary highlight, useful for inspecting the parent structure
+    /// without the slice's cyan trace competing for attention. On by default.
+    pub(crate) wireframe_perimeter: bool,
     /// Base RGB for wireframe edges. Orthogonal to [`Self::wireframe_nearest_active`]:
     /// the color mode picks the hue, the nearest-active toggle then modulates alpha on
     /// top.
     pub(crate) wireframe_color_mode: WireframeColorMode,
+    /// How the parent wireframe's 4D vertex positions project to R³. The cross-section
+    /// always uses drop-w (mathematically the inhabitant's view of the slice 3-flat);
+    /// this toggle only affects the dim wireframe overlay on top.
+    pub(crate) wireframe_projection: WireframeProjection,
     /// Filled-faces rasterizer for the cross-section of every polychoral body. When
     /// [`Self::surface_raster_enabled`] is `true`, this replaces the SDF raymarch for the
     /// six regular convex 4-polytopes: the SDF gets `BodyUniform::default()` for those
@@ -291,17 +382,10 @@ pub(crate) struct Demo {
     /// polychoron's vertex / triangle count seen so far.
     pub(crate) section_world_vertices_scratch: Vec<glam::Vec4>,
     pub(crate) section_faces_mesh_scratch: rye_shape::TriangleMesh<3>,
-    /// Selects how the six regular convex 4-polytopes are rendered:
-    /// - `true` (default): rasterized filled cross-section cell caps via
-    ///   [`Self::section_faces`]. Much faster for the 120-cell + 600-cell, exact (no
-    ///   Wolfe-greedy approximation), sidesteps the cell120/600 face-plane BUG in
-    ///   `rye_physics::euclidean_r4`.
-    /// - `false`: SDF raymarch in [`Self::node`]. The historical pre-rasterizer
-    ///   behavior, kept available behind the console toggle for visual comparison.
-    ///
-    /// Smooth-surface shapes (Clifford torus, duocylinder, etc.) ignore this toggle and
-    /// always render via the SDF; they have no polytope topology to section.
-    pub(crate) surface_raster_enabled: bool,
+    /// Selects how the six regular convex 4-polytopes are rendered. Smooth-surface shapes
+    /// (Clifford torus, duocylinder, etc.) ignore this and always render via the SDF since
+    /// they have no polytope topology to section.
+    pub(crate) surface_mode: SurfaceMode,
     /// Polytope row built at startup from `--shapes` CLI args (or `DEFAULT_ROW`); drives
     /// both the body uniforms and per-body label lookups in the overlay.
     pub(crate) row: Vec<ShapeEntry>,
@@ -444,17 +528,18 @@ impl Demo {
         }
     }
 
-    /// Build the SDF body uniform for a single row entry, with surface-raster opt-out:
-    /// when raster mode is on AND the entry has polytope topology, the returned uniform
-    /// is `BodyUniform::default()` (kind = Invalid), which the kernel's dispatch chain
-    /// skips. The slot is preserved (so the visual layout doesn't shift); the polychoral
-    /// surface is rendered separately via [`Self::section_faces`] in `main.rs`.
+    /// Build the SDF body uniform for a single row entry, with polychora opt-out based on
+    /// the active [`SurfaceMode`]: when the polychora are being rendered outside the SDF
+    /// (Raster, or Off entirely), the returned uniform is `BodyUniform::default()` (kind =
+    /// Invalid), which the kernel's dispatch chain skips. The slot is preserved (so the
+    /// visual layout doesn't shift); the polychoral surface is rendered separately via
+    /// [`Self::section_faces`] in `main.rs` (Raster) or simply not at all (Off).
     ///
-    /// Smooth-surface shapes (Clifford torus, etc.) ignore the raster toggle and always
-    /// produce a live SDF body.
+    /// Smooth-surface shapes (Clifford torus, etc.) ignore the surface mode and always
+    /// produce a live SDF body; they have no rasterizer path.
     fn sdf_body_for_slot(&self, slot: usize, n: usize, rotor: Rotor4) -> BodyUniform {
         let entry = &self.row[slot];
-        if self.surface_raster_enabled && entry.shape.polytope4().is_some() {
+        if !self.surface_mode.uses_sdf_for_polychora() && entry.shape.polytope4().is_some() {
             return BodyUniform::default();
         }
         BodyUniform::polytope_with_rotor(
@@ -477,9 +562,9 @@ impl Demo {
     }
 
     /// Re-emit every body's uniform from the current row + rotor state. Called after row
-    /// mutations (add/remove/reorder), rotor changes during spin, and surface-mode
-    /// toggles (since flipping `surface_raster_enabled` redirects polychora between the
-    /// SDF and the raster pipelines).
+    /// mutations (add/remove/reorder), rotor changes during spin, and surface-mode changes
+    /// (any time the polychora switch between SDF-live and SDF-inert, which happens at
+    /// every transition involving SDF mode).
     pub(crate) fn rebuild_bodies(&mut self) {
         let n = self.row.len();
         let rotor = self.rot_state;


### PR DESCRIPTION
`Projection<4>::Perspective4D` adds the cube-within-a-cube tesseract view; `wireframe perspective drop-w|w-depth` toggles between drop-w (default) and the new pinhole. `SurfaceMode { Raster, Sdf, Off }` replaces the old bool with bare `surface` shorthand for off. Independent `wireframe perimeter` toggle for the cyan section outlines. Fixed a body-local-vs-world bug where perspective was scaling each body's row x-position alongside its 4D vertices.

Verify:
- `cargo test --workspace` (544 passing)
- `cargo run --release --example rotate_polytopes -- --shapes 5-cell,8-cell,16-cell,24-cell,120-cell,600-cell`, then `wireframe on; wireframe perspective` for cube-within-cube, `surface` for hide, `wireframe perimeter` for cyan toggle