### PR TITLE
Polish/playground pass 1

### DIFF
--- a/crates/polytope_playground/build.rs
+++ b/crates/polytope_playground/build.rs
@@ -1,0 +1,50 @@
+//! Bake a short git hash + working-tree-dirty flag into the binary as
+//! `BUILD_HASH` and `BUILD_DIRTY` env vars, surfaced at runtime via `env!`.
+//!
+//! Purpose: visible build-identifier label in the demo's HUD so a tester
+//! reloading the page can confirm at-a-glance that they're looking at the
+//! latest build (the wasm filename includes a content hash, but the browser
+//! cache can still serve a stale page+script combination). Falls back to
+//! `nogit` when not building from a git checkout (e.g. crates.io download
+//! someday), so packaging in non-git contexts still works.
+
+use std::process::Command;
+
+fn main() {
+    // Short 8-char hash. Enough to disambiguate any two commits we'd ever
+    // realistically compare side-by-side. Falls back to "nogit" if git isn't
+    // on PATH or this isn't a git checkout.
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short=8", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "nogit".to_string());
+    println!("cargo:rustc-env=BUILD_HASH={hash}");
+
+    // Marker for uncommitted changes. Empty when working tree is clean;
+    // "+dirty" otherwise. Easier to read than a pure bool in the HUD.
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+    let dirty_marker = if dirty { "+dirty" } else { "" };
+    println!("cargo:rustc-env=BUILD_DIRTY={dirty_marker}");
+
+    // Re-run this build script when HEAD changes or files get staged/unstaged.
+    // `.git/HEAD` covers branch + commit moves; `.git/index` covers staging.
+    // Note: editing a tracked file without staging it won't re-trigger this
+    // script via cargo's usual src-watch (cargo only watches .rs / Cargo.toml
+    // by default), so a dirty-but-not-committed change may show stale.
+    // Acceptable for now; for stricter freshness, also list specific files
+    // or `cargo:rerun-if-changed=src` (which would trigger every src edit).
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/index");
+}

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -55,7 +55,10 @@
 
 use anyhow::{anyhow, Result};
 use glam::{Mat4, Vec2, Vec3, Vec4};
-use rye_app::{egui, App, Camera, FrameCtx, OrbitController, RunConfig, SetupCtx};
+use rye_app::{
+    egui, App, Camera, CameraController, FirstPersonController, FrameCtx, OrbitController,
+    RunConfig, SetupCtx,
+};
 use rye_egui::Console;
 use rye_math::WPlane;
 use rye_math::{Bivector, EuclideanR3, Rotor, Rotor4};
@@ -115,7 +118,7 @@ use active::combo_name;
 use catalog::{parse_row_from_args, SHAPE_CATALOG};
 use consts::{BODY_SIZE, BODY_Y, T_SCRUB_RATE, T_SLIDER_INITIAL, W_RANGE, W_SCRUB_RATE};
 use state::{
-    body_position, Demo, RotationMode, SurfaceMode, ViewMode, WireframeColorMode,
+    body_position, CameraMode, Demo, RotationMode, SurfaceMode, ViewMode, WireframeColorMode,
     WireframeProjection,
 };
 
@@ -248,6 +251,13 @@ impl Demo {
         // default zoom; user can scroll-zoom in.
         orbit.set_orbit(9.5, -0.25);
 
+        // Free-roam controller is constructed but unused until the user
+        // toggles via `camera freecam`. Initial yaw 0 / pitch 0 matches the
+        // tesseract_demo pattern; the camera's actual orientation seeds
+        // from the orbit's last frame at toggle time.
+        let free_roam = FirstPersonController::<EuclideanR3>::new(0.0, 0.0);
+        let free_roam_pos = camera.position;
+
         // Always start at w=0 regardless of row contents. Auto-shifting
         // to the 120/600-cell's "Platonic-named" cross-section was
         // confusing in mixed rows: the other shapes' slices got pulled
@@ -259,6 +269,9 @@ impl Demo {
             space: EuclideanR3,
             camera,
             orbit,
+            free_roam,
+            free_roam_pos,
+            camera_mode: CameraMode::default(),
             node,
             section_edges,
             parent_wireframe,
@@ -417,10 +430,29 @@ impl Demo {
         // of a row of horizon shots.
         let lift_orbit = self.view_mode == ViewMode::Filmstrip && self.strip_w && self.strip_t;
         self.orbit.target.y = if lift_orbit { BODY_Y } else { 0.0 };
-        use rye_camera::CameraController;
         if !ctx.ui_has_focus {
-            self.orbit
-                .advance(ctx.input, &mut self.camera, &EuclideanR3, 0.0);
+            match self.camera_mode {
+                CameraMode::Orbit => {
+                    self.orbit
+                        .advance(ctx.input, &mut self.camera, &EuclideanR3, dt_secs);
+                }
+                CameraMode::FreeRoam => {
+                    // Mouse-look + WASD translation. Mirror tesseract_demo's
+                    // pattern: controller handles look; we integrate position
+                    // here from the drained input axes.
+                    self.free_roam
+                        .advance(ctx.input, &mut self.camera, &EuclideanR3, dt_secs);
+                    const FREECAM_SPEED: f32 = 4.5; // units/sec
+                    let mut delta = self.camera.forward * ctx.input.move_forward
+                        + self.camera.right * ctx.input.move_right
+                        + Vec3::Y * ctx.input.move_up;
+                    if delta.length_squared() > 1e-6 {
+                        delta = delta.normalize();
+                        self.free_roam_pos += delta * FREECAM_SPEED * dt_secs;
+                        self.camera.position = self.free_roam_pos;
+                    }
+                }
+            }
         }
         let view = self.camera.view();
 
@@ -456,29 +488,23 @@ impl Demo {
         // subsequent positioning calculations).
         self.render_menu_bar(ctx);
 
-        // Top-left: title + fps + framebuffer size. Replaces the old
-        // panel header now that the side panel is gone. Larger
-        // typography so the title reads as the program's nameplate
-        // rather than just another label.
-        let cfg = &frame.rd.surface_bundle.config;
-        let (fb_w, fb_h) = (cfg.width, cfg.height);
-        // y offset clears the menu bar (~24-28px depending on
-        // font) plus a small visual margin. egui::Area's anchor
-        // is screen-relative, not content-rect-relative, so the
-        // offset must include the menu bar height manually.
-        egui::Area::new(egui::Id::new("polytope-playground-title"))
-            .anchor(egui::Align2::LEFT_TOP, [20.0, 50.0])
+        // Top-right: short git hash + dirty marker. Identifies the build at
+        // a glance when a tester reloads the wasm bundle; the browser cache
+        // can serve a stale page+script combination otherwise. F3's perf
+        // overlay shows fps + framebuffer size when that data is wanted.
+        let build_label = format!(
+            "{}{}",
+            env!("BUILD_HASH"),
+            env!("BUILD_DIRTY"),
+        );
+        egui::Area::new(egui::Id::new("polytope-playground-build"))
+            .anchor(egui::Align2::RIGHT_TOP, [-12.0, 50.0])
             .show(ctx, |ui| {
                 ui.add(egui::Label::new(
-                    egui::RichText::new("Polytope Playground")
-                        .size(22.0)
-                        .strong()
-                        .color(egui::Color32::WHITE),
-                ));
-                ui.add(egui::Label::new(
-                    egui::RichText::new(format!("{:.0} fps   {}×{}", frame.fps, fb_w, fb_h))
-                        .size(13.0)
-                        .color(egui::Color32::from_gray(190)),
+                    egui::RichText::new(build_label)
+                        .monospace()
+                        .size(11.0)
+                        .color(egui::Color32::from_gray(140)),
                 ));
             });
 
@@ -1525,11 +1551,77 @@ impl RotatePolytopesApp {
         // Framework-provided frame-timing surface: `trace [summary|last|clear|cap N]`.
         // The runner is already recording per-section scopes on every redraw; this
         // command lets the user read them. Surfaces the slowest hot-path sections,
-        // which is the data we need to drive M4.5 v2 perf decisions (pipeline
-        // warming, wireframe caching).
+        // which is the data the pipeline-warming + wireframe-cache decisions read
+        // from.
         rye_app::trace::register_command(&mut c);
         rye_app::fps::register_command(&mut c);
         rye_app::vsync::register_command(&mut c);
+        rye_app::version::register_command(
+            &mut c,
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            env!("BUILD_HASH"),
+            env!("BUILD_DIRTY"),
+        );
+
+        // Demo-side camera mode toggle. Bare `camera` cycles between Orbit
+        // (the default scroll-zoom/drag camera) and FreeRoam (WASD + mouse-
+        // look). Explicit `camera orbit` resets the orbit controller to its
+        // default distance + pitch so the camera returns to a known framing
+        // around the world origin; `camera freecam` seeds the free-roam
+        // position from the camera's current location.
+        c.register(
+            rye_egui::cmd::<Demo, _>(
+                "camera",
+                "camera mode: orbit (default) or freecam (WASD + mouse-look). Bare cycles.",
+                |args, demo, out| {
+                    let next = match args.first().copied() {
+                        None => match demo.camera_mode {
+                            CameraMode::Orbit => CameraMode::FreeRoam,
+                            CameraMode::FreeRoam => CameraMode::Orbit,
+                        },
+                        Some("orbit") => CameraMode::Orbit,
+                        Some("freecam") => CameraMode::FreeRoam,
+                        Some(other) => {
+                            out.line(format!(
+                                "camera: unknown mode `{other}` (try orbit|freecam)"
+                            ));
+                            return Ok(());
+                        }
+                    };
+                    demo.camera_mode = next;
+                    match next {
+                        CameraMode::Orbit => {
+                            // Reset orbit so the camera returns to a known
+                            // framing around (0, 0, 0) regardless of where
+                            // freecam left it.
+                            demo.orbit = OrbitController::default();
+                            demo.orbit.set_orbit(9.5, -0.25);
+                            out.line("camera: orbit (reset to world origin)");
+                        }
+                        CameraMode::FreeRoam => {
+                            // Seed freecam from the camera's current pose so
+                            // the toggle feels continuous instead of
+                            // teleporting.
+                            demo.free_roam_pos = demo.camera.position;
+                            out.line(
+                                "camera: freecam (WASD + Space/Shift; drag to look)",
+                            );
+                        }
+                    }
+                    Ok(())
+                },
+            )
+            .with_args(&[&["orbit", "freecam"]]),
+        );
+
+        // The `floor` toggle the user asked for is deferred. The SDF ground
+        // (a y=0 HalfSpace4D in the scene composition) is baked into the
+        // shader module at App::setup time via `Scene4::to_hyperslice_wgsl`,
+        // so toggling visibility at runtime requires either recompiling the
+        // shader (cheap, ~100-300ms wasm) or adding a kernel-uniform flag to
+        // rye-scene (cheaper per-toggle but engine-level work). Tracked as
+        // follow-up; not part of this polish pass.
 
         c
     }

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -56,8 +56,8 @@
 use anyhow::{anyhow, Result};
 use glam::{Mat4, Vec2, Vec3, Vec4};
 use rye_app::{
-    egui, App, Camera, CameraController, FirstPersonController, FrameCtx, OrbitController,
-    RunConfig, SetupCtx,
+    egui, freecam::Freecam, App, Camera, CameraController, FrameCtx, OrbitController, RunConfig,
+    SetupCtx,
 };
 use rye_egui::Console;
 use rye_math::WPlane;
@@ -251,12 +251,10 @@ impl Demo {
         // default zoom; user can scroll-zoom in.
         orbit.set_orbit(9.5, -0.25);
 
-        // Free-roam controller is constructed but unused until the user
-        // toggles via `camera freecam`. Initial yaw 0 / pitch 0 matches the
-        // tesseract_demo pattern; the camera's actual orientation seeds
-        // from the orbit's last frame at toggle time.
-        let free_roam = FirstPersonController::<EuclideanR3>::new(0.0, 0.0);
-        let free_roam_pos = camera.position;
+        // Freecam preset; inactive at startup. The `camera freecam` console
+        // command calls `freecam.set_active(true, camera.position)` which
+        // grabs the cursor + seeds the freecam position from the camera.
+        let freecam = Freecam::new();
 
         // Always start at w=0 regardless of row contents. Auto-shifting
         // to the 120/600-cell's "Platonic-named" cross-section was
@@ -269,10 +267,8 @@ impl Demo {
             space: EuclideanR3,
             camera,
             orbit,
-            free_roam,
-            free_roam_pos,
+            freecam,
             camera_mode: CameraMode::default(),
-            cursor_grabbed: false,
             node,
             section_edges,
             parent_wireframe,
@@ -437,29 +433,12 @@ impl Demo {
                     self.orbit
                         .advance(ctx.input, &mut self.camera, &EuclideanR3, dt_secs);
                 }
-                // Freecam advances only while the cursor is grabbed. Alt
-                // releases the grab for UI interaction; while ungrabbed,
-                // the camera holds still so the user can click + drag UI
-                // widgets without the scene panning underneath them.
-                CameraMode::FreeRoam if self.cursor_grabbed => {
-                    // Mouse-look + WASD translation. Controller handles
-                    // look (consuming raw mouse delta via use_raw_delta);
-                    // position integrates from the drained input axes.
-                    self.free_roam
-                        .advance(ctx.input, &mut self.camera, &EuclideanR3, dt_secs);
-                    const FREECAM_SPEED: f32 = 4.5; // units/sec
-                    let mut delta = self.camera.forward * ctx.input.move_forward
-                        + self.camera.right * ctx.input.move_right
-                        + Vec3::Y * ctx.input.move_up;
-                    if delta.length_squared() > 1e-6 {
-                        delta = delta.normalize();
-                        self.free_roam_pos += delta * FREECAM_SPEED * dt_secs;
-                        self.camera.position = self.free_roam_pos;
-                    }
-                }
                 CameraMode::FreeRoam => {
-                    // Cursor released (Alt held the toggle): no-op so the
-                    // user can interact with UI without the scene moving.
+                    // Freecam preset handles look + WASD + cursor-grab
+                    // gating internally. No-ops when cursor is released
+                    // (Alt-toggled UI-access mode), so the scene holds
+                    // still while the user interacts with UI.
+                    self.freecam.advance(ctx.input, &mut self.camera, dt_secs);
                 }
             }
         }
@@ -698,18 +677,13 @@ impl Demo {
             }
             // Alt toggles the cursor grab while in freecam: hidden +
             // confined for mouse-look, visible + free for UI interaction.
-            // Mode stays FreeRoam either way; only the grab flips. Outside
-            // freecam Alt is a no-op (cursor is never grabbed there).
+            // The preset's `toggle_cursor_grab` handles the grab request
+            // and the controller's raw-delta flag together; demo just
+            // calls it. No-op outside freecam (the preset is inactive).
             KeyCode::AltLeft | KeyCode::AltRight
                 if pressed && matches!(self.camera_mode, CameraMode::FreeRoam) =>
             {
-                self.cursor_grabbed = !self.cursor_grabbed;
-                if self.cursor_grabbed {
-                    rye_app::cursor::request_grab();
-                } else {
-                    rye_app::cursor::request_release();
-                }
-                self.free_roam.use_raw_delta = self.cursor_grabbed;
+                self.freecam.toggle_cursor_grab();
             }
             // Plane toggles. Sum-of-bivectors composition is
             // commutative, so the order in which planes are toggled
@@ -1626,25 +1600,18 @@ impl RotatePolytopesApp {
                         CameraMode::Orbit => {
                             // Reset orbit so the camera returns to a known
                             // framing around (0, 0, 0) regardless of where
-                            // freecam left it. Release the cursor grab; the
-                            // UI is interactive again, mouse-look is off.
+                            // freecam left it. Freecam's `set_active(false)`
+                            // releases the cursor grab.
                             demo.orbit = OrbitController::default();
                             demo.orbit.set_orbit(9.5, -0.25);
-                            demo.cursor_grabbed = false;
-                            demo.free_roam.use_raw_delta = false;
-                            rye_app::cursor::request_release();
+                            demo.freecam.set_active(false, demo.camera.position);
                             out.line("camera: orbit (reset to world origin)");
                         }
                         CameraMode::FreeRoam => {
-                            // Seed freecam from the camera's current pose so
-                            // the toggle feels continuous instead of
-                            // teleporting. Grab the cursor so panning works
-                            // past the screen edge; user presses Alt to
-                            // release for UI access.
-                            demo.free_roam_pos = demo.camera.position;
-                            demo.cursor_grabbed = true;
-                            demo.free_roam.use_raw_delta = true;
-                            rye_app::cursor::request_grab();
+                            // Preset grabs cursor + seeds position from the
+                            // camera's current pose so the toggle is
+                            // continuous, not a teleport.
+                            demo.freecam.set_active(true, demo.camera.position);
                             out.line(
                                 "camera: freecam (WASD + Space/Shift; mouse-look; Alt to free cursor)",
                             );

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -230,11 +230,7 @@ fn unique_edge_palette(edges: &[[u32; 2]]) -> Vec<[f32; 4]> {
 /// by the cell's half-extent, a cheap proxy for the actual cap area that
 /// gives the same visual gradient. Shared by `render_wireframe_overlay` and
 /// `render_points` so both honor the same cell-activity definition.
-fn compute_cell_strengths(
-    cells: &[&[u32]],
-    local_vertices: &[Vec4],
-    w_slice: f32,
-) -> Vec<f32> {
+fn compute_cell_strengths(cells: &[&[u32]], local_vertices: &[Vec4], w_slice: f32) -> Vec<f32> {
     cells
         .iter()
         .map(|cell| {
@@ -547,8 +543,7 @@ impl Demo {
         let dir = (self.slider_up_held as i32 - self.slider_down_held as i32) as f32;
         if dir != 0.0 {
             let w_range = self.effective_w_range();
-            self.w_slice =
-                (self.w_slice + dir * W_SCRUB_RATE * dt_secs).clamp(-w_range, w_range);
+            self.w_slice = (self.w_slice + dir * W_SCRUB_RATE * dt_secs).clamp(-w_range, w_range);
         }
 
         // Time scrub (t axis, left/right arrow keys). Mirrors the
@@ -1538,14 +1533,14 @@ impl Demo {
             // graph). Memoize by `Polytope4` variant so the 600-cell's ~520k pair-checks
             // run once per launch instead of once per frame. Cache lives on Demo; an
             // empty cache simply triggers first-use population for the visited variants.
-            let edge_palette: &[[f32; 4]] =
-                if matches!(color_mode, WireframeColorMode::UniqueEdge) {
-                    self.unique_edge_palette_cache
-                        .entry(polytope)
-                        .or_insert_with(|| unique_edge_palette(topo.edges))
-                } else {
-                    &[]
-                };
+            let edge_palette: &[[f32; 4]] = if matches!(color_mode, WireframeColorMode::UniqueEdge)
+            {
+                self.unique_edge_palette_cache
+                    .entry(polytope)
+                    .or_insert_with(|| unique_edge_palette(topo.edges))
+            } else {
+                &[]
+            };
             // For `WDepth` we normalize against this polytope's CANONICAL max
             // |w| (NOT the per-frame rotated max). The rotor preserves
             // magnitudes, so the maximum |w| any rotated vertex can reach is
@@ -2224,16 +2219,11 @@ impl RotatePolytopesApp {
                         Some("on") => true,
                         Some("off") => false,
                         Some(other) => {
-                            return Err(anyhow!(
-                                "floor: unknown arg `{other}` (try on|off)"
-                            ));
+                            return Err(anyhow!("floor: unknown arg `{other}` (try on|off)"));
                         }
                     };
                     demo.floor_enabled = next;
-                    out.line(format!(
-                        "floor: {}",
-                        if next { "on" } else { "off" }
-                    ));
+                    out.line(format!("floor: {}", if next { "on" } else { "off" }));
                     Ok(())
                 },
             )
@@ -2486,7 +2476,10 @@ mod color_tests {
 
         let c_back = w_depth_color(-5.0, 1.0);
         let c_at_neg_extent = w_depth_color(-1.0, 1.0);
-        assert_eq!(c_back, c_at_neg_extent, "-w past extent should clamp to back");
+        assert_eq!(
+            c_back, c_at_neg_extent,
+            "-w past extent should clamp to back"
+        );
     }
 
     // ---- compute_cell_strengths -----------------------------------------

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -56,8 +56,9 @@
 use anyhow::{anyhow, Result};
 use glam::{Mat4, Vec2, Vec3, Vec4};
 use rye_app::{
-    egui, freecam::Freecam, App, Camera, CameraController, FrameCtx, OrbitController, RunConfig,
-    SetupCtx,
+    egui,
+    freecam::{CursorMode, Freecam},
+    App, Camera, CameraController, FrameCtx, OrbitController, RunConfig, SetupCtx,
 };
 use rye_egui::Console;
 use rye_math::WPlane;
@@ -116,11 +117,165 @@ mod ui;
 
 use active::combo_name;
 use catalog::{parse_row_from_args, SHAPE_CATALOG};
-use consts::{BODY_SIZE, BODY_Y, T_SCRUB_RATE, T_SLIDER_INITIAL, W_RANGE, W_SCRUB_RATE};
+use consts::{BODY_SIZE, BODY_Y, T_SCRUB_RATE, T_SLIDER_INITIAL, W_SCRUB_RATE};
 use state::{
     body_position, CameraMode, Demo, RotationMode, SurfaceMode, ViewMode, WireframeColorMode,
     WireframeProjection,
 };
+
+// Cool-to-warm diverging palette for the `w-depth` wireframe color mode.
+// Tracks SIGNED w in the body-local frame: cool blue at extreme -w (the
+// vertex sits "behind" the slice plane in 4D), warm orange at extreme +w
+// (vertex sits "in front"), and a near-neutral midpoint at w = 0 (vertex
+// sits on the slice plane). This is the same palette + scheme the
+// `LineRasterStaticR4` shader uses in `tesseract_demo`, where it reads as
+// "which edge is in front of which in the rotating tesseract." Picking up
+// the same colors here lets the playground demonstrate the same w-depth
+// cue across every polytope.
+//
+// Signed (not `|w|`) is the key: a tesseract vertex at +0.5 and one at
+// -0.5 are visually distinguishable, so the viewer can track a vertex
+// migrating between "near" and "far" camps as the rotor swings. The
+// previous |w|-based scheme collapsed both into the same color and made
+// 4D rotation visually indistinguishable from a 3D twist at certain
+// angles.
+const W_DEPTH_BACK: [f32; 3] = [0.30, 0.42, 0.58];
+const W_DEPTH_FRONT: [f32; 3] = [1.00, 0.78, 0.45];
+
+/// Convert HSV to RGB. h, s, v in [0, 1]; output channels in [0, 1].
+/// See e.g. Foley, van Dam et al., *Computer Graphics: Principles and
+/// Practice*, 2nd ed., section 13.3.4.
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [f32; 3] {
+    let h6 = h.fract() * 6.0;
+    let c = v * s;
+    let x = c * (1.0 - (h6 % 2.0 - 1.0).abs());
+    let m = v - c;
+    let (r, g, b) = match h6.floor() as i32 % 6 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    [r + m, g + m, b + m]
+}
+
+/// Deterministic palette: golden-ratio hue spacing + saturation/value
+/// modulation so consecutive palette indices land far apart in HSV. The
+/// greedy graph-coloring in [`unique_edge_palette`] only ever needs the
+/// first few indices for any of the regular 4-polytopes, so the first ~12
+/// entries are the perceptually-important ones.
+fn unique_edge_palette_color(idx: usize) -> [f32; 4] {
+    // Golden-ratio conjugate: maximally irrational, spreads hues evenly
+    // even for small N. See Knuth, TAOCP vol. 3, section 6.4.
+    const PHI_INV: f32 = 0.618_034;
+    let h = ((idx as f32) * PHI_INV).fract();
+    // 3-cycle on saturation and 2-cycle on value so adjacent indices (which
+    // already differ in hue by ~137 degrees) also differ in S/V.
+    let s = 0.78 + 0.18 * ((idx % 3) as f32 / 2.0);
+    let v = 0.92 - 0.18 * (((idx / 3) % 2) as f32);
+    let [r, g, b] = hsv_to_rgb(h, s, v);
+    [r, g, b, 1.0]
+}
+
+/// Per-edge RGBA palette via greedy graph-coloring on the line graph of
+/// `topo.edges`: two edges sharing a vertex are forbidden the same palette
+/// index, so locally-adjacent edges always read as different colors. The
+/// coloring is deterministic in the input edge order (which is itself
+/// deterministic per [`rye_physics::polytope::Polytope4Topology::edges`]),
+/// so the same polytope paints identically across runs.
+///
+/// Greedy first-fit coloring matches the line graph's chromatic number to
+/// within a factor that depends on vertex ordering; for the six regular
+/// convex 4-polytopes' edge graphs the result is within 1-2 colors of
+/// optimal in practice, which is fine for visual identification.
+fn unique_edge_palette(edges: &[[u32; 2]]) -> Vec<[f32; 4]> {
+    let n = edges.len();
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let [a0, a1] = edges[i];
+            let [b0, b1] = edges[j];
+            if a0 == b0 || a0 == b1 || a1 == b0 || a1 == b1 {
+                adj[i].push(j);
+                adj[j].push(i);
+            }
+        }
+    }
+    let mut color_idx = vec![usize::MAX; n];
+    let mut used = std::collections::HashSet::<usize>::new();
+    for i in 0..n {
+        used.clear();
+        for &nbr in &adj[i] {
+            if color_idx[nbr] != usize::MAX {
+                used.insert(color_idx[nbr]);
+            }
+        }
+        let mut c = 0;
+        while used.contains(&c) {
+            c += 1;
+        }
+        color_idx[i] = c;
+    }
+    color_idx
+        .into_iter()
+        .map(unique_edge_palette_color)
+        .collect()
+}
+
+/// Per-cell "crossing strength" in `[0, 1]`: 1 when `w_slice` sits at the
+/// cell's w-midpoint (the cap face is widest); 0 when the slice is outside
+/// the cell's w-range entirely. Linear in `|w_slice - midpoint|` normalized
+/// by the cell's half-extent, a cheap proxy for the actual cap area that
+/// gives the same visual gradient. Shared by `render_wireframe_overlay` and
+/// `render_points` so both honor the same cell-activity definition.
+fn compute_cell_strengths(
+    cells: &[&[u32]],
+    local_vertices: &[Vec4],
+    w_slice: f32,
+) -> Vec<f32> {
+    cells
+        .iter()
+        .map(|cell| {
+            let (w_min, w_max) = cell
+                .iter()
+                .map(|&i| local_vertices[i as usize].w)
+                .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), w| {
+                    (lo.min(w), hi.max(w))
+                });
+            let half_extent = (w_max - w_min) * 0.5;
+            if half_extent <= 0.0 {
+                return 0.0;
+            }
+            let mid = (w_min + w_max) * 0.5;
+            let dist = (w_slice - mid).abs();
+            (1.0 - dist / half_extent).clamp(0.0, 1.0)
+        })
+        .collect()
+}
+
+/// Per-vertex `w-depth` color: cool blue at -w extreme, warm orange at
+/// +w extreme, near-neutral on the slice plane. `w_extent_local` is the
+/// FIXED post-scale bound on `|w|` for this polytope's canonical vertex
+/// set (`canonical_max_w * body_size`), so the gradient stays stable as
+/// the rotor spins: a vertex that lands at `w = +0.4 * body_size` paints
+/// the same color regardless of orientation. Per-vertex (not per-edge)
+/// so edges that span the slice plane visibly fade cool to warm along their
+/// length, surfacing the w-depth migration directly.
+fn w_depth_color(w: f32, w_extent_local: f32) -> [f32; 4] {
+    let denom = w_extent_local.max(1e-6);
+    // Shift signed w from [-extent, +extent] into [0, 1]; clamp guards
+    // against any vertex slightly past the canonical extent (numeric drift
+    // or non-unit-circumradius polytopes).
+    let t = ((w / denom) * 0.5 + 0.5).clamp(0.0, 1.0);
+    [
+        W_DEPTH_BACK[0] + (W_DEPTH_FRONT[0] - W_DEPTH_BACK[0]) * t,
+        W_DEPTH_BACK[1] + (W_DEPTH_FRONT[1] - W_DEPTH_BACK[1]) * t,
+        W_DEPTH_BACK[2] + (W_DEPTH_FRONT[2] - W_DEPTH_BACK[2]) * t,
+        1.0,
+    ]
+}
 
 #[cfg(test)]
 use catalog::{parse_shape_name, ShapeEntry, DEFAULT_ROW};
@@ -143,11 +298,19 @@ impl Demo {
         // shapes can be added to the row at runtime via the panel.
         // The ~24 KB const-array cost is fixed per app and acceptable
         // for a viz/demo target.
+        //
+        // Floor visibility is gated at runtime via `u.params.x` (set by
+        // [`Demo::floor_enabled`] each frame in `update`): when 0.0 the
+        // halfspace SDF returns 1e9 + the ray-plane bound is skipped, so
+        // the marcher never converges on the floor and the checkerboard
+        // never paints. Engine-level support: see
+        // [`Scene4::to_hyperslice_wgsl_gated`]. Zero per-frame cost; one
+        // shader build per launch.
         let shader_source = format!(
             "{kernel}\n{polytope}\n{scene}\n",
             kernel = HYPERSLICE_KERNEL_WGSL,
             polytope = polytope_extended_sdfs_wgsl(),
-            scene = scene.to_hyperslice_wgsl("u.w_slice"),
+            scene = scene.to_hyperslice_wgsl_gated("u.w_slice", "u.params.x"),
         );
         let module = ctx
             .rd
@@ -218,14 +381,16 @@ impl Demo {
         );
 
         // Point-disc rasterizer for the optional vertex + cell-center sprites overlay.
-        // Same depth-attachment setup as the other rasterizer nodes so points respect the
-        // shared section-faces depth buffer (sprites that sit behind a cap get occluded).
+        // No depth attachment: points are debug markers that must read as an overlay
+        // regardless of where the section caps sit. With the previous ReadOnly setup,
+        // a vertex at non-zero w would project (via drop-w) to the SAME (x, y, z) as
+        // its enclosing cap's slice intersection but with a slightly farther camera
+        // depth, so `LessEqual` failed and the sprite vanished behind the cap. The
+        // overlay semantic ("show me where the vertices are") wants always-visible.
         let points_node = PointRasterNode::new(
             &ctx.rd.device,
             ctx.rd.target_format(),
-            DepthMode::ReadOnly {
-                format: SECTION_FACES_DEPTH_FORMAT,
-            },
+            DepthMode::Off,
             ctx.rd.sample_count(),
         );
 
@@ -238,6 +403,30 @@ impl Demo {
             &ctx.rd.device,
             ctx.rd.target_format(),
             DepthMode::ReadWrite {
+                format: SECTION_FACES_DEPTH_FORMAT,
+            },
+            rye_render::FragmentShading::FaceNormalLambert,
+            ctx.rd.sample_count(),
+        );
+        // Translucent variant: identical pipeline modulo depth-write. When
+        // `surface_alpha < 1.0` we render through this one so the parent
+        // wireframe (drawn AFTER section faces with `LessEqual` depth-test)
+        // can show through the cap. The ReadWrite variant above writes
+        // depth, which would otherwise hide wireframe edges sitting behind
+        // a cap regardless of the cap's alpha.
+        //
+        // Tradeoff: with ReadOnly depth, caps within a single polytope can
+        // overpaint each other in submission order when their R³
+        // projections overlap. In practice the section-cap of one cell is
+        // disjoint from the section-cap of another cell at the same
+        // w_slice (each cell hosts at most one cap and they tile the
+        // section), so overdraw is rare. If it surfaces on the 24-cell or
+        // 600-cell at oblique angles, the fix is a depth-only prepass +
+        // ReadOnly color pass; punted until we observe the artifact.
+        let section_faces_translucent = TriangleRasterNode::new(
+            &ctx.rd.device,
+            ctx.rd.target_format(),
+            DepthMode::ReadOnly {
                 format: SECTION_FACES_DEPTH_FORMAT,
             },
             rye_render::FragmentShading::FaceNormalLambert,
@@ -277,7 +466,14 @@ impl Demo {
             wireframe_perimeter: true,
             wireframe_color_mode: WireframeColorMode::default(),
             wireframe_projection: WireframeProjection::default(),
+            wireframe_width_px: 1.8,
+            wireframe_alpha: 1.0,
+            unique_edge_palette_cache: std::collections::HashMap::new(),
+            surface_scale: 1.0,
+            surface_alpha: 1.0,
+            floor_enabled: true,
             section_faces,
+            section_faces_translucent,
             points_node,
             points_enabled: false,
             points_show_vertices: true,
@@ -345,10 +541,14 @@ impl Demo {
     pub(crate) fn update(&mut self, ctx: &mut FrameCtx<'_>) {
         let dt_secs = ctx.n_ticks as f32 / 60.0;
 
-        // Slice scrub (w axis, up/down arrow keys).
+        // Slice scrub (w axis, up/down arrow keys). Clamps against the
+        // surface-scaled range so the keyboard scrub matches the slider
+        // bounds after `surface scale`.
         let dir = (self.slider_up_held as i32 - self.slider_down_held as i32) as f32;
         if dir != 0.0 {
-            self.w_slice = (self.w_slice + dir * W_SCRUB_RATE * dt_secs).clamp(-W_RANGE, W_RANGE);
+            let w_range = self.effective_w_range();
+            self.w_slice =
+                (self.w_slice + dir * W_SCRUB_RATE * dt_secs).clamp(-w_range, w_range);
         }
 
         // Time scrub (t axis, left/right arrow keys). Mirrors the
@@ -457,6 +657,12 @@ impl Demo {
             u.time = ctx.time;
             u.tick = ctx.tick as f32;
             u.w_slice = self.w_slice;
+            // Floor-toggle gate read by the wrapper around `rye_scene_sdf`
+            // we injected at App::setup time. `u.params[0]` is 1.0 = floor
+            // on (the canonical halfspace SDF runs), 0.0 = floor off (the
+            // wrapper short-circuits to 1e9 so the marcher never converges
+            // on the floor and the checkerboard never paints).
+            u.params[0] = if self.floor_enabled { 1.0 } else { 0.0 };
         }
         self.node.flush_uniforms(&ctx.rd.queue);
     }
@@ -480,13 +686,19 @@ impl Demo {
         // a glance when a tester reloads the wasm bundle; the browser cache
         // can serve a stale page+script combination otherwise. F3's perf
         // overlay shows fps + framebuffer size when that data is wanted.
-        let build_label = format!(
-            "version: {}{}",
-            env!("BUILD_HASH"),
-            env!("BUILD_DIRTY"),
-        );
+        // Build label: short git hash + dirty marker, rendered top-right with
+        // visually symmetric padding (same gap from menu-bar bottom as from
+        // window's right edge). `MENU_BAR_PAD + LABEL_INSET` lands the label
+        // 14 px below the menu bar; `-LABEL_INSET` puts it 14 px in from the
+        // right edge. Matching values keep the two whitespaces equal.
+        const MENU_BAR_PAD: f32 = 24.0;
+        const LABEL_INSET: f32 = 14.0;
+        let build_label = format!("build: {}{}", env!("BUILD_HASH"), env!("BUILD_DIRTY"),);
         egui::Area::new(egui::Id::new("polytope-playground-build"))
-            .anchor(egui::Align2::RIGHT_TOP, [-12.0, 50.0])
+            .anchor(
+                egui::Align2::RIGHT_TOP,
+                [-LABEL_INSET, MENU_BAR_PAD + LABEL_INSET],
+            )
             .show(ctx, |ui| {
                 ui.add(egui::Label::new(
                     egui::RichText::new(build_label)
@@ -588,7 +800,7 @@ impl Demo {
         let polytope = entry.shape.polytope4().expect("filter guarantees Some");
         let topo = polytope.topology();
         let canonical_v0 = topo.vertices[0];
-        let v_local_4d = BODY_SIZE * self.rot_state.apply(canonical_v0);
+        let v_local_4d = self.effective_body_size() * self.rot_state.apply(canonical_v0);
         let v_local_r3 = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
             v_local_4d,
             &self.wireframe_projection.to_projection(),
@@ -670,20 +882,20 @@ impl Demo {
             // on `FrameInput::move_up`); rotating-on-Space would conflict.
             // T remains the always-available rotation toggle for freecam
             // users.
-            KeyCode::Space
-                if pressed && !matches!(self.camera_mode, CameraMode::FreeRoam) =>
-            {
+            KeyCode::Space if pressed && !matches!(self.camera_mode, CameraMode::FreeRoam) => {
                 self.rotate = !self.rotate;
             }
-            // Alt toggles the cursor grab while in freecam: hidden +
-            // confined for mouse-look, visible + free for UI interaction.
-            // The preset's `toggle_cursor_grab` handles the grab request
-            // and the controller's raw-delta flag together; demo just
-            // calls it. No-op outside freecam (the preset is inactive).
+            // Alt modulates the cursor grab while in freecam. Toggle mode
+            // (default, FPS sticky): press flips the grab, release is
+            // ignored. Hold mode (MMO-style): cursor released while Alt is
+            // held, re-grabbed when Alt is released. Both are routed
+            // through `Freecam::on_alt`, which inspects its `cursor_mode`
+            // field. We forward press AND release so Hold mode sees both
+            // edges; outside freecam the preset short-circuits to no-op.
             KeyCode::AltLeft | KeyCode::AltRight
-                if pressed && matches!(self.camera_mode, CameraMode::FreeRoam) =>
+                if matches!(self.camera_mode, CameraMode::FreeRoam) =>
             {
-                self.freecam.toggle_cursor_grab();
+                self.freecam.on_alt(pressed);
             }
             // Plane toggles. Sum-of-bivectors composition is
             // commutative, so the order in which planes are toggled
@@ -725,7 +937,7 @@ impl Demo {
             // rotor: `exp(omega_animation * t_offset) * rot_state`.
             // For the w-only and t-only 1D cases, the second
             // axis collapses to a single cell with offset=0.
-            let strip_w_extent = BODY_SIZE;
+            let strip_w_extent = self.effective_body_size();
             let (cols, rows, w_on_cols) = match (self.strip_w, self.strip_t) {
                 (true, true) => {
                     if self.strip_swap_axes {
@@ -780,7 +992,7 @@ impl Demo {
                     let body = BodyUniform::polytope_with_rotor(
                         [0.0, BODY_Y, 0.0, 0.0],
                         entry.shape.shape_id(),
-                        BODY_SIZE,
+                        self.effective_body_size(),
                         cell_rotor,
                         entry.body_color,
                     );
@@ -883,7 +1095,7 @@ impl Demo {
     /// raster pass. No-op when no polychoral body is present in the row.
     ///
     /// Per-body world transform mirrors `render_wireframe_overlay`: canonical vertices
-    /// `v` become `body_position + BODY_SIZE * rot_state.apply(v)`. The section
+    /// `v` become `body_position + effective_body_size() * rot_state.apply(v)`. The section
     /// algorithm then runs on these world vertices against the demo's `w_slice`,
     /// producing R³ geometry that composes with the camera the SDF raymarcher uses.
     ///
@@ -902,19 +1114,27 @@ impl Demo {
     /// projected through `wireframe_projection`, and translated by the body's R³ position so
     /// the perspective scale doesn't smear the body across its row x-offset.
     ///
-    /// Coloring: vertex sprites use the same per-vertex position-derived RGB scheme as the
-    /// "unique" wireframe color mode (`vertex_color_by_position`), so vertex sprites visually
-    /// belong with the colored wireframe. Cell-center sprites use a uniform white with
-    /// reduced alpha to read as a secondary structural marker rather than competing with the
-    /// vertex sprites.
+    /// Coloring: sprites honor the active [`WireframeColorMode`] so the
+    /// points overlay reads as part of the same wireframe rendering pass.
+    /// Per-vertex sprites get the same color the matching wireframe vertex
+    /// would carry; per-cell-center sprites get the dominant-cell color
+    /// (cell strength for `Active`, cell-center w for `WDepth`, position-
+    /// derived gradient otherwise). For `UniqueEdge` mode the points fall
+    /// back to the position-gradient because the unique-edge palette is
+    /// edge-indexed and has no canonical vertex assignment.
     fn render_points(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> Result<()> {
         let cfg = &rd.surface_bundle.config;
         let n = self.row.len();
         let wireframe_projection = self.wireframe_projection.to_projection();
-        // Cell-center sprite color: a dim warm white. Pre-multiplied alpha makes the sprite
-        // read as a "second-tier" marker behind the brighter vertex discs.
-        const CELL_CENTER_COLOR: [f32; 4] = [0.92, 0.88, 0.78, 0.65];
+        // Active-mode palette: bright green for vertices that belong to a
+        // currently-intersected cell, dim gray otherwise. Same hues the
+        // wireframe overlay uses so the visual identity stays consistent.
+        const ACTIVE_GREEN: [f32; 4] = [0.40, 1.00, 0.55, 1.0];
+        const INACTIVE_GRAY: [f32; 4] = [0.55, 0.55, 0.58, 0.85];
+        let color_mode = self.wireframe_color_mode;
 
+        let body_size = self.effective_body_size();
+        let w_slice = self.w_slice;
         let mesh = &mut self.points_mesh_scratch;
         mesh.positions.clear();
         mesh.colors.clear();
@@ -928,33 +1148,112 @@ impl Demo {
             let body_pos = body_position(slot, n);
             let body_pos_r3 = Vec3::new(body_pos[0], body_pos[1], body_pos[2]);
 
+            // Per-frame, per-polytope body-local 4D vertices (rotated + scaled).
+            // Shared by the vertex AND cell-center loops: for WDepth we need
+            // the maximum |w| across them to normalize the gradient, and for
+            // Active we need them to derive cell strengths.
+            let local_vertices: Vec<Vec4> = topo
+                .vertices
+                .iter()
+                .map(|v| body_size * self.rot_state.apply(*v))
+                .collect();
+            // Same canonical-max-w normalization the wireframe overlay uses
+            // (see render_wireframe_overlay), keeping the points' color in
+            // step with the edges across the same w-depth scheme.
+            let w_extent_local: f32 = if matches!(color_mode, WireframeColorMode::WDepth) {
+                let canonical_max_w = topo
+                    .vertices
+                    .iter()
+                    .map(|v| v.w.abs())
+                    .fold(0.0_f32, f32::max)
+                    .max(1e-6);
+                canonical_max_w * body_size
+            } else {
+                1.0
+            };
+            // Cell strengths only computed for the Active mode; saves work in
+            // the common case. Same definition the wireframe overlay uses
+            // (`compute_cell_strengths`) so "vertex in an active cell" reads
+            // consistently across edges + dots.
+            let cell_strengths: Vec<f32> = if matches!(color_mode, WireframeColorMode::Active) {
+                compute_cell_strengths(topo.cells, &local_vertices, w_slice)
+            } else {
+                Vec::new()
+            };
+            let vertex_is_active = |vi: usize| -> bool {
+                topo.cells
+                    .iter()
+                    .zip(cell_strengths.iter())
+                    .any(|(cell, &s)| s > 0.0 && cell.contains(&(vi as u32)))
+            };
+
             if self.points_show_vertices {
-                for v in topo.vertices {
-                    let v_local = BODY_SIZE * self.rot_state.apply(*v);
+                for (vi, v) in topo.vertices.iter().enumerate() {
+                    let v_local = local_vertices[vi];
                     let v3_local =
                         <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
                             v_local,
                             &wireframe_projection,
                         );
                     let v_world = v3_local + body_pos_r3;
+                    let color = match color_mode {
+                        // Position-gradient also covers UniqueEdge, since the
+                        // unique-edge palette is edge-indexed (no canonical
+                        // assignment for a vertex shared by several edges).
+                        WireframeColorMode::VertexGradient | WireframeColorMode::UniqueEdge => {
+                            vertex_color_by_position(*v)
+                        }
+                        WireframeColorMode::WDepth => w_depth_color(v_local.w, w_extent_local),
+                        WireframeColorMode::Active => {
+                            if vertex_is_active(vi) {
+                                ACTIVE_GREEN
+                            } else {
+                                INACTIVE_GRAY
+                            }
+                        }
+                    };
                     mesh.positions.push(v_world.to_array());
-                    // Color by the canonical (unrotated) vertex position so the sprite hue
-                    // matches its corresponding wireframe edge in `WireframeColorMode::Unique`.
-                    mesh.colors.push(vertex_color_by_position(*v));
+                    mesh.colors.push(color);
                     mesh.sizes.push(self.points_size_px);
                 }
             }
             if self.points_show_cell_centers {
-                for c in polytope.cell_centers() {
-                    let c_local = BODY_SIZE * self.rot_state.apply(c);
+                // Pull cell centroids radially inward by `CELL_CENTER_INSET` so
+                // they read as "interior markers" instead of coinciding with the
+                // DUAL polytope's vertices. Mathematically `polytope.cell_centers()`
+                // returns each cell's centroid at the inradius, which IS the
+                // dual's vertex set (16-cell's cell-centroids form a tesseract,
+                // tesseract's form a 16-cell, etc). At full inradius the sprites
+                // look like a smaller dual polytope sitting at the inradius; the
+                // inset puts them visibly INSIDE the body's cap so a viewer reads
+                // "one dot per cell, in the cell's direction" rather than
+                // "vertices of the wrong polytope."
+                const CELL_CENTER_INSET: f32 = 0.5;
+                let centers = polytope.cell_centers();
+                for (ci, c) in centers.iter().enumerate() {
+                    let c_local = body_size * CELL_CENTER_INSET * self.rot_state.apply(*c);
                     let c3_local =
                         <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
                             c_local,
                             &wireframe_projection,
                         );
                     let c_world = c3_local + body_pos_r3;
+                    let color = match color_mode {
+                        WireframeColorMode::VertexGradient | WireframeColorMode::UniqueEdge => {
+                            vertex_color_by_position(*c)
+                        }
+                        WireframeColorMode::WDepth => w_depth_color(c_local.w, w_extent_local),
+                        WireframeColorMode::Active => {
+                            let s = cell_strengths.get(ci).copied().unwrap_or(0.0);
+                            if s > 0.0 {
+                                ACTIVE_GREEN
+                            } else {
+                                INACTIVE_GRAY
+                            }
+                        }
+                    };
                     mesh.positions.push(c_world.to_array());
-                    mesh.colors.push(CELL_CENTER_COLOR);
+                    mesh.colors.push(color);
                     // Cell-center sprites half-sized so they don't compete visually with the
                     // brighter vertex discs.
                     mesh.sizes.push(self.points_size_px * 0.5);
@@ -976,12 +1275,10 @@ impl Demo {
             mesh,
             &rye_math::Projection::Identity,
         );
-        let depth_view = self
-            .section_faces_depth
-            .as_ref()
-            .map(|b| &b.view)
-            .expect("shared depth buffer must be ensured before points overlay");
-        self.points_node.execute(rd, view, Some(depth_view), None)?;
+        // No depth attachment: see `PointRasterNode::new` site for the rationale
+        // (drop-w + ReadOnly LessEqual was occluding non-w=0 vertices behind their
+        // own caps).
+        self.points_node.execute(rd, view, None, None)?;
         Ok(())
     }
 
@@ -992,6 +1289,7 @@ impl Demo {
         // Reuse the per-Demo scratch mesh; capacity grows once to fit the largest
         // polychoron and stays there. Each frame's `clear()` keeps the underlying
         // allocations.
+        let body_size = self.effective_body_size();
         let combined = &mut self.section_faces_mesh_scratch;
         combined.vertices.clear();
         combined.colors.clear();
@@ -1020,12 +1318,14 @@ impl Demo {
             self.section_world_vertices_scratch.extend(
                 topo.vertices
                     .iter()
-                    .map(|v| BODY_SIZE * self.rot_state.apply(*v)),
+                    .map(|v| body_size * self.rot_state.apply(*v)),
             );
 
             // Match the SDF's per-body solid coloring: every cap of this polychoron uses
             // the body's identity color from the catalog. Per-face Lambert in the fragment
-            // shader adds the geometric depth; the underlying color is flat.
+            // shader adds the geometric depth; the underlying color is flat. Alpha is
+            // the user-tuneable `surface_alpha` (default 1.0); below 1.0 the wireframe
+            // overlay behind composites through via `SrcAlpha/OneMinusSrcAlpha` blending.
             let [r, g, b] = entry.body_color;
             let start = combined.vertices.len();
             polytope_section_faces_append(
@@ -1033,7 +1333,7 @@ impl Demo {
                 topo.cells,
                 &self.section_world_vertices_scratch,
                 WPlane::new(self.w_slice),
-                [r, g, b, 1.0],
+                [r, g, b, self.surface_alpha],
                 combined,
             );
             // Translate this body's body-local cap vertices into world R³. Indices were
@@ -1063,15 +1363,34 @@ impl Demo {
             .as_ref()
             .expect("shared depth buffer must be ensured before section_faces");
 
-        self.section_faces.set_camera(&rd.queue, view_proj);
-        self.section_faces.upload::<EuclideanR3, 3>(
-            &rd.device,
-            &rd.queue,
-            combined,
-            &rye_math::Projection::Identity,
-        );
-        self.section_faces
-            .execute(rd, view, Some(&depth.view), None)?;
+        // Pick the depth-write variant based on `surface_alpha`: opaque
+        // (1.0) writes depth so caps occlude one another correctly within
+        // a polytope; translucent (< 1.0) skips depth-write so the parent
+        // wireframe drawn after sees through. The two nodes carry their
+        // own GPU buffers, so we upload the mesh into whichever path
+        // we're about to execute.
+        if self.surface_alpha >= 1.0 {
+            self.section_faces.set_camera(&rd.queue, view_proj);
+            self.section_faces.upload::<EuclideanR3, 3>(
+                &rd.device,
+                &rd.queue,
+                combined,
+                &rye_math::Projection::Identity,
+            );
+            self.section_faces
+                .execute(rd, view, Some(&depth.view), None)?;
+        } else {
+            self.section_faces_translucent
+                .set_camera(&rd.queue, view_proj);
+            self.section_faces_translucent.upload::<EuclideanR3, 3>(
+                &rd.device,
+                &rd.queue,
+                combined,
+                &rye_math::Projection::Identity,
+            );
+            self.section_faces_translucent
+                .execute(rd, view, Some(&depth.view), None)?;
+        }
         Ok(())
     }
 
@@ -1080,9 +1399,9 @@ impl Demo {
     /// depth buffer, and execute the three raster passes on top of the existing SDF render.
     ///
     /// Per-body transform: each canonical Polytope4 vertex `v` becomes the world Vec4
-    /// `body.position + BODY_SIZE * rot_state.apply(v)`. The section algorithm then runs
-    /// on these world vertices against the demo's `w_slice`, producing geometry in world
-    /// R³ that composes cleanly with the SDF camera frame.
+    /// `body.position + effective_body_size() * rot_state.apply(v)`. The section algorithm
+    /// then runs on these world vertices against the demo's `w_slice`, producing geometry
+    /// in world R³ that composes cleanly with the SDF camera frame.
     ///
     /// Non-polychoral shapes (Clifford torus, duocylinder, etc.) in the row are skipped:
     /// they have no [`rye_physics::polytope::Polytope4`] mapping and the cross-section
@@ -1101,10 +1420,16 @@ impl Demo {
         // Uniform-alpha endpoints when `nearest-active` is off; the active-mode mapping
         // interpolates between DIM (cells the slice misses entirely) and BRIGHT (cells
         // the slice is at the midpoint of).
-        const PARENT_ALPHA_UNIFORM: f32 = 0.55;
+        // When `wireframe nearest-active` is OFF, every edge gets the user-
+        // tuneable uniform alpha (`wireframe_alpha`, default 1.0). When ON,
+        // edges interpolate between DIM (cells the slice misses entirely)
+        // and BRIGHT (cells the slice is at the midpoint of). DIM/BRIGHT
+        // stay hardcoded because they encode "very off" / "very on" peaks
+        // of the activity gradient, not a global opacity setting.
         const PARENT_ALPHA_DIM: f32 = 0.10;
         const PARENT_ALPHA_BRIGHT: f32 = 0.85;
-        const PARENT_WIDTH: f32 = 1.2;
+        let parent_alpha_uniform = self.wireframe_alpha;
+        let parent_width = self.wireframe_width_px;
         // Active-mode palette. Green for edges in any currently-intersected cell;
         // neutral gray for the rest. Chosen for clear binary contrast against the
         // grayish-blue scene backdrop and the dim ground checkerboard.
@@ -1131,10 +1456,11 @@ impl Demo {
             // Body-local 4D vertices: rotor-rotated, scaled, NO world translate yet. The
             // translate happens after the chosen `wireframe_projection` maps each vertex
             // from R⁴ to R³.
+            let body_size = self.effective_body_size();
             let local_vertices: Vec<Vec4> = topo
                 .vertices
                 .iter()
-                .map(|v| BODY_SIZE * self.rot_state.apply(*v))
+                .map(|v| body_size * self.rot_state.apply(*v))
                 .collect();
 
             // Cross-section perimeter edges. The cyan outlines bound each cell cap on the
@@ -1160,30 +1486,10 @@ impl Demo {
                 section_edges.widths.append(&mut perim.widths);
             }
 
-            // Per-cell "crossing strength" in [0, 1]: 1 when `w_slice` is at the cell's
-            // w-midpoint (cap face is widest), 0 when the slice is at the cell's w-boundary
-            // or outside it entirely. A linear w-midpoint proxy avoids computing actual
-            // cap areas while giving the same visual gradient: cells the slice is *deep
-            // in* peak in brightness, cells the slice barely touches taper to dim.
-            let cell_strengths: Vec<f32> = topo
-                .cells
-                .iter()
-                .map(|cell| {
-                    let (w_min, w_max) = cell
-                        .iter()
-                        .map(|&i| local_vertices[i as usize].w)
-                        .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), w| {
-                            (lo.min(w), hi.max(w))
-                        });
-                    let half_extent = (w_max - w_min) * 0.5;
-                    if half_extent <= 0.0 {
-                        return 0.0;
-                    }
-                    let mid = (w_min + w_max) * 0.5;
-                    let dist = (self.w_slice - mid).abs();
-                    (1.0 - dist / half_extent).clamp(0.0, 1.0)
-                })
-                .collect();
+            // Per-cell "crossing strength" in [0, 1] - shared with render_points
+            // via `compute_cell_strengths` so both passes agree on what "active"
+            // means for a given w_slice + rotated polytope.
+            let cell_strengths = compute_cell_strengths(topo.cells, &local_vertices, self.w_slice);
 
             // Per-edge brightness: max strength across cells the edge belongs to. An edge
             // belongs to a cell when both endpoints sit in that cell's vertex list. This
@@ -1215,22 +1521,70 @@ impl Demo {
 
             // Parent wireframe: every polytope edge as a world-R³ line. Base RGB is
             // picked by `wireframe_color_mode`:
-            // - `Unique`: per-vertex position-derived RGB from the canonical vertex
-            //   set so each vertex gets a distinct hue from its 4D coordinates and
-            //   the polytope's symmetry shows as smooth gradients (same scheme as
+            // - `VertexGradient`: per-vertex position-derived RGB from the canonical
+            //   vertex set so each vertex gets a distinct hue from its 4D coordinates
+            //   and the polytope's symmetry shows as smooth gradients (same scheme as
             //   `Polytope4::lines_colored_by_position`).
+            // - `UniqueEdge`: each edge gets a distinct palette color via greedy
+            //   graph-coloring on the line graph (see `unique_edge_palette`).
+            // - `WDepth`: per-endpoint cool-blue-to-warm-orange by SIGNED w
+            //   in body-local frame, normalized against the polytope's canonical
+            //   max |w| (fixed-band, not per-frame), so a vertex paints the same
+            //   color at the same w regardless of rotor orientation.
             // - `Active`: binary green/gray by cell-activity (see `edge_is_active`).
             // Alpha is then modulated per-edge by the `nearest-active` strength (when
             // that toggle is on) or held uniform.
-            for &[i, j] in topo.edges {
+            // UniqueEdge palette is topology-only (greedy graph-coloring on the line
+            // graph). Memoize by `Polytope4` variant so the 600-cell's ~520k pair-checks
+            // run once per launch instead of once per frame. Cache lives on Demo; an
+            // empty cache simply triggers first-use population for the visited variants.
+            let edge_palette: &[[f32; 4]] =
+                if matches!(color_mode, WireframeColorMode::UniqueEdge) {
+                    self.unique_edge_palette_cache
+                        .entry(polytope)
+                        .or_insert_with(|| unique_edge_palette(topo.edges))
+                } else {
+                    &[]
+                };
+            // For `WDepth` we normalize against this polytope's CANONICAL max
+            // |w| (NOT the per-frame rotated max). The rotor preserves
+            // magnitudes, so the maximum |w| any rotated vertex can reach is
+            // bounded by the canonical max times `body_size`. Holding the
+            // gradient endpoints fixed across frames is what makes the color
+            // cue temporally stable: a vertex migrating from -w to +w as
+            // the rotor swings paints a continuous cool-to-warm shift rather
+            // than a per-frame normalized re-saturation. Mirrors the
+            // `LineRasterStaticR4` shader's hardcoded `[-0.5, +0.5]` band
+            // (which is correct for the tesseract); here it's per-polytope
+            // because the 16-cell, 5-cell, etc. don't share that band.
+            let w_extent_local: f32 = if matches!(color_mode, WireframeColorMode::WDepth) {
+                let canonical_max_w = topo
+                    .vertices
+                    .iter()
+                    .map(|v| v.w.abs())
+                    .fold(0.0_f32, f32::max)
+                    .max(1e-6);
+                canonical_max_w * body_size
+            } else {
+                1.0
+            };
+            for (edge_idx, &[i, j]) in topo.edges.iter().enumerate() {
                 let ia = i as usize;
                 let ja = j as usize;
                 let a = local_vertices[ia];
                 let b = local_vertices[ja];
                 let (mut color_a, mut color_b) = match color_mode {
-                    WireframeColorMode::Unique => (
+                    WireframeColorMode::VertexGradient => (
                         vertex_color_by_position(topo.vertices[ia]),
                         vertex_color_by_position(topo.vertices[ja]),
+                    ),
+                    WireframeColorMode::UniqueEdge => {
+                        let c = edge_palette[edge_idx];
+                        (c, c)
+                    }
+                    WireframeColorMode::WDepth => (
+                        w_depth_color(a.w, w_extent_local),
+                        w_depth_color(b.w, w_extent_local),
                     ),
                     WireframeColorMode::Active => {
                         let c = if edge_is_active(i, j) {
@@ -1245,7 +1599,7 @@ impl Demo {
                     let s = edge_strength(i, j);
                     PARENT_ALPHA_DIM + (PARENT_ALPHA_BRIGHT - PARENT_ALPHA_DIM) * s
                 } else {
-                    PARENT_ALPHA_UNIFORM
+                    parent_alpha_uniform
                 };
                 color_a[3] = alpha;
                 color_b[3] = alpha;
@@ -1267,7 +1621,7 @@ impl Demo {
                 let b3 = b3_local + body_pos_r3;
                 parent_lines.segments.push((a3.to_array(), b3.to_array()));
                 parent_lines.colors.push((color_a, color_b));
-                parent_lines.widths.push(PARENT_WIDTH);
+                parent_lines.widths.push(parent_width);
             }
         }
 
@@ -1354,6 +1708,10 @@ struct RotatePolytopesApp {
     /// Capture parameters panel (output dir, format, fps, scale, start/stop).
     /// Toggled via the `capture panel` console command or the F11 default bind.
     capture_panel: rye_app::capture::CapturePanel,
+    /// F3-toggle live perf overlay: FPS, frame-time, sparkline. Reads from
+    /// `rye_time::frame_trace`, so it surfaces the same numbers `trace summary`
+    /// dumps but continuously. Cheap when hidden (just a key-press check).
+    perf: rye_app::trace::PerfOverlay,
 }
 
 impl RotatePolytopesApp {
@@ -1419,19 +1777,92 @@ impl RotatePolytopesApp {
                         Ok(())
                     },
                 )
+                .custom(
+                    "width",
+                    "parent-wireframe edge thickness in pixels (default 1.8)",
+                    &[&[]],
+                    &[],
+                    |d, args, out| {
+                        match args.first().copied() {
+                            None => {
+                                out.line(format!(
+                                    "wireframe width: {:.2} px",
+                                    d.wireframe_width_px
+                                ));
+                            }
+                            Some(s) => match s.parse::<f32>() {
+                                Ok(w) if w > 0.0 && w <= 16.0 => {
+                                    d.wireframe_width_px = w;
+                                    out.line(format!(
+                                        "wireframe width: set to {w:.2} px"
+                                    ));
+                                }
+                                _ => {
+                                    out.line(format!(
+                                        "wireframe width: invalid `{s}` (need a float in (0, 16])"
+                                    ));
+                                }
+                            },
+                        }
+                        Ok(())
+                    },
+                )
+                .custom(
+                    "alpha",
+                    "uniform edge alpha when nearest-active is off (default 1.0)",
+                    &[&[]],
+                    &[],
+                    |d, args, out| {
+                        match args.first().copied() {
+                            None => {
+                                out.line(format!(
+                                    "wireframe alpha: {:.3} ({})",
+                                    d.wireframe_alpha,
+                                    if d.wireframe_nearest_active {
+                                        "overridden by nearest-active gradient; toggle off to apply"
+                                    } else {
+                                        "active"
+                                    }
+                                ));
+                            }
+                            Some(s) => match s.parse::<f32>() {
+                                Ok(a) if a > 0.0 && a <= 1.0 => {
+                                    d.wireframe_alpha = a;
+                                    out.line(format!(
+                                        "wireframe alpha: set to {a:.3}"
+                                    ));
+                                }
+                                _ => {
+                                    out.line(format!(
+                                        "wireframe alpha: invalid `{s}` (need a float in (0, 1])"
+                                    ));
+                                }
+                            },
+                        }
+                        Ok(())
+                    },
+                )
                 .choice(
                     "color",
-                    "base RGB for parent edges (bare cycles): unique (default) or active",
-                    &["unique", "active"],
+                    "parent-edge color mode (bare cycles): vertex-gradient|unique-edge|w-depth|active",
+                    &["vertex-gradient", "unique-edge", "w-depth", "active"],
                     |d, name| {
                         d.wireframe_color_mode = match name {
                             Some(n) => WireframeColorMode::from_token(n).ok_or_else(|| {
-                                anyhow!("unknown color mode `{n}` (try unique|active)")
+                                anyhow!(
+                                    "unknown color mode `{n}` (try vertex-gradient|unique-edge|w-depth|active)"
+                                )
                             })?,
-                            None => match d.wireframe_color_mode {
-                                WireframeColorMode::Unique => WireframeColorMode::Active,
-                                WireframeColorMode::Active => WireframeColorMode::Unique,
-                            },
+                            None => {
+                                // Cycle through the canonical order so bare
+                                // `wireframe color` visits every mode in turn.
+                                let all = WireframeColorMode::ALL;
+                                let i = all
+                                    .iter()
+                                    .position(|m| *m == d.wireframe_color_mode)
+                                    .unwrap_or(0);
+                                all[(i + 1) % all.len()]
+                            }
                         };
                         Ok(())
                     },
@@ -1452,51 +1883,59 @@ impl RotatePolytopesApp {
                         };
                         Ok(())
                     },
-                ),
-        );
-
-        // Points overlay: vertex markers + cell-center sprites. Same SubcommandSet shape as
-        // `wireframe`: bare flips main on/off, subcommands gate per-category visibility, and
-        // a size knob for the disc radius. Off by default so first-launch readers see the
-        // demo's identity (SDF / raster + wireframe) rather than a vertex cloud.
-        c.register(
-            rye_egui::subcommands::<Demo>("points", "vertex + cell-center sprite overlay")
-                .on_bare(|d| {
-                    d.points_enabled = !d.points_enabled;
-                    Ok(())
-                })
-                .toggle(
-                    "vertices",
-                    "render a disc at each polytope vertex (bare flips)",
-                    |d, v| {
-                        d.points_show_vertices = v.unwrap_or(!d.points_show_vertices);
-                        Ok(())
-                    },
-                )
-                .toggle(
-                    "cell-centers",
-                    "render a dim disc at each cell's centroid (bare flips)",
-                    |d, v| {
-                        d.points_show_cell_centers = v.unwrap_or(!d.points_show_cell_centers);
-                        Ok(())
-                    },
                 )
                 .custom(
-                    "size",
-                    "set the disc radius in pixels (e.g. `points size 8`)",
+                    "points",
+                    "vertex + cell-center sprite overlay (bare flips; sub: vertices|cell-centers|size <N>)",
+                    &[&["vertices", "cell-centers", "size"]],
                     &[],
-                    &[],
-                    |d, rest, _out| {
-                        let Some(token) = rest.first() else {
-                            return Err(anyhow!("usage: points size <pixels>"));
-                        };
-                        let px: f32 = token
-                            .parse()
-                            .map_err(|e| anyhow!("invalid pixel value `{token}`: {e}"))?;
-                        if !(1.0..=64.0).contains(&px) {
-                            return Err(anyhow!("points size {px} out of range; expected 1..=64"));
+                    |d, args, out| {
+                        match args.first().copied() {
+                            None => {
+                                d.points_enabled = !d.points_enabled;
+                                out.line(format!(
+                                    "points: {}",
+                                    if d.points_enabled { "on" } else { "off" }
+                                ));
+                            }
+                            Some("vertices") => {
+                                d.points_show_vertices = !d.points_show_vertices;
+                                out.line(format!(
+                                    "points vertices: {}",
+                                    if d.points_show_vertices { "on" } else { "off" }
+                                ));
+                            }
+                            Some("cell-centers") => {
+                                d.points_show_cell_centers = !d.points_show_cell_centers;
+                                out.line(format!(
+                                    "points cell-centers: {}",
+                                    if d.points_show_cell_centers { "on" } else { "off" }
+                                ));
+                            }
+                            Some("size") => match args.get(1) {
+                                None => out.line(format!(
+                                    "points size: {:.1} px",
+                                    d.points_size_px
+                                )),
+                                Some(token) => {
+                                    let px: f32 = token.parse().map_err(|e| {
+                                        anyhow!("invalid pixel value `{token}`: {e}")
+                                    })?;
+                                    if !(1.0..=64.0).contains(&px) {
+                                        return Err(anyhow!(
+                                            "points size {px} out of range; expected 1..=64"
+                                        ));
+                                    }
+                                    d.points_size_px = px;
+                                    out.line(format!("points size: set to {px:.1} px"));
+                                }
+                            },
+                            Some(other) => {
+                                return Err(anyhow!(
+                                    "unknown points subcommand `{other}` (try vertices|cell-centers|size)"
+                                ));
+                            }
                         }
-                        d.points_size_px = px;
                         Ok(())
                     },
                 ),
@@ -1506,14 +1945,77 @@ impl RotatePolytopesApp {
         // shorthand for "off" so the user can hide cap fills quickly when inspecting the
         // wireframe and cross-section perimeter on their own. Explicit `surface raster`
         // and `surface sdf` set those modes; `surface off` is the same as bare.
+        // `surface scale <N>` rescales every polychoron in the row by multiplying the
+        // canonical `BODY_SIZE` (see [`Demo::effective_body_size`]); default 1.0.
         c.register(
             rye_egui::cmd(
                 "surface",
-                "polychoral surface mode: raster | sdf | off (bare = off)",
-                |args, demo: &mut Demo, _out| {
+                "polychoral surface mode: raster | sdf | off (bare = off); `scale <N>` to resize",
+                |args, demo: &mut Demo, out| {
+                    if matches!(args.first().copied(), Some("scale")) {
+                        match args.get(1).copied() {
+                            None => {
+                                out.line(format!(
+                                    "surface scale: {:.3} (multiplies BODY_SIZE)",
+                                    demo.surface_scale
+                                ));
+                            }
+                            Some(token) => {
+                                let parsed: f32 = token.parse().map_err(|e| {
+                                    anyhow!("invalid scale `{token}`: {e}")
+                                })?;
+                                if !(0.05..=10.0).contains(&parsed) {
+                                    return Err(anyhow!(
+                                        "surface scale {parsed} out of range; expected 0.05..=10.0"
+                                    ));
+                                }
+                                demo.surface_scale = parsed;
+                                // Rebuild SDF body uniforms so the kernel sees the new
+                                // radius immediately; raster paths read effective_body_size()
+                                // every frame and don't need a rebuild.
+                                demo.rebuild_bodies();
+                                // Clamp the current w-slice into the new scaled range so
+                                // a shrink doesn't leave the slider off the visible body.
+                                let w_range = demo.effective_w_range();
+                                demo.w_slice = demo.w_slice.clamp(-w_range, w_range);
+                                out.line(format!(
+                                    "surface scale: set to {parsed:.3}"
+                                ));
+                            }
+                        }
+                        return Ok(());
+                    }
+                    if matches!(args.first().copied(), Some("alpha")) {
+                        match args.get(1).copied() {
+                            None => {
+                                out.line(format!(
+                                    "surface alpha: {:.3} ({} pipeline)",
+                                    demo.surface_alpha,
+                                    if demo.surface_alpha >= 1.0 {
+                                        "opaque"
+                                    } else {
+                                        "translucent"
+                                    }
+                                ));
+                            }
+                            Some(token) => {
+                                let parsed: f32 = token.parse().map_err(|e| {
+                                    anyhow!("invalid alpha `{token}`: {e}")
+                                })?;
+                                if !(0.05..=1.0).contains(&parsed) {
+                                    return Err(anyhow!(
+                                        "surface alpha {parsed} out of range; expected 0.05..=1.0 (use `surface off` for invisible)"
+                                    ));
+                                }
+                                demo.surface_alpha = parsed;
+                                out.line(format!("surface alpha: set to {parsed:.3}"));
+                            }
+                        }
+                        return Ok(());
+                    }
                     let next = match args.first().copied() {
                         Some(token) => SurfaceMode::from_token(token).ok_or_else(|| {
-                            anyhow!("unknown arg `{token}` (try raster|sdf|off)")
+                            anyhow!("unknown arg `{token}` (try raster|sdf|off|scale|alpha)")
                         })?,
                         None => SurfaceMode::Off,
                     };
@@ -1526,20 +2028,23 @@ impl RotatePolytopesApp {
                     Ok(())
                 },
             )
-            .with_args(&[&["raster", "sdf", "off"]])
+            .with_args(&[&["raster", "sdf", "off", "scale", "alpha"]])
             .with_long_help(
                 "Selects how the six regular convex 4-polytopes (5-cell, tesseract, 16-cell,\n\
-                 24-cell, 120-cell, 600-cell) are rendered.\n\
+                 24-cell, 120-cell, 600-cell) are rendered, plus runtime scale + alpha knobs.\n\
                  \n\
                  subcommands:\n  \
-                 raster  Rasterized cross-section cell-caps (the default). Face-normal Lambert\n                         lit, per-body solid color. Much faster for the 120-cell + 600-cell\n                         and exact (no SDF approximation).\n  \
-                 sdf     SDF raymarch. The historical pre-rasterizer path; smoother shading\n                         but the 120-cell and 600-cell carry a face-plane approximation BUG.\n                         Kept for visual comparison.\n  \
-                 off     No surface rendered. Wireframe overlay + cross-section perimeter\n                         stay visible if enabled; the cap interiors are blank. Useful for\n                         inspecting the wireframe on its own.\n\
+                 raster      Rasterized cross-section cell-caps (the default). Face-normal\n                             Lambert lit, per-body solid color. Much faster for the\n                             120-cell + 600-cell and exact (no SDF approximation).\n  \
+                 sdf         SDF raymarch. The historical pre-rasterizer path; smoother\n                             shading but the 120-cell and 600-cell carry a face-plane\n                             approximation BUG. Kept for visual comparison.\n  \
+                 off         No surface rendered. Wireframe overlay + cross-section\n                             perimeter stay visible if enabled; the cap interiors are\n                             blank. Useful for inspecting the wireframe on its own.\n  \
+                 scale <N>   Multiply the canonical body radius by N (default 1.0; range\n                             0.05..=10.0). Affects SDF kernel, raster cross-section caps,\n                             wireframe overlay, perimeter, and points sprites uniformly.\n  \
+                 alpha <N>   Section-faces opacity (default 1.0; range 0.05..=1.0). Below\n                             1.0 the cap renders through a no-depth-write pipeline so\n                             the parent wireframe behind composes through. Use `surface\n                             off` for fully invisible caps.\n\
                  \n\
                  Bare `surface` (no argument) is shorthand for `surface off`.\n\
                  \n\
                  Smooth-surface shapes (Clifford torus, duocylinder, spherinder, 3-sphere)\n\
-                 ignore this and always render via the SDF; they have no rasterizer path.",
+                 ignore the mode and always render via the SDF; they have no rasterizer\n\
+                 path. Surface scale still applies to their SDF body radius.",
             ),
         );
 
@@ -1576,11 +2081,87 @@ impl RotatePolytopesApp {
         // default distance + pitch so the camera returns to a known framing
         // around the world origin; `camera freecam` seeds the free-roam
         // position from the camera's current location.
+        //
+        // Freecam tuning subcommands (do NOT change mode):
+        //   `camera freecam speed=<N>`        WASD/Space/Shift units/sec.
+        //   `camera freecam speed`            Print the current speed.
+        //   `camera freecam cursor_mode <m>`  `toggle` (default, FPS) or `hold` (MMO).
+        //   `camera freecam cursor_mode`      Print the current mode.
         c.register(
             rye_egui::cmd::<Demo, _>(
                 "camera",
-                "camera mode: orbit (default) or freecam (WASD + mouse-look). Bare cycles.",
+                "camera mode: orbit | freecam; bare cycles. `camera freecam speed=<N>` / `cursor_mode hold|toggle` tune the preset",
                 |args, demo, out| {
+                    // Freecam-tuning forms have a second positional token.
+                    // `speed=<N>` is parsed as one token (matches the user's
+                    // `speed=<N>` spec); `speed` alone queries; `cursor_mode
+                    // <m>` is two tokens.
+                    if matches!(args.first().copied(), Some("freecam")) && args.len() >= 2 {
+                        let second = args[1];
+                        // `speed=<N>` and `speed <N>` and bare `speed`.
+                        if let Some(value) = second.strip_prefix("speed=") {
+                            let parsed: f32 = value
+                                .parse()
+                                .map_err(|e| anyhow!("invalid speed `{value}`: {e}"))?;
+                            if !(0.1..=200.0).contains(&parsed) {
+                                return Err(anyhow!(
+                                    "camera freecam speed {parsed} out of range; expected 0.1..=200.0"
+                                ));
+                            }
+                            demo.freecam.speed = parsed;
+                            out.line(format!("camera freecam speed: set to {parsed:.2} u/sec"));
+                            return Ok(());
+                        }
+                        if second == "speed" {
+                            if let Some(value) = args.get(2) {
+                                let parsed: f32 = value.parse().map_err(|e| {
+                                    anyhow!("invalid speed `{value}`: {e}")
+                                })?;
+                                if !(0.1..=200.0).contains(&parsed) {
+                                    return Err(anyhow!(
+                                        "camera freecam speed {parsed} out of range; expected 0.1..=200.0"
+                                    ));
+                                }
+                                demo.freecam.speed = parsed;
+                                out.line(format!(
+                                    "camera freecam speed: set to {parsed:.2} u/sec"
+                                ));
+                            } else {
+                                out.line(format!(
+                                    "camera freecam speed: {:.2} u/sec",
+                                    demo.freecam.speed
+                                ));
+                            }
+                            return Ok(());
+                        }
+                        if second == "cursor_mode" {
+                            match args.get(2).copied() {
+                                None => {
+                                    out.line(format!(
+                                        "camera freecam cursor_mode: {}",
+                                        demo.freecam.cursor_mode().token()
+                                    ));
+                                }
+                                Some(token) => {
+                                    let mode = CursorMode::from_token(token).ok_or_else(|| {
+                                        anyhow!(
+                                            "unknown cursor_mode `{token}` (try hold|toggle)"
+                                        )
+                                    })?;
+                                    demo.freecam.set_cursor_mode(mode);
+                                    out.line(format!(
+                                        "camera freecam cursor_mode: set to {}",
+                                        mode.token()
+                                    ));
+                                }
+                            }
+                            return Ok(());
+                        }
+                        // Unknown second token under `camera freecam`: fall
+                        // through to the mode-switch path which will yell
+                        // about it.
+                    }
+
                     let next = match args.first().copied() {
                         None => match demo.camera_mode {
                             CameraMode::Orbit => CameraMode::FreeRoam,
@@ -1620,16 +2201,44 @@ impl RotatePolytopesApp {
                     Ok(())
                 },
             )
-            .with_args(&[&["orbit", "freecam"]]),
+            .with_args(&[
+                &["orbit", "freecam"],
+                &["speed=", "cursor_mode"],
+                &["hold", "toggle"],
+            ]),
         );
 
-        // The `floor` toggle the user asked for is deferred. The SDF ground
-        // (a y=0 HalfSpace4D in the scene composition) is baked into the
-        // shader module at App::setup time via `Scene4::to_hyperslice_wgsl`,
-        // so toggling visibility at runtime requires either recompiling the
-        // shader (cheap, ~100-300ms wasm) or adding a kernel-uniform flag to
-        // rye-scene (cheaper per-toggle but engine-level work). Tracked as
-        // follow-up; not part of this polish pass.
+        // Floor toggle for the y=0 hyperplane ground. On by default. The
+        // SDF kernel reads `u.params[0]` (set in `Demo::update`); when 0.0
+        // the wrapper around `rye_scene_sdf` (injected into the shader at
+        // setup time) short-circuits to a huge distance, so the marcher
+        // never converges on the floor and the checkerboard never paints.
+        // Bare `floor` flips the flag; `floor on|off` is the explicit form.
+        c.register(
+            rye_egui::cmd::<Demo, _>(
+                "floor",
+                "toggle the y=0 hyperplane ground (on | off; bare flips)",
+                |args, demo, out| {
+                    let next = match args.first().copied() {
+                        None => !demo.floor_enabled,
+                        Some("on") => true,
+                        Some("off") => false,
+                        Some(other) => {
+                            return Err(anyhow!(
+                                "floor: unknown arg `{other}` (try on|off)"
+                            ));
+                        }
+                    };
+                    demo.floor_enabled = next;
+                    out.line(format!(
+                        "floor: {}",
+                        if next { "on" } else { "off" }
+                    ));
+                    Ok(())
+                },
+            )
+            .with_args(&[&["on", "off"]]),
+        );
 
         c
     }
@@ -1646,6 +2255,7 @@ impl App for RotatePolytopesApp {
             console,
             last_egui_keyboard: false,
             capture_panel: rye_app::capture::CapturePanel::new(),
+            perf: rye_app::trace::PerfOverlay::new(),
         })
     }
 
@@ -1660,6 +2270,10 @@ impl App for RotatePolytopesApp {
     fn ui(&mut self, ctx: &egui::Context, frame: &mut FrameCtx<'_>) {
         self.demo.ui(ctx, frame);
         self.capture_panel.show(ctx);
+        // F3-toggle perf overlay (FPS / frame-time / between-frames). Reads
+        // its hotkey state from the same egui Context the rest of the UI uses,
+        // so the demo doesn't need to forward F3. Cheap when hidden.
+        self.perf.show(ctx);
         // Pump any pending tracing events into the console scrollback BEFORE rendering
         // it, so the user sees mirrored log lines this frame instead of next.
         rye_app::log::pump_into(&mut self.console);
@@ -1724,6 +2338,227 @@ fn main() -> Result<()> {
 //
 // `egui::Context` works fine without a renderer for layout-only
 // tests; nothing here touches the GPU.
+
+#[cfg(test)]
+mod color_tests {
+    //! Unit tests for the pure color/topology helpers used by `render_wireframe_overlay`
+    //! and `render_points`. These are load-bearing primitives behind every wireframe
+    //! color mode; a sign flip or off-by-one would slip past clippy + the GPU-side
+    //! kernel parse tests.
+    use super::*;
+
+    // ---- hsv_to_rgb ------------------------------------------------------
+
+    /// HSV anchor cases against the standard reference. h=0 -> red, h=1/3 -> green,
+    /// h=2/3 -> blue. Saturation 1, value 1, so output is the pure primary.
+    #[test]
+    fn hsv_to_rgb_primaries() {
+        let red = hsv_to_rgb(0.0, 1.0, 1.0);
+        assert!((red[0] - 1.0).abs() < 1e-5);
+        assert!(red[1].abs() < 1e-5);
+        assert!(red[2].abs() < 1e-5);
+
+        let green = hsv_to_rgb(1.0 / 3.0, 1.0, 1.0);
+        assert!(green[0].abs() < 1e-5);
+        assert!((green[1] - 1.0).abs() < 1e-5);
+        assert!(green[2].abs() < 1e-5);
+
+        let blue = hsv_to_rgb(2.0 / 3.0, 1.0, 1.0);
+        assert!(blue[0].abs() < 1e-5);
+        assert!(blue[1].abs() < 1e-5);
+        assert!((blue[2] - 1.0).abs() < 1e-5);
+    }
+
+    /// Zero saturation collapses to gray regardless of hue: r == g == b == value.
+    #[test]
+    fn hsv_to_rgb_zero_saturation_is_gray() {
+        for h in [0.0, 0.25, 0.5, 0.75, 0.999_f32] {
+            let rgb = hsv_to_rgb(h, 0.0, 0.7);
+            assert!((rgb[0] - 0.7).abs() < 1e-5, "h={h}: r should be 0.7");
+            assert!((rgb[1] - 0.7).abs() < 1e-5, "h={h}: g should be 0.7");
+            assert!((rgb[2] - 0.7).abs() < 1e-5, "h={h}: b should be 0.7");
+        }
+    }
+
+    /// Zero value collapses to black regardless of hue/saturation.
+    #[test]
+    fn hsv_to_rgb_zero_value_is_black() {
+        let rgb = hsv_to_rgb(0.5, 0.8, 0.0);
+        assert!(rgb.iter().all(|c| c.abs() < 1e-5));
+    }
+
+    // ---- unique_edge_palette --------------------------------------------
+
+    /// Adjacent edges (sharing a vertex) get different palette colors. This is the
+    /// defining invariant of the greedy graph-coloring on the line graph; if it
+    /// fails, the whole point of the mode is broken.
+    #[test]
+    fn unique_edge_palette_separates_adjacent_edges() {
+        // A simple line graph: three edges meeting at vertex 0.
+        //     1
+        //     |
+        // 2 - 0 - 3
+        let edges: &[[u32; 2]] = &[[0, 1], [0, 2], [0, 3]];
+        let palette = unique_edge_palette(edges);
+        assert_eq!(palette.len(), 3, "one color per edge");
+        // All three edges share vertex 0, so all three must be distinct in the line graph.
+        for i in 0..palette.len() {
+            for j in (i + 1)..palette.len() {
+                assert_ne!(
+                    palette[i], palette[j],
+                    "edges {i} and {j} share vertex 0; palette must differ"
+                );
+            }
+        }
+    }
+
+    /// Edges with no shared vertex are NOT adjacent in the line graph and CAN end up
+    /// sharing palette indices (greedy first-fit will reuse index 0 for both).
+    #[test]
+    fn unique_edge_palette_non_adjacent_edges_may_share_color() {
+        // Two disconnected edges: (0,1) and (2,3). No shared vertex.
+        let edges: &[[u32; 2]] = &[[0, 1], [2, 3]];
+        let palette = unique_edge_palette(edges);
+        assert_eq!(palette.len(), 2);
+        // Greedy first-fit assigns index 0 to both since they're not adjacent.
+        assert_eq!(palette[0], palette[1]);
+    }
+
+    /// Determinism: calling twice on the same edge slice yields identical output.
+    /// Critical for caching by `Polytope4` variant (`unique_edge_palette_cache`).
+    #[test]
+    fn unique_edge_palette_is_deterministic() {
+        let edges: &[[u32; 2]] = &[[0, 1], [1, 2], [2, 3], [0, 3]];
+        let a = unique_edge_palette(edges);
+        let b = unique_edge_palette(edges);
+        assert_eq!(a, b);
+    }
+
+    // ---- w_depth_color --------------------------------------------------
+
+    /// At w = 0 (the slice plane), the color sits exactly midway between back and front.
+    /// `t = 0.5` means RGB is the literal midpoint of W_DEPTH_BACK and W_DEPTH_FRONT.
+    #[test]
+    fn w_depth_color_zero_w_is_midpoint() {
+        let c = w_depth_color(0.0, 1.0);
+        for ch in 0..3 {
+            let expected = (W_DEPTH_BACK[ch] + W_DEPTH_FRONT[ch]) * 0.5;
+            assert!(
+                (c[ch] - expected).abs() < 1e-5,
+                "channel {ch}: expected {expected}, got {}",
+                c[ch],
+            );
+        }
+        assert!((c[3] - 1.0).abs() < 1e-5, "alpha is 1.0");
+    }
+
+    /// At w = -extent the color is the back tint (cool blue).
+    #[test]
+    fn w_depth_color_neg_extent_is_back() {
+        let c = w_depth_color(-1.0, 1.0);
+        for ch in 0..3 {
+            assert!(
+                (c[ch] - W_DEPTH_BACK[ch]).abs() < 1e-5,
+                "channel {ch}: expected back tint",
+            );
+        }
+    }
+
+    /// At w = +extent the color is the front tint (warm orange).
+    #[test]
+    fn w_depth_color_pos_extent_is_front() {
+        let c = w_depth_color(1.0, 1.0);
+        for ch in 0..3 {
+            assert!(
+                (c[ch] - W_DEPTH_FRONT[ch]).abs() < 1e-5,
+                "channel {ch}: expected front tint",
+            );
+        }
+    }
+
+    /// Vertices past the extent (a polytope canonical max underestimate, or
+    /// numeric drift) clamp to the endpoint colors rather than over-saturating.
+    #[test]
+    fn w_depth_color_clamps_past_extent() {
+        let c_far = w_depth_color(5.0, 1.0);
+        let c_at_extent = w_depth_color(1.0, 1.0);
+        assert_eq!(c_far, c_at_extent, "+w past extent should clamp to front");
+
+        let c_back = w_depth_color(-5.0, 1.0);
+        let c_at_neg_extent = w_depth_color(-1.0, 1.0);
+        assert_eq!(c_back, c_at_neg_extent, "-w past extent should clamp to back");
+    }
+
+    // ---- compute_cell_strengths -----------------------------------------
+
+    /// Slice at the cell's w-midpoint produces strength = 1 (cap is widest there).
+    #[test]
+    fn cell_strength_at_midpoint_is_one() {
+        // Single cell with two vertices at w = -0.5 and w = +0.5. Midpoint w = 0.
+        let cells: [&[u32]; 1] = [&[0, 1]];
+        let local_vertices = [
+            glam::Vec4::new(0.0, 0.0, 0.0, -0.5),
+            glam::Vec4::new(0.0, 0.0, 0.0, 0.5),
+        ];
+        let strengths = compute_cell_strengths(&cells, &local_vertices, 0.0);
+        assert_eq!(strengths.len(), 1);
+        assert!((strengths[0] - 1.0).abs() < 1e-5);
+    }
+
+    /// Slice outside the cell's w-range produces strength = 0 (cap doesn't exist).
+    #[test]
+    fn cell_strength_outside_range_is_zero() {
+        let cells: [&[u32]; 1] = [&[0, 1]];
+        let local_vertices = [
+            glam::Vec4::new(0.0, 0.0, 0.0, -0.5),
+            glam::Vec4::new(0.0, 0.0, 0.0, 0.5),
+        ];
+        let strengths = compute_cell_strengths(&cells, &local_vertices, 5.0);
+        assert!(strengths[0].abs() < 1e-5);
+    }
+
+    /// Slice at the cell's w-boundary produces strength = 0 (cap is degenerate).
+    #[test]
+    fn cell_strength_at_boundary_is_zero() {
+        let cells: [&[u32]; 1] = [&[0, 1]];
+        let local_vertices = [
+            glam::Vec4::new(0.0, 0.0, 0.0, -0.5),
+            glam::Vec4::new(0.0, 0.0, 0.0, 0.5),
+        ];
+        // Slice exactly at the +w extreme: dist = 0.5, half_extent = 0.5,
+        // strength = 1 - 1 = 0.
+        let strengths = compute_cell_strengths(&cells, &local_vertices, 0.5);
+        assert!(strengths[0].abs() < 1e-5);
+    }
+
+    /// Halfway between midpoint and boundary yields strength = 0.5 (linear in
+    /// `|w_slice - mid| / half_extent`).
+    #[test]
+    fn cell_strength_is_linear() {
+        let cells: [&[u32]; 1] = [&[0, 1]];
+        let local_vertices = [
+            glam::Vec4::new(0.0, 0.0, 0.0, -0.5),
+            glam::Vec4::new(0.0, 0.0, 0.0, 0.5),
+        ];
+        // midpoint = 0, half_extent = 0.5; slice at 0.25 -> dist 0.25 -> 1 - 0.5 = 0.5.
+        let strengths = compute_cell_strengths(&cells, &local_vertices, 0.25);
+        assert!((strengths[0] - 0.5).abs() < 1e-5);
+    }
+
+    /// Degenerate cell (all vertices at the same w) yields strength = 0; the half-extent
+    /// is zero so the gradient has nothing to interpolate. The function returns 0 rather
+    /// than divide-by-zero, which is what the wireframe overlay path expects.
+    #[test]
+    fn cell_strength_degenerate_cell_is_zero() {
+        let cells: [&[u32]; 1] = [&[0, 1]];
+        let local_vertices = [
+            glam::Vec4::new(0.0, 0.0, 0.0, 0.0),
+            glam::Vec4::new(1.0, 0.0, 0.0, 0.0),
+        ];
+        let strengths = compute_cell_strengths(&cells, &local_vertices, 0.0);
+        assert!(strengths[0].abs() < 1e-5);
+    }
+}
 
 #[cfg(test)]
 mod alignment_tests {

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -272,6 +272,7 @@ impl Demo {
             free_roam,
             free_roam_pos,
             camera_mode: CameraMode::default(),
+            cursor_grabbed: false,
             node,
             section_edges,
             parent_wireframe,
@@ -436,10 +437,14 @@ impl Demo {
                     self.orbit
                         .advance(ctx.input, &mut self.camera, &EuclideanR3, dt_secs);
                 }
-                CameraMode::FreeRoam => {
-                    // Mouse-look + WASD translation. Mirror tesseract_demo's
-                    // pattern: controller handles look; we integrate position
-                    // here from the drained input axes.
+                // Freecam advances only while the cursor is grabbed. Alt
+                // releases the grab for UI interaction; while ungrabbed,
+                // the camera holds still so the user can click + drag UI
+                // widgets without the scene panning underneath them.
+                CameraMode::FreeRoam if self.cursor_grabbed => {
+                    // Mouse-look + WASD translation. Controller handles
+                    // look (consuming raw mouse delta via use_raw_delta);
+                    // position integrates from the drained input axes.
                     self.free_roam
                         .advance(ctx.input, &mut self.camera, &EuclideanR3, dt_secs);
                     const FREECAM_SPEED: f32 = 4.5; // units/sec
@@ -451,6 +456,10 @@ impl Demo {
                         self.free_roam_pos += delta * FREECAM_SPEED * dt_secs;
                         self.camera.position = self.free_roam_pos;
                     }
+                }
+                CameraMode::FreeRoam => {
+                    // Cursor released (Alt held the toggle): no-op so the
+                    // user can interact with UI without the scene moving.
                 }
             }
         }
@@ -671,13 +680,36 @@ impl Demo {
             KeyCode::ArrowRight => self.slider_right_held = pressed,
             KeyCode::KeyR if pressed => self.reset(),
             KeyCode::KeyH if pressed => self.show_controls = !self.show_controls,
-            KeyCode::KeyT | KeyCode::Space if pressed => {
-                // Pause / resume only, DO NOT touch rot_state. The
-                // bodies keep their current orientation when paused
-                // and resume from there when toggled back on. Both
-                // T (legacy) and Space (media-player convention)
-                // bind to the same toggle.
+            KeyCode::KeyT if pressed => {
+                // Pause / resume only, DO NOT touch rot_state. The bodies
+                // keep their current orientation when paused and resume
+                // from there when toggled back on.
                 self.rotate = !self.rotate;
+            }
+            // Space ALSO toggles rotation, but only outside freecam mode.
+            // In freecam Space is bound to the move-up axis (Space = +1
+            // on `FrameInput::move_up`); rotating-on-Space would conflict.
+            // T remains the always-available rotation toggle for freecam
+            // users.
+            KeyCode::Space
+                if pressed && !matches!(self.camera_mode, CameraMode::FreeRoam) =>
+            {
+                self.rotate = !self.rotate;
+            }
+            // Alt toggles the cursor grab while in freecam: hidden +
+            // confined for mouse-look, visible + free for UI interaction.
+            // Mode stays FreeRoam either way; only the grab flips. Outside
+            // freecam Alt is a no-op (cursor is never grabbed there).
+            KeyCode::AltLeft | KeyCode::AltRight
+                if pressed && matches!(self.camera_mode, CameraMode::FreeRoam) =>
+            {
+                self.cursor_grabbed = !self.cursor_grabbed;
+                if self.cursor_grabbed {
+                    rye_app::cursor::request_grab();
+                } else {
+                    rye_app::cursor::request_release();
+                }
+                self.free_roam.use_raw_delta = self.cursor_grabbed;
             }
             // Plane toggles. Sum-of-bivectors composition is
             // commutative, so the order in which planes are toggled
@@ -1594,18 +1626,27 @@ impl RotatePolytopesApp {
                         CameraMode::Orbit => {
                             // Reset orbit so the camera returns to a known
                             // framing around (0, 0, 0) regardless of where
-                            // freecam left it.
+                            // freecam left it. Release the cursor grab; the
+                            // UI is interactive again, mouse-look is off.
                             demo.orbit = OrbitController::default();
                             demo.orbit.set_orbit(9.5, -0.25);
+                            demo.cursor_grabbed = false;
+                            demo.free_roam.use_raw_delta = false;
+                            rye_app::cursor::request_release();
                             out.line("camera: orbit (reset to world origin)");
                         }
                         CameraMode::FreeRoam => {
                             // Seed freecam from the camera's current pose so
                             // the toggle feels continuous instead of
-                            // teleporting.
+                            // teleporting. Grab the cursor so panning works
+                            // past the screen edge; user presses Alt to
+                            // release for UI access.
                             demo.free_roam_pos = demo.camera.position;
+                            demo.cursor_grabbed = true;
+                            demo.free_roam.use_raw_delta = true;
+                            rye_app::cursor::request_grab();
                             out.line(
-                                "camera: freecam (WASD + Space/Shift; drag to look)",
+                                "camera: freecam (WASD + Space/Shift; mouse-look; Alt to free cursor)",
                             );
                         }
                     }

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -493,7 +493,7 @@ impl Demo {
         // can serve a stale page+script combination otherwise. F3's perf
         // overlay shows fps + framebuffer size when that data is wanted.
         let build_label = format!(
-            "{}{}",
+            "version: {}{}",
             env!("BUILD_HASH"),
             env!("BUILD_DIRTY"),
         );

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -8,7 +8,8 @@
 //! `pub(crate)` so those sibling impls can access them directly without
 //! per-field accessors.
 
-use rye_app::{Camera, OrbitController};
+use glam::Vec3;
+use rye_app::{Camera, FirstPersonController, OrbitController};
 use rye_math::{Bivector4, EuclideanR3, Plane4, Rotor4};
 use rye_render::raymarch::{BodyUniform, Hyperslice4DNode};
 
@@ -162,6 +163,22 @@ impl WireframeColorMode {
             _ => None,
         }
     }
+}
+
+/// Camera control mode. `Orbit` is the default scroll-zoom/drag-to-rotate camera that
+/// stays focused on the world origin (where the polytope bodies sit). `FreeRoam` lets
+/// the user fly the camera around via WASD + mouse-look; useful for inspecting the
+/// 120-cell / 600-cell from arbitrary angles without orbiting through the floor.
+///
+/// Toggle via the `camera` console command: bare `camera` cycles, `camera orbit` /
+/// `camera freecam` set explicitly. Switching to `Orbit` resets the orbit controller
+/// to its default distance + pitch so the camera returns to a known framing instead
+/// of inheriting wherever FreeRoam ended.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) enum CameraMode {
+    #[default]
+    Orbit,
+    FreeRoam,
 }
 
 // ---------------------------------------------------------------------------
@@ -324,6 +341,19 @@ pub(crate) struct Demo {
     pub(crate) space: EuclideanR3,
     pub(crate) camera: Camera<EuclideanR3>,
     pub(crate) orbit: OrbitController<EuclideanR3>,
+    /// Free-roam controller for the WASD + mouse-look camera mode. Coexists with
+    /// `orbit` so toggling between modes preserves each controller's internal
+    /// state (orbit's distance/pitch, freecam's yaw/pitch). Only the active mode
+    /// advances against input each frame.
+    pub(crate) free_roam: FirstPersonController<EuclideanR3>,
+    /// World-space position the camera holds in `FreeRoam` mode. The controller
+    /// only handles look direction (right/up/forward); position is integrated
+    /// here from `move_forward / move_right / move_up` axes in the per-frame
+    /// update.
+    pub(crate) free_roam_pos: Vec3,
+    /// Active camera control mode. Default `Orbit` matches the long-standing
+    /// behavior; `FreeRoam` is opt-in via the `camera` console command.
+    pub(crate) camera_mode: CameraMode,
     pub(crate) node: Hyperslice4DNode,
     /// Rasterizer node for the cross-section perimeter (bright cyan edges around each
     /// cap polygon). Filled caps are NOT drawn -- the SDF raymarcher already renders the
@@ -457,9 +487,9 @@ pub(crate) struct Demo {
     /// the polytope rotates. Off by default; opened from `View > Example callout`
     /// (and toggleable via the console `callout` command).
     ///
-    /// Hosts the `rye_egui::callout` primitive added in the M4-close mini-sprint;
-    /// future tutorial / explanation overlays in the playground will instantiate
-    /// additional `CalloutState`s the same way.
+    /// Hosts the `rye_egui::callout` primitive; future tutorial / explanation
+    /// overlays in the playground will instantiate additional `CalloutState`s
+    /// the same way.
     pub(crate) example_callout: rye_egui::CalloutState,
 
     /// Cached natural overlay width on first frame. Used as the fixed width of the

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -8,8 +8,7 @@
 //! `pub(crate)` so those sibling impls can access them directly without
 //! per-field accessors.
 
-use glam::Vec3;
-use rye_app::{Camera, FirstPersonController, OrbitController};
+use rye_app::{freecam::Freecam, Camera, OrbitController};
 use rye_math::{Bivector4, EuclideanR3, Plane4, Rotor4};
 use rye_render::raymarch::{BodyUniform, Hyperslice4DNode};
 
@@ -341,27 +340,17 @@ pub(crate) struct Demo {
     pub(crate) space: EuclideanR3,
     pub(crate) camera: Camera<EuclideanR3>,
     pub(crate) orbit: OrbitController<EuclideanR3>,
-    /// Free-roam controller for the WASD + mouse-look camera mode. Coexists with
-    /// `orbit` so toggling between modes preserves each controller's internal
-    /// state (orbit's distance/pitch, freecam's yaw/pitch). Only the active mode
-    /// advances against input each frame.
-    pub(crate) free_roam: FirstPersonController<EuclideanR3>,
-    /// World-space position the camera holds in `FreeRoam` mode. The controller
-    /// only handles look direction (right/up/forward); position is integrated
-    /// here from `move_forward / move_right / move_up` axes in the per-frame
-    /// update.
-    pub(crate) free_roam_pos: Vec3,
-    /// Active camera control mode. Default `Orbit` matches the long-standing
-    /// behavior; `FreeRoam` is opt-in via the `camera` console command.
+    /// Freecam preset (mouse-look + WASD + cursor grab). Drives the
+    /// camera in `CameraMode::FreeRoam`; the orbit controller drives it
+    /// in `CameraMode::Orbit`. The preset owns its own yaw, pitch,
+    /// position, and cursor-grab state internally; the demo reads
+    /// `freecam.active()` / `freecam.cursor_grabbed()` rather than
+    /// mirroring those flags.
+    pub(crate) freecam: Freecam,
+    /// Active camera control mode. Default `Orbit` matches the long-
+    /// standing behavior; `FreeRoam` is opt-in via the `camera` console
+    /// command.
     pub(crate) camera_mode: CameraMode,
-    /// Whether the cursor is currently grabbed (hidden + confined to the
-    /// window). Set to `true` when entering FreeRoam; toggleable within
-    /// FreeRoam via Alt for UI access. Reset to `false` when leaving
-    /// FreeRoam. Drives both the runtime cursor visibility (via
-    /// `rye_app::cursor::request_*`) and the `FirstPersonController`'s
-    /// `use_raw_delta` flag (raw motion past the screen edge keeps panning
-    /// alive when the cursor is grabbed).
-    pub(crate) cursor_grabbed: bool,
     pub(crate) node: Hyperslice4DNode,
     /// Rasterizer node for the cross-section perimeter (bright cyan edges around each
     /// cap polygon). Filled caps are NOT drawn -- the SDF raymarcher already renders the

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -354,6 +354,14 @@ pub(crate) struct Demo {
     /// Active camera control mode. Default `Orbit` matches the long-standing
     /// behavior; `FreeRoam` is opt-in via the `camera` console command.
     pub(crate) camera_mode: CameraMode,
+    /// Whether the cursor is currently grabbed (hidden + confined to the
+    /// window). Set to `true` when entering FreeRoam; toggleable within
+    /// FreeRoam via Alt for UI access. Reset to `false` when leaving
+    /// FreeRoam. Drives both the runtime cursor visibility (via
+    /// `rye_app::cursor::request_*`) and the `FirstPersonController`'s
+    /// `use_raw_delta` flag (raw motion past the screen edge keeps panning
+    /// alive when the cursor is grabbed).
+    pub(crate) cursor_grabbed: bool,
     pub(crate) node: Hyperslice4DNode,
     /// Rasterizer node for the cross-section perimeter (bright cyan edges around each
     /// cap polygon). Filled caps are NOT drawn -- the SDF raymarcher already renders the

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -8,8 +8,11 @@
 //! `pub(crate)` so those sibling impls can access them directly without
 //! per-field accessors.
 
+use std::collections::HashMap;
+
 use rye_app::{freecam::Freecam, Camera, OrbitController};
 use rye_math::{Bivector4, EuclideanR3, Plane4, Rotor4};
+use rye_physics::polytope::Polytope4;
 use rye_render::raymarch::{BodyUniform, Hyperslice4DNode};
 
 use crate::catalog::ShapeEntry;
@@ -137,13 +140,29 @@ impl WireframeProjection {
 /// nearest-active toggle then modulates alpha on top.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub(crate) enum WireframeColorMode {
-    /// Per-vertex RGB from [`rye_physics::polytope::vertex_color_by_position`]: a
-    /// continuous color field over the polytope's vertex set that flows smoothly
-    /// across the edge graph and reveals symmetry as color gradients. Every vertex
-    /// picks up a distinct hue from its 4D coordinates, so the polytope reads as a
-    /// stylized colorful identity rather than a uniform mass of edges.
+    /// Per-vertex RGB from [`rye_physics::polytope::vertex_color_by_position`]:
+    /// each edge is shaded as a smooth gradient between its two endpoint vertex
+    /// colors, and the canonical vertex hue is derived from the vertex's 4D
+    /// coordinate. The polytope's symmetry shows up as continuous color flow
+    /// across the edge graph (same scheme as `Polytope4::lines_colored_by_position`).
     #[default]
-    Unique,
+    VertexGradient,
+    /// Each edge gets a distinct solid RGB color via greedy graph-coloring on
+    /// the polytope's line graph: edges sharing a vertex always end up with
+    /// different palette indices, so the local edge structure stays visually
+    /// separable at any zoom level. Palette is deterministic (golden-ratio
+    /// hue spacing) so the same shape always paints the same edges the same way.
+    UniqueEdge,
+    /// Per-vertex color by SIGNED `w` in the body-local frame: cool blue
+    /// at extreme `-w`, warm orange at extreme `+w`, near-neutral at the
+    /// slice plane. Normalized against the polytope's canonical max `|w|`
+    /// (a fixed band per shape, NOT a per-frame rotated extent), so the
+    /// gradient stays temporally stable as the rotor spins. Mirrors the
+    /// `LineRasterStaticR4` shader's depth cue in `tesseract_demo`: a
+    /// tesseract under xy/zw rotation paints inner cube blue + outer
+    /// cube orange + connecting edges as smooth blue-to-orange gradients,
+    /// making the w-depth migration visible regardless of camera angle.
+    WDepth,
     /// Binary green/gray by cell activity: edges that belong to at least one cell
     /// the slice is *currently* intersecting are bright green; all other edges are
     /// dim neutral gray. Reads as "which cells of the polytope am I looking at right
@@ -153,13 +172,33 @@ pub(crate) enum WireframeColorMode {
 }
 
 impl WireframeColorMode {
-    /// Parse a console-arg spelling (`unique` or `active`). Returns `None` for any
-    /// other input; the caller surfaces a usage error.
+    /// All four modes in console-cycle order.
+    pub(crate) const ALL: [Self; 4] = [
+        Self::VertexGradient,
+        Self::UniqueEdge,
+        Self::WDepth,
+        Self::Active,
+    ];
+
+    /// Parse a console-arg spelling. Returns `None` for any unknown input;
+    /// the caller surfaces a usage error.
     pub(crate) fn from_token(token: &str) -> Option<Self> {
         match token {
-            "unique" => Some(WireframeColorMode::Unique),
-            "active" => Some(WireframeColorMode::Active),
+            "vertex-gradient" => Some(Self::VertexGradient),
+            "unique-edge" => Some(Self::UniqueEdge),
+            "w-depth" => Some(Self::WDepth),
+            "active" => Some(Self::Active),
             _ => None,
+        }
+    }
+
+    /// Display label for the egui radio buttons.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::VertexGradient => "Vertex gradient",
+            Self::UniqueEdge => "Unique edge",
+            Self::WDepth => "W-depth",
+            Self::Active => "Active",
         }
     }
 }
@@ -386,12 +425,60 @@ pub(crate) struct Demo {
     /// always uses drop-w (mathematically the inhabitant's view of the slice 3-flat);
     /// this toggle only affects the dim wireframe overlay on top.
     pub(crate) wireframe_projection: WireframeProjection,
+    /// Pixel width of parent-wireframe edges. Tuneable via `wireframe width <N>`
+    /// for thicker lines on screenshots. Default bumped from 1.2 px to 1.8 px
+    /// after side-by-side comparison: 1.2 px was too fine to read clearly
+    /// against the SDF backdrop on hi-DPI displays.
+    pub(crate) wireframe_width_px: f32,
+    /// Uniform alpha applied to every parent-wireframe edge when
+    /// [`Self::wireframe_nearest_active`] is OFF. Default 1.0 (fully
+    /// opaque). Tuneable via `wireframe alpha <N>` for a low-key
+    /// "wireframe as background layer" look. Ignored when
+    /// `nearest_active` is ON; in that mode the alpha is driven by the
+    /// per-cell crossing strength (DIM 0.10 to BRIGHT 0.85) regardless
+    /// of this field.
+    pub(crate) wireframe_alpha: f32,
+    /// Memoized per-edge palette for the `unique-edge` wireframe color
+    /// mode, keyed by [`Polytope4`] variant. The palette is a function of
+    /// topology alone (greedy graph-coloring on the line graph), so once
+    /// computed it stays valid for the process lifetime regardless of
+    /// rotor / w_slice / surface scale. Computed on first use; an empty
+    /// cache means the demo has never visited `unique-edge` mode for the
+    /// row's current shapes.
+    pub(crate) unique_edge_palette_cache: HashMap<Polytope4, Vec<[f32; 4]>>,
+    /// Runtime multiplier on [`BODY_SIZE`] for all polychora in the row.
+    /// Set via `surface scale <N>` (default 1.0). Multiplies wireframe, SDF,
+    /// section perimeter, and cross-section cap-fill geometry uniformly so
+    /// the slice-of-the-same-shape stays consistent at any scale. Values in
+    /// (0, 10] are accepted; the upper bound exists to keep the SDF
+    /// marcher's bounded-w-slice assumption intact.
+    pub(crate) surface_scale: f32,
+    /// Per-fragment alpha for the rasterized section-faces (filled cross-
+    /// section cell-caps). Default 1.0 (fully opaque); `surface alpha <N>`
+    /// lowers it so the parent wireframe shows through. Independent of
+    /// `wireframe_nearest_active` (which only modulates wireframe-edge
+    /// alpha, not the surface). Accepted range `(0, 1]`; the lower bound
+    /// is open since 0.0 would just hide the surface entirely (use
+    /// `surface off` for that).
+    pub(crate) surface_alpha: f32,
+    /// `y = 0` hyperplane floor visibility (the gridded ground). On by
+    /// default; toggled via the `floor` console command. Gated at the
+    /// kernel via `u.params[0]` so the toggle is zero-cost: when off, the
+    /// scene's halfspace SDF returns a huge distance and the marcher
+    /// never converges on the floor, so the checkerboard never paints.
+    pub(crate) floor_enabled: bool,
     /// Filled-faces rasterizer for the cross-section of every polychoral body. When
     /// `Self::surface_raster_enabled` is `true`, this replaces the SDF raymarch for the
     /// six regular convex 4-polytopes: the SDF gets `BodyUniform::default()` for those
     /// slots (which the kernel skips) and the section's filled cell-caps come through
     /// here instead. Per-body solid color + face-normal Lambert in the fragment shader.
     pub(crate) section_faces: rye_render::TriangleRasterNode,
+    /// Translucent variant of [`Self::section_faces`] with depth-write
+    /// disabled. Used in place of `section_faces` when `surface_alpha`
+    /// drops below 1.0 so the parent wireframe can show through caps.
+    /// Same vertex/fragment shaders + blend state; the only delta is the
+    /// `DepthMode::ReadOnly` pipeline-bake.
+    pub(crate) section_faces_translucent: rye_render::TriangleRasterNode,
     /// Antialiased point-disc rasterizer for vertex markers and cell-center sprites.
     /// Constructed once during demo setup; uploaded with the combined point mesh each
     /// frame the points overlay is enabled.
@@ -610,10 +697,29 @@ impl Demo {
         BodyUniform::polytope_with_rotor(
             body_position(slot, n),
             entry.shape.shape_id(),
-            BODY_SIZE,
+            self.effective_body_size(),
             rotor,
             entry.body_color,
         )
+    }
+
+    /// Effective body radius after the runtime [`Self::surface_scale`]
+    /// multiplier. All consumers that previously read `BODY_SIZE` directly
+    /// should route through here so the `surface scale` command takes
+    /// effect uniformly across SDF, wireframe, section perimeter, and
+    /// cross-section caps.
+    pub(crate) fn effective_body_size(&self) -> f32 {
+        BODY_SIZE * self.surface_scale
+    }
+
+    /// Effective `w` slider half-range after [`Self::surface_scale`]. The
+    /// canonical [`crate::consts::W_RANGE`] covers a unit-circumradius
+    /// polytope's full w-extent with a small margin; scaling the polytope up
+    /// requires the same scaling on the slider so the slice plane still leaves
+    /// the body at the extremes (otherwise `surface scale 4.0` would cap the
+    /// slider before w reaches the body's hull).
+    pub(crate) fn effective_w_range(&self) -> f32 {
+        crate::consts::W_RANGE * self.surface_scale
     }
 
     /// Drive every body in the row with the same rotor, lets the user directly compare

--- a/crates/polytope_playground/src/ui.rs
+++ b/crates/polytope_playground/src/ui.rs
@@ -15,7 +15,7 @@ use rye_egui::{
 };
 use rye_math::{Bivector, Rotor4};
 
-use crate::consts::{CONTROL_H, CONTROL_W, PLAY_PAUSE_W, W_RANGE};
+use crate::consts::{CONTROL_H, CONTROL_W, PLAY_PAUSE_W};
 use crate::state::{
     DeferredAction, Demo, RotationMode, RotorTerm, SurfaceMode, ViewMode, WireframeColorMode,
     WireframeProjection,
@@ -133,9 +133,9 @@ impl Demo {
     }
 
     /// Floating `Render` settings modal. Surfaces the same toggles the console exposes
-    /// (`surface`, `wireframe`, `points`) so new readers can discover the rendering modes
-    /// without typing commands. Each control writes through the same Demo fields the
-    /// console handlers do; the two interfaces stay in lockstep automatically.
+    /// (`surface`, `wireframe`, `wireframe points`) so new readers can discover the
+    /// rendering modes without typing commands. Each control writes through the same Demo
+    /// fields the console handlers do; the two interfaces stay in lockstep automatically.
     ///
     /// Off by default; opened via the gear button in the bottom overlay. Hosted in
     /// [`rye_egui::floating_panel`] for consistency with the engine's other floating
@@ -182,8 +182,9 @@ impl Demo {
                     ui.checkbox(wireframe_nearest_active, "Nearest-active gradient");
                     ui.horizontal(|ui| {
                         ui.label("Color");
-                        ui.radio_value(wireframe_color_mode, WireframeColorMode::Unique, "Unique");
-                        ui.radio_value(wireframe_color_mode, WireframeColorMode::Active, "Active");
+                        for mode in WireframeColorMode::ALL {
+                            ui.radio_value(wireframe_color_mode, mode, mode.label());
+                        }
                     });
                     ui.horizontal(|ui| {
                         ui.label("Projection");
@@ -410,12 +411,15 @@ impl Demo {
 
         let row_size = egui::vec2(avail, CONTROL_H);
         let row_layout = egui::Layout::left_to_right(egui::Align::Center);
+        // Surface-scaled W range so a `surface scale 4.0` body has a slider
+        // wide enough for the slice plane to leave it.
+        let w_range = self.effective_w_range();
         ui.allocate_ui_with_layout(row_size, row_layout, |ui| {
             let formatted = format!("w {:>+.3}", self.w_slice);
             slider_with_edit(
                 ui,
                 &mut self.w_slice,
-                -W_RANGE..=W_RANGE,
+                -w_range..=w_range,
                 &formatted,
                 "",
                 3,

--- a/crates/rye-app/src/cursor.rs
+++ b/crates/rye-app/src/cursor.rs
@@ -1,0 +1,86 @@
+//! Cursor grab + visibility request channel between the App and the Runner.
+//!
+//! Same shape as [`crate::frame_pacing::request_vsync_on`]: process-global
+//! atomic, the App pokes it from anywhere it has access (console handler,
+//! `App::update`, `App::on_event`), the Runner reads + applies it once per
+//! redraw via `Window::set_cursor_grab` + `set_cursor_visible`.
+//!
+//! ## Why a request channel
+//!
+//! `winit::Window::set_cursor_grab` must run on the main thread (the only
+//! thread holding the `Window`). The App, especially when a console command
+//! drives the request, doesn't always have direct `Window` access. Funnelling
+//! through this atomic keeps the call site simple and the application of the
+//! request scoped to the Runner.
+//!
+//! ## What "grab" means here
+//!
+//! Encodes both the cursor-grab mode and visibility into a single boolean:
+//!
+//! - `true`: confine the cursor to the window AND hide it. Pairs with raw
+//!   mouse delta consumption (`FrameInput::mouse_raw_delta`) for FPS-style
+//!   mouse-look: the cursor stops appearing on screen, deltas keep arriving
+//!   regardless of where the user's hand moves the mouse.
+//! - `false`: release the cursor AND make it visible. Default UX.
+//!
+//! ## Wasm note
+//!
+//! Browser Pointer Lock API requires "transient activation" (a recent user
+//! gesture) before `element.requestPointerLock()` succeeds. Console commands
+//! issued via keystroke into the in-canvas console do NOT count as the
+//! gesture from the browser's perspective; the keystroke is captured by the
+//! worker and the lock request races without an activated context.
+//!
+//! Net effect on wasm: cursor-grab requests will silently fail unless the
+//! request is triggered by a direct click handler. The runner's wasm path
+//! does not currently call Pointer Lock at all for this reason; demos that
+//! need freecam-on-wasm will need a click-to-engage UX layered on top. See
+//! `FLATLAND_DEMO.md` and the runner's wasm module for the architectural
+//! seam this would fit in.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+// Encoded request state. `0` = no pending request, `1` = request grab=true,
+// `2` = request grab=false. Runner swaps to 0 after reading so subsequent
+// frames don't re-apply unchanged state every redraw.
+const NONE: u8 = 0;
+const REQ_GRAB: u8 = 1;
+const REQ_RELEASE: u8 = 2;
+static PENDING: AtomicU8 = AtomicU8::new(NONE);
+
+/// Request the runner grab and hide the cursor on its next redraw.
+pub fn request_grab() {
+    PENDING.store(REQ_GRAB, Ordering::Release);
+}
+
+/// Request the runner release and show the cursor on its next redraw.
+pub fn request_release() {
+    PENDING.store(REQ_RELEASE, Ordering::Release);
+}
+
+/// Read + clear the pending cursor request. Runner calls this once per
+/// redraw before applying any change to the window. `Some(true)` =
+/// grab+hide; `Some(false)` = release+show; `None` = no change.
+pub fn take_pending() -> Option<bool> {
+    match PENDING.swap(NONE, Ordering::AcqRel) {
+        REQ_GRAB => Some(true),
+        REQ_RELEASE => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        // Clear any leftover state from sibling tests.
+        let _ = take_pending();
+        request_grab();
+        assert_eq!(take_pending(), Some(true));
+        assert_eq!(take_pending(), None, "second read clears");
+        request_release();
+        assert_eq!(take_pending(), Some(false));
+    }
+}

--- a/crates/rye-app/src/cursor.rs
+++ b/crates/rye-app/src/cursor.rs
@@ -95,6 +95,11 @@ const VIS_SHOW: u8 = 1;
 const VIS_HIDE: u8 = 2;
 static PENDING_VISIBLE: AtomicU8 = AtomicU8::new(VIS_NONE);
 
+// "Warp cursor to window center" pending flag. Demos pair this with a grab
+// release so the OS-cached cursor position doesn't pop up at a stale spot
+// when the user temporarily un-grabs (e.g., Alt in MMO-style cursor mode).
+static PENDING_WARP_CENTER: AtomicBool = AtomicBool::new(false);
+
 // Last-applied state. Updated by the runner once it commits a transition
 // to the window. Read by [`current_state`].
 static APPLIED_GRAB: AtomicU8 = AtomicU8::new(GRAB_NONE);
@@ -130,10 +135,17 @@ pub fn request_grab_mode(mode: GrabMode) {
 
 /// Request the runner show or hide the cursor on its next redraw.
 pub fn request_cursor_visible(visible: bool) {
-    PENDING_VISIBLE.store(
-        if visible { VIS_SHOW } else { VIS_HIDE },
-        Ordering::Release,
-    );
+    PENDING_VISIBLE.store(if visible { VIS_SHOW } else { VIS_HIDE }, Ordering::Release);
+}
+
+/// Request the runner warp the OS cursor to the window's center on its
+/// next redraw. Use this when releasing the grab so the cursor reappears
+/// in a predictable spot (typically the same screen position the user
+/// was aiming at) instead of the OS-cached random position. No-op on wasm
+/// (the browser owns cursor positioning; the warn from `request_grab` covers
+/// this).
+pub fn request_warp_to_center() {
+    PENDING_WARP_CENTER.store(true, Ordering::Release);
 }
 
 /// Convenience: request the FPS-mouse-look pair (Locked + hidden). Common
@@ -166,6 +178,12 @@ pub fn take_pending() -> (Option<GrabMode>, Option<bool>) {
         _ => None,
     };
     (grab, visible)
+}
+
+/// Read + clear the pending warp-to-center flag. Runner-internal.
+#[doc(hidden)]
+pub fn take_pending_warp_center() -> bool {
+    PENDING_WARP_CENTER.swap(false, Ordering::AcqRel)
 }
 
 /// Record what the runner just applied, so [`current_state`] reads it.
@@ -248,5 +266,32 @@ mod tests {
         assert!(!s.visible);
         // Restore default so sibling tests aren't surprised.
         mark_applied(GrabMode::None, true);
+    }
+
+    /// Warp-to-center is a one-shot flag: `request_warp_to_center` sets it,
+    /// `take_pending_warp_center` returns true once and then false until the next
+    /// request. Mirrors the grab/visibility channel's "swap-on-read" semantic so the
+    /// runner doesn't re-warp every frame if no one re-requests.
+    #[test]
+    fn warp_to_center_is_one_shot() {
+        // Drain anything left over from a sibling test.
+        let _ = take_pending_warp_center();
+
+        // No request yet -> false.
+        assert!(!take_pending_warp_center());
+
+        // After requesting -> true once, then false on the second read.
+        request_warp_to_center();
+        assert!(take_pending_warp_center(), "first read after request");
+        assert!(
+            !take_pending_warp_center(),
+            "second read should clear the flag"
+        );
+
+        // Two requests before a read coalesce: still one consumed event.
+        request_warp_to_center();
+        request_warp_to_center();
+        assert!(take_pending_warp_center());
+        assert!(!take_pending_warp_center());
     }
 }

--- a/crates/rye-app/src/cursor.rs
+++ b/crates/rye-app/src/cursor.rs
@@ -1,71 +1,200 @@
 //! Cursor grab + visibility request channel between the App and the Runner.
 //!
 //! Same shape as [`crate::frame_pacing::request_vsync_on`]: process-global
-//! atomic, the App pokes it from anywhere it has access (console handler,
-//! `App::update`, `App::on_event`), the Runner reads + applies it once per
+//! atomics; the App pokes them from anywhere it has access (console handler,
+//! `App::update`, `App::on_event`); the Runner reads + applies them once per
 //! redraw via `Window::set_cursor_grab` + `set_cursor_visible`.
 //!
 //! ## Why a request channel
 //!
 //! `winit::Window::set_cursor_grab` must run on the main thread (the only
 //! thread holding the `Window`). The App, especially when a console command
-//! drives the request, doesn't always have direct `Window` access. Funnelling
-//! through this atomic keeps the call site simple and the application of the
-//! request scoped to the Runner.
+//! drives the request, doesn't always have direct `Window` access.
+//! Funnelling through these atomics keeps the call site simple and the
+//! application of the request scoped to the Runner.
 //!
-//! ## What "grab" means here
+//! ## Surface
 //!
-//! Encodes both the cursor-grab mode and visibility into a single boolean:
+//! Grab mode and visibility are independent:
 //!
-//! - `true`: confine the cursor to the window AND hide it. Pairs with raw
-//!   mouse delta consumption (`FrameInput::mouse_raw_delta`) for FPS-style
-//!   mouse-look: the cursor stops appearing on screen, deltas keep arriving
-//!   regardless of where the user's hand moves the mouse.
-//! - `false`: release the cursor AND make it visible. Default UX.
+//! - [`request_grab_mode`] picks confinement: `None` lets the cursor roam
+//!   freely across the OS desktop; `Confined` keeps it inside the window
+//!   but visible; `Locked` pins it to the window center and reports raw
+//!   motion (the FPS-mouse-look mode).
+//! - [`request_cursor_visible`] picks whether the cursor renders.
+//!
+//! Both default to "released and visible" (the conventional UI state).
+//! Mouse-look apps typically pair `Locked` with `visible = false`; an
+//! adventure-game pointer might pair `Confined` with `visible = true`; a
+//! cinematic mode might pair `None` with `visible = false`.
+//!
+//! [`request_grab`] / [`request_release`] are convenience wrappers for the
+//! common mouse-look toggle.
+//!
+//! [`current_state`] returns what the runner last applied so demos don't
+//! need to mirror their own copy.
 //!
 //! ## Wasm note
 //!
 //! Browser Pointer Lock API requires "transient activation" (a recent user
-//! gesture) before `element.requestPointerLock()` succeeds. Console commands
-//! issued via keystroke into the in-canvas console do NOT count as the
-//! gesture from the browser's perspective; the keystroke is captured by the
-//! worker and the lock request races without an activated context.
-//!
-//! Net effect on wasm: cursor-grab requests will silently fail unless the
-//! request is triggered by a direct click handler. The runner's wasm path
-//! does not currently call Pointer Lock at all for this reason; demos that
-//! need freecam-on-wasm will need a click-to-engage UX layered on top. See
-//! `FLATLAND_DEMO.md` and the runner's wasm module for the architectural
-//! seam this would fit in.
+//! gesture) before `element.requestPointerLock()` succeeds. Console
+//! commands issued via keystrokes do NOT count as the gesture from the
+//! browser's perspective. The runner's wasm path therefore does not call
+//! Pointer Lock at all today; a request on wasm emits a one-time
+//! [`tracing::warn!`] so the demo author notices the no-op, then stays
+//! silent for the rest of the session.
 
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
-// Encoded request state. `0` = no pending request, `1` = request grab=true,
-// `2` = request grab=false. Runner swaps to 0 after reading so subsequent
-// frames don't re-apply unchanged state every redraw.
+/// Cursor confinement modes. Mirrors `winit::window::CursorGrabMode` so
+/// the engine API doesn't leak winit into demo code.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum GrabMode {
+    /// Cursor moves freely across the OS desktop, including outside the
+    /// window. Default UX.
+    #[default]
+    None,
+    /// Cursor confined inside the window's client rect but otherwise
+    /// moves normally. Pairs with `visible = true` for click discipline
+    /// in modal UIs.
+    Confined,
+    /// Cursor pinned at the window center; movement reported as raw
+    /// device delta (`FrameInput::mouse_raw_delta`). Pairs with
+    /// `visible = false` for FPS-style mouse-look.
+    Locked,
+}
+
+/// Snapshot of the last cursor state the runner applied. Read via
+/// [`current_state`] so demos don't need to mirror this themselves.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct CursorState {
+    pub grab: GrabMode,
+    pub visible: bool,
+}
+
+impl CursorState {
+    /// Default the runner uses before any request lands: released +
+    /// visible. The conventional UI cursor.
+    pub const RELEASED: Self = Self {
+        grab: GrabMode::None,
+        visible: true,
+    };
+}
+
+// Encoded pending requests. `0` = no request; nonzero values map to
+// specific transitions. Runner swaps to 0 after reading so subsequent
+// frames don't re-apply unchanged state on every redraw.
 const NONE: u8 = 0;
-const REQ_GRAB: u8 = 1;
-const REQ_RELEASE: u8 = 2;
-static PENDING: AtomicU8 = AtomicU8::new(NONE);
+const GRAB_NONE: u8 = 1;
+const GRAB_CONFINED: u8 = 2;
+const GRAB_LOCKED: u8 = 3;
+static PENDING_GRAB: AtomicU8 = AtomicU8::new(NONE);
 
-/// Request the runner grab and hide the cursor on its next redraw.
+const VIS_NONE: u8 = 0;
+const VIS_SHOW: u8 = 1;
+const VIS_HIDE: u8 = 2;
+static PENDING_VISIBLE: AtomicU8 = AtomicU8::new(VIS_NONE);
+
+// Last-applied state. Updated by the runner once it commits a transition
+// to the window. Read by [`current_state`].
+static APPLIED_GRAB: AtomicU8 = AtomicU8::new(GRAB_NONE);
+static APPLIED_VISIBLE: AtomicBool = AtomicBool::new(true);
+
+// One-time wasm "this API is a no-op here" warn flag. Avoids per-frame
+// spam if a demo polls request_grab in update() by mistake.
+#[cfg(target_arch = "wasm32")]
+static WASM_WARNED: AtomicBool = AtomicBool::new(false);
+
+fn grab_mode_to_code(mode: GrabMode) -> u8 {
+    match mode {
+        GrabMode::None => GRAB_NONE,
+        GrabMode::Confined => GRAB_CONFINED,
+        GrabMode::Locked => GRAB_LOCKED,
+    }
+}
+
+fn code_to_grab_mode(code: u8) -> GrabMode {
+    match code {
+        GRAB_CONFINED => GrabMode::Confined,
+        GRAB_LOCKED => GrabMode::Locked,
+        _ => GrabMode::None,
+    }
+}
+
+/// Request the runner change the grab mode on its next redraw.
+pub fn request_grab_mode(mode: GrabMode) {
+    PENDING_GRAB.store(grab_mode_to_code(mode), Ordering::Release);
+    #[cfg(target_arch = "wasm32")]
+    warn_wasm_once_if_grabbing(mode);
+}
+
+/// Request the runner show or hide the cursor on its next redraw.
+pub fn request_cursor_visible(visible: bool) {
+    PENDING_VISIBLE.store(
+        if visible { VIS_SHOW } else { VIS_HIDE },
+        Ordering::Release,
+    );
+}
+
+/// Convenience: request the FPS-mouse-look pair (Locked + hidden). Common
+/// enough to be its own call.
 pub fn request_grab() {
-    PENDING.store(REQ_GRAB, Ordering::Release);
+    request_grab_mode(GrabMode::Locked);
+    request_cursor_visible(false);
 }
 
-/// Request the runner release and show the cursor on its next redraw.
+/// Convenience: request the conventional UI pair (None + visible).
 pub fn request_release() {
-    PENDING.store(REQ_RELEASE, Ordering::Release);
+    request_grab_mode(GrabMode::None);
+    request_cursor_visible(true);
 }
 
-/// Read + clear the pending cursor request. Runner calls this once per
-/// redraw before applying any change to the window. `Some(true)` =
-/// grab+hide; `Some(false)` = release+show; `None` = no change.
-pub fn take_pending() -> Option<bool> {
-    match PENDING.swap(NONE, Ordering::AcqRel) {
-        REQ_GRAB => Some(true),
-        REQ_RELEASE => Some(false),
+/// Read + clear the pending grab/visibility transition. Runner-internal;
+/// returns `(grab_change, visible_change)` where each is `Some(new_value)`
+/// if a request landed since the last call, `None` otherwise.
+///
+/// `#[doc(hidden)]` because the engine is the only consumer; demos that
+/// want the applied state read [`current_state`] instead.
+#[doc(hidden)]
+pub fn take_pending() -> (Option<GrabMode>, Option<bool>) {
+    let grab_code = PENDING_GRAB.swap(NONE, Ordering::AcqRel);
+    let grab = (grab_code != NONE).then(|| code_to_grab_mode(grab_code));
+    let vis_code = PENDING_VISIBLE.swap(VIS_NONE, Ordering::AcqRel);
+    let visible = match vis_code {
+        VIS_SHOW => Some(true),
+        VIS_HIDE => Some(false),
         _ => None,
+    };
+    (grab, visible)
+}
+
+/// Record what the runner just applied, so [`current_state`] reads it.
+/// Runner-internal.
+#[doc(hidden)]
+pub fn mark_applied(grab: GrabMode, visible: bool) {
+    APPLIED_GRAB.store(grab_mode_to_code(grab), Ordering::Release);
+    APPLIED_VISIBLE.store(visible, Ordering::Release);
+}
+
+/// Last-applied cursor state. Read this from anywhere (demo, console
+/// handler, render code) instead of mirroring a copy of the grab flag.
+pub fn current_state() -> CursorState {
+    CursorState {
+        grab: code_to_grab_mode(APPLIED_GRAB.load(Ordering::Acquire)),
+        visible: APPLIED_VISIBLE.load(Ordering::Acquire),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn warn_wasm_once_if_grabbing(mode: GrabMode) {
+    if mode != GrabMode::None && !WASM_WARNED.swap(true, Ordering::AcqRel) {
+        tracing::warn!(
+            "rye_app::cursor: grab requested on wasm32, but Pointer Lock \
+             requires a recent user gesture that console-driven commands \
+             don't satisfy. The request is silently a no-op; the cursor \
+             will not be confined or hidden. See the cursor module doc \
+             for the architectural fix (main-thread click handler)."
+        );
     }
 }
 
@@ -74,13 +203,50 @@ mod tests {
     use super::*;
 
     #[test]
-    fn round_trip() {
-        // Clear any leftover state from sibling tests.
+    fn round_trip_grab_mode() {
+        let _ = take_pending();
+        request_grab_mode(GrabMode::Locked);
+        let (grab, _) = take_pending();
+        assert_eq!(grab, Some(GrabMode::Locked));
+        let (grab, _) = take_pending();
+        assert_eq!(grab, None, "second read clears");
+        request_grab_mode(GrabMode::Confined);
+        let (grab, _) = take_pending();
+        assert_eq!(grab, Some(GrabMode::Confined));
+    }
+
+    #[test]
+    fn round_trip_visibility() {
+        let _ = take_pending();
+        request_cursor_visible(false);
+        let (_, vis) = take_pending();
+        assert_eq!(vis, Some(false));
+        request_cursor_visible(true);
+        let (_, vis) = take_pending();
+        assert_eq!(vis, Some(true));
+    }
+
+    #[test]
+    fn convenience_pairs_set_both() {
         let _ = take_pending();
         request_grab();
-        assert_eq!(take_pending(), Some(true));
-        assert_eq!(take_pending(), None, "second read clears");
+        let (g, v) = take_pending();
+        assert_eq!(g, Some(GrabMode::Locked));
+        assert_eq!(v, Some(false));
+
         request_release();
-        assert_eq!(take_pending(), Some(false));
+        let (g, v) = take_pending();
+        assert_eq!(g, Some(GrabMode::None));
+        assert_eq!(v, Some(true));
+    }
+
+    #[test]
+    fn current_state_reads_applied_value() {
+        mark_applied(GrabMode::Confined, false);
+        let s = current_state();
+        assert_eq!(s.grab, GrabMode::Confined);
+        assert!(!s.visible);
+        // Restore default so sibling tests aren't surprised.
+        mark_applied(GrabMode::None, true);
     }
 }

--- a/crates/rye-app/src/freecam.rs
+++ b/crates/rye-app/src/freecam.rs
@@ -34,6 +34,12 @@
 //! `use_raw_delta` flag) without changing `active`. Bind this to a key
 //! (Alt is the convention) for in-freecam UI interaction.
 //!
+//! Prefer [`Freecam::on_alt`] for the standard FPS/MMO modifier-key contract:
+//! demos forward Alt press AND release into `on_alt(pressed)` and the
+//! cursor-mode field decides whether to toggle (default, FPS sticky) or
+//! hold-to-release (MMO). The mode is runtime-configurable via
+//! [`Freecam::set_cursor_mode`].
+//!
 //! ## Wasm caveat
 //!
 //! `rye_app::cursor::request_grab` is a documented no-op on wasm
@@ -51,6 +57,43 @@ use crate::Camera;
 
 /// Default WASD translation speed for new Freecam instances.
 const DEFAULT_SPEED: f32 = 4.5;
+
+/// How the Alt modifier influences the cursor grab in [`Freecam`].
+///
+/// Both modes still flip the controller's `use_raw_delta` flag so a
+/// released cursor never accumulates yaw/pitch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum CursorMode {
+    /// MMO-style: cursor released while Alt is held, re-grabbed when Alt
+    /// is released. Best when the cursor-release windows are short
+    /// (click a button, then resume).
+    Hold,
+    /// FPS sticky-modifier: press Alt to flip the grab, press again to
+    /// flip back. Release does nothing. Default. Best when the
+    /// cursor-release windows are long (read a panel, type into a text
+    /// field).
+    #[default]
+    Toggle,
+}
+
+impl CursorMode {
+    /// Parse a console token (e.g. from `camera freecam cursor_mode hold`).
+    pub fn from_token(s: &str) -> Option<Self> {
+        match s {
+            "hold" => Some(Self::Hold),
+            "toggle" => Some(Self::Toggle),
+            _ => None,
+        }
+    }
+
+    /// Lowercase token mirroring [`Self::from_token`].
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::Hold => "hold",
+            Self::Toggle => "toggle",
+        }
+    }
+}
 
 /// FPS-style camera preset: mouse-look + WASD/Space/Shift translation +
 /// cursor grab management.
@@ -75,6 +118,7 @@ pub struct Freecam {
     pub speed: f32,
     active: bool,
     cursor_grabbed: bool,
+    cursor_mode: CursorMode,
 }
 
 impl Default for Freecam {
@@ -94,6 +138,7 @@ impl Freecam {
             speed: DEFAULT_SPEED,
             active: false,
             cursor_grabbed: false,
+            cursor_mode: CursorMode::default(),
         }
     }
 
@@ -101,6 +146,26 @@ impl Freecam {
     pub fn with_speed(mut self, speed: f32) -> Self {
         self.speed = speed;
         self
+    }
+
+    /// Builder: override the Alt-cursor mode. Default
+    /// [`CursorMode::Toggle`].
+    pub fn with_cursor_mode(mut self, mode: CursorMode) -> Self {
+        self.cursor_mode = mode;
+        self
+    }
+
+    /// Current Alt-cursor mode.
+    pub fn cursor_mode(&self) -> CursorMode {
+        self.cursor_mode
+    }
+
+    /// Switch between [`CursorMode::Hold`] and [`CursorMode::Toggle`] at
+    /// runtime. Does NOT change the current grab state; only how future
+    /// Alt events are interpreted by [`on_alt`](Self::on_alt). Call after
+    /// any user-facing setting flips, e.g. a console command.
+    pub fn set_cursor_mode(&mut self, mode: CursorMode) {
+        self.cursor_mode = mode;
     }
 
     /// Is freecam currently the active camera mode for the demo?
@@ -144,10 +209,53 @@ impl Freecam {
         }
     }
 
+    /// Apply an Alt key event according to the current [`cursor_mode`](Self::cursor_mode).
+    ///
+    /// - [`CursorMode::Hold`]: cursor released while `pressed=true`;
+    ///   re-grabbed when `pressed=false`. Demos must forward BOTH press
+    ///   and release events.
+    /// - [`CursorMode::Toggle`]: `pressed=true` flips the grab once;
+    ///   `pressed=false` is ignored. Demos can forward release safely.
+    ///
+    /// No-op when freecam isn't active.
+    pub fn on_alt(&mut self, pressed: bool) {
+        if !self.active {
+            return;
+        }
+        let target_grabbed = match self.cursor_mode {
+            CursorMode::Hold => !pressed,
+            CursorMode::Toggle => {
+                if !pressed {
+                    return;
+                }
+                !self.cursor_grabbed
+            }
+        };
+        if target_grabbed == self.cursor_grabbed {
+            return;
+        }
+        self.cursor_grabbed = target_grabbed;
+        self.controller.use_raw_delta = target_grabbed;
+        if target_grabbed {
+            crate::cursor::request_grab();
+        } else {
+            // Warp to window center on release so the cursor reappears in a
+            // predictable spot (rather than wherever the OS cached it before
+            // the grab); the user was aiming at the screen center the whole
+            // time freecam was engaged.
+            crate::cursor::request_release();
+            crate::cursor::request_warp_to_center();
+        }
+    }
+
     /// Flip the cursor grab without changing the active state. Bind to
     /// Alt (or similar) in the demo for "release the cursor so I can
     /// click a UI widget, then re-grab to resume mouse-look." No-op if
     /// the freecam isn't active.
+    ///
+    /// Prefer [`on_alt`](Self::on_alt) for the standard modifier-key
+    /// contract; this method ignores [`cursor_mode`](Self::cursor_mode)
+    /// and always toggles.
     pub fn toggle_cursor_grab(&mut self) {
         if !self.active {
             return;
@@ -158,6 +266,7 @@ impl Freecam {
             crate::cursor::request_grab();
         } else {
             crate::cursor::request_release();
+            crate::cursor::request_warp_to_center();
         }
     }
 
@@ -168,19 +277,13 @@ impl Freecam {
     ///
     /// Caller still owns the higher-level mode switch (orbit vs freecam);
     /// this method assumes `Freecam` IS the active controller this frame.
-    pub fn advance(
-        &mut self,
-        input: FrameInput,
-        camera: &mut Camera<EuclideanR3>,
-        dt: f32,
-    ) {
+    pub fn advance(&mut self, input: FrameInput, camera: &mut Camera<EuclideanR3>, dt: f32) {
         if !self.active || !self.cursor_grabbed {
             return;
         }
         // Look direction: controller reads raw delta, updates yaw + pitch,
         // writes the camera's right/up/forward.
-        self.controller
-            .advance(input, camera, &EuclideanR3, dt);
+        self.controller.advance(input, camera, &EuclideanR3, dt);
         // Position: integrate the WASD + Space/Shift axes in the camera's
         // local frame.
         let mut delta = camera.forward * input.move_forward
@@ -331,6 +434,94 @@ mod tests {
         };
         f.advance(input, &mut cam, 0.016);
         assert_eq!(cam.forward, cam_before.forward, "look frozen when released");
+    }
+
+    #[test]
+    fn default_cursor_mode_is_toggle() {
+        let f = Freecam::new();
+        assert_eq!(f.cursor_mode(), CursorMode::Toggle);
+    }
+
+    #[test]
+    fn cursor_mode_from_token_roundtrip() {
+        for m in [CursorMode::Hold, CursorMode::Toggle] {
+            assert_eq!(CursorMode::from_token(m.token()), Some(m));
+        }
+        assert_eq!(CursorMode::from_token("nope"), None);
+    }
+
+    #[test]
+    fn on_alt_hold_releases_and_regrabs() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new().with_cursor_mode(CursorMode::Hold);
+        f.set_active(true, Vec3::ZERO);
+        let _ = cursor::take_pending();
+
+        f.on_alt(true);
+        assert!(f.active());
+        assert!(!f.cursor_grabbed());
+        let (grab, _vis) = cursor::take_pending();
+        assert_eq!(grab, Some(cursor::GrabMode::None));
+
+        f.on_alt(false);
+        assert!(f.cursor_grabbed());
+        let (grab, _vis) = cursor::take_pending();
+        assert_eq!(grab, Some(cursor::GrabMode::Locked));
+    }
+
+    #[test]
+    fn on_alt_toggle_ignores_release() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new().with_cursor_mode(CursorMode::Toggle);
+        f.set_active(true, Vec3::ZERO);
+        let _ = cursor::take_pending();
+
+        // First press: flip to released.
+        f.on_alt(true);
+        assert!(!f.cursor_grabbed());
+        let _ = cursor::take_pending();
+
+        // Release: ignored.
+        f.on_alt(false);
+        assert!(!f.cursor_grabbed());
+        let (grab, vis) = cursor::take_pending();
+        assert_eq!(grab, None);
+        assert_eq!(vis, None);
+
+        // Second press: flip back to grabbed.
+        f.on_alt(true);
+        assert!(f.cursor_grabbed());
+    }
+
+    #[test]
+    fn on_alt_noop_when_inactive() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new();
+        f.on_alt(true);
+        assert!(!f.active());
+        let (grab, vis) = cursor::take_pending();
+        assert_eq!(grab, None);
+        assert_eq!(vis, None);
+    }
+
+    #[test]
+    fn set_cursor_mode_preserves_grab_state() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new();
+        f.set_active(true, Vec3::ZERO);
+        let _ = cursor::take_pending();
+        let grabbed_before = f.cursor_grabbed();
+
+        f.set_cursor_mode(CursorMode::Toggle);
+        assert_eq!(f.cursor_mode(), CursorMode::Toggle);
+        assert_eq!(
+            f.cursor_grabbed(),
+            grabbed_before,
+            "mode flip leaves grab alone"
+        );
+        let (grab, vis) = cursor::take_pending();
+        assert_eq!(grab, None);
+        assert_eq!(vis, None);
     }
 
     #[test]

--- a/crates/rye-app/src/freecam.rs
+++ b/crates/rye-app/src/freecam.rs
@@ -1,0 +1,358 @@
+//! Freecam preset for FPS-style mouse-look + WASD translation.
+//!
+//! Composes [`rye_camera::FirstPersonController`] + a world-space position +
+//! [`crate::cursor`] grab requests into a single struct. The pattern was
+//! growing in two demos (tesseract_demo + polytope_playground) and shared
+//! enough to lift here per the engine-first guideline.
+//!
+//! ## What a Freecam does each frame
+//!
+//! When [`Freecam::active`] is `true` AND [`Freecam::cursor_grabbed`] is
+//! `true`:
+//!
+//! 1. The internal [`FirstPersonController`] consumes
+//!    `FrameInput::mouse_raw_delta` to update yaw + pitch.
+//! 2. WASD + Space/Shift on `FrameInput` integrate the world-space
+//!    `position` field at `speed` units/sec.
+//! 3. The owning `Camera<EuclideanR3>` has its `position` + basis updated.
+//!
+//! When `active = false` OR `cursor_grabbed = false`: [`Freecam::advance`]
+//! is a no-op. The cursor-grab toggle lets the user release the mouse for
+//! UI access without leaving freecam mode entirely (the position + look
+//! direction freeze in place; resuming the grab continues from there).
+//!
+//! ## Activation contract
+//!
+//! [`Freecam::set_active`] seeds the freecam's `position` from the
+//! current camera location AND requests a cursor grab via
+//! `rye_app::cursor`. Deactivating requests a cursor release. The cursor
+//! grab is paired with hidden visibility for FPS mouse-look; demos that
+//! want a different cursor regime override via `rye_app::cursor` directly
+//! after `set_active`.
+//!
+//! [`Freecam::toggle_cursor_grab`] flips JUST the grab (and the controller's
+//! `use_raw_delta` flag) without changing `active`. Bind this to a key
+//! (Alt is the convention) for in-freecam UI interaction.
+//!
+//! ## Wasm caveat
+//!
+//! `rye_app::cursor::request_grab` is a documented no-op on wasm
+//! (browser Pointer Lock requires a user gesture). Freecam on wasm will
+//! work but the mouse will escape the screen; demos shipping freecam to
+//! browsers need a click-to-engage layer on the main-thread side. See the
+//! cursor module doc.
+
+use glam::Vec3;
+use rye_camera::{CameraController, FirstPersonController};
+use rye_input::FrameInput;
+use rye_math::EuclideanR3;
+
+use crate::Camera;
+
+/// Default WASD translation speed for new Freecam instances.
+const DEFAULT_SPEED: f32 = 4.5;
+
+/// FPS-style camera preset: mouse-look + WASD/Space/Shift translation +
+/// cursor grab management.
+///
+/// Construct with [`Freecam::new`], optionally tune with [`Freecam::with_speed`],
+/// then call [`Freecam::set_active`] to enter freecam mode and
+/// [`Freecam::advance`] each frame.
+#[derive(Clone, Copy, Debug)]
+pub struct Freecam {
+    /// Underlying look-direction controller. Public so demos can read
+    /// yaw/pitch for HUD display or tweak `use_raw_delta` directly.
+    /// `Freecam::advance` overwrites `use_raw_delta` based on the grab
+    /// state each frame, so manual changes don't persist past the next
+    /// advance call.
+    pub controller: FirstPersonController<EuclideanR3>,
+    /// World-space position. Updated each `advance` while active +
+    /// grabbed. Public so demos can teleport or restore from save.
+    pub position: Vec3,
+    /// Translation speed in units per second. Affects WASD + Space/Shift
+    /// only; mouse-look sensitivity is set on `controller` (see
+    /// `rye_camera::FIRST_PERSON_MOUSE_SENSITIVITY`).
+    pub speed: f32,
+    active: bool,
+    cursor_grabbed: bool,
+}
+
+impl Default for Freecam {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Freecam {
+    /// Construct an inactive freecam at the origin with default speed.
+    /// Call [`set_active(true, current_pos)`](Self::set_active) when the
+    /// demo enters freecam mode.
+    pub fn new() -> Self {
+        Self {
+            controller: FirstPersonController::<EuclideanR3>::new(0.0, 0.0),
+            position: Vec3::ZERO,
+            speed: DEFAULT_SPEED,
+            active: false,
+            cursor_grabbed: false,
+        }
+    }
+
+    /// Builder: set translation speed at construction. Default 4.5 u/sec.
+    pub fn with_speed(mut self, speed: f32) -> Self {
+        self.speed = speed;
+        self
+    }
+
+    /// Is freecam currently the active camera mode for the demo?
+    pub fn active(&self) -> bool {
+        self.active
+    }
+
+    /// Is the cursor currently grabbed (mouse-look engaged)? Always false
+    /// when inactive; toggleable via [`toggle_cursor_grab`](Self::toggle_cursor_grab)
+    /// while active.
+    pub fn cursor_grabbed(&self) -> bool {
+        self.cursor_grabbed
+    }
+
+    /// Enter or leave freecam mode.
+    ///
+    /// On entry (`active = true`): seeds the internal position from
+    /// `current_camera_pos` (so the toggle feels continuous rather than
+    /// teleporting), grabs the cursor + hides it, and primes the
+    /// controller to read raw mouse deltas. The caller should switch
+    /// their camera-mode state machine to "freecam" and stop running the
+    /// orbit controller's advance.
+    ///
+    /// On exit (`active = false`): releases the cursor + shows it,
+    /// resets the controller's raw-delta flag, leaves position + yaw +
+    /// pitch where they were so a re-entry returns to the same pose.
+    pub fn set_active(&mut self, active: bool, current_camera_pos: Vec3) {
+        if active == self.active {
+            return;
+        }
+        self.active = active;
+        if active {
+            self.position = current_camera_pos;
+            self.cursor_grabbed = true;
+            self.controller.use_raw_delta = true;
+            crate::cursor::request_grab();
+        } else {
+            self.cursor_grabbed = false;
+            self.controller.use_raw_delta = false;
+            crate::cursor::request_release();
+        }
+    }
+
+    /// Flip the cursor grab without changing the active state. Bind to
+    /// Alt (or similar) in the demo for "release the cursor so I can
+    /// click a UI widget, then re-grab to resume mouse-look." No-op if
+    /// the freecam isn't active.
+    pub fn toggle_cursor_grab(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.cursor_grabbed = !self.cursor_grabbed;
+        self.controller.use_raw_delta = self.cursor_grabbed;
+        if self.cursor_grabbed {
+            crate::cursor::request_grab();
+        } else {
+            crate::cursor::request_release();
+        }
+    }
+
+    /// Per-frame update. Drives the camera's basis from yaw/pitch and
+    /// the camera's position from `position` (which itself is integrated
+    /// from WASD + Space/Shift). No-op when inactive or when the cursor
+    /// is released (Alt-toggled in-freecam UI-access mode).
+    ///
+    /// Caller still owns the higher-level mode switch (orbit vs freecam);
+    /// this method assumes `Freecam` IS the active controller this frame.
+    pub fn advance(
+        &mut self,
+        input: FrameInput,
+        camera: &mut Camera<EuclideanR3>,
+        dt: f32,
+    ) {
+        if !self.active || !self.cursor_grabbed {
+            return;
+        }
+        // Look direction: controller reads raw delta, updates yaw + pitch,
+        // writes the camera's right/up/forward.
+        self.controller
+            .advance(input, camera, &EuclideanR3, dt);
+        // Position: integrate the WASD + Space/Shift axes in the camera's
+        // local frame.
+        let mut delta = camera.forward * input.move_forward
+            + camera.right * input.move_right
+            + Vec3::Y * input.move_up;
+        if delta.length_squared() > 1e-6 {
+            delta = delta.normalize();
+            self.position += delta * self.speed * dt;
+            camera.position = self.position;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cursor;
+
+    fn make_camera() -> Camera<EuclideanR3> {
+        let mut c = Camera::<EuclideanR3>::at_origin();
+        c.position = Vec3::new(0.0, 1.0, 5.0);
+        c.forward = -Vec3::Z;
+        c.right = Vec3::X;
+        c.up = Vec3::Y;
+        c
+    }
+
+    #[test]
+    fn new_is_inactive() {
+        let f = Freecam::new();
+        assert!(!f.active());
+        assert!(!f.cursor_grabbed());
+        assert_eq!(f.speed, DEFAULT_SPEED);
+    }
+
+    #[test]
+    fn with_speed_overrides() {
+        let f = Freecam::new().with_speed(12.0);
+        assert!((f.speed - 12.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn set_active_true_seeds_position_and_grabs() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new();
+        let cam_pos = Vec3::new(3.0, 2.0, 7.0);
+        f.set_active(true, cam_pos);
+        assert!(f.active());
+        assert!(f.cursor_grabbed());
+        assert!(f.controller.use_raw_delta);
+        assert_eq!(f.position, cam_pos);
+        // Verify a grab request was queued.
+        let (grab, vis) = cursor::take_pending();
+        assert_eq!(grab, Some(cursor::GrabMode::Locked));
+        assert_eq!(vis, Some(false));
+    }
+
+    #[test]
+    fn set_active_false_releases() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new();
+        f.set_active(true, Vec3::ZERO);
+        let _ = cursor::take_pending();
+        f.set_active(false, Vec3::ZERO);
+        assert!(!f.active());
+        assert!(!f.cursor_grabbed());
+        assert!(!f.controller.use_raw_delta);
+        let (grab, vis) = cursor::take_pending();
+        assert_eq!(grab, Some(cursor::GrabMode::None));
+        assert_eq!(vis, Some(true));
+    }
+
+    #[test]
+    fn set_active_idempotent() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new();
+        f.set_active(true, Vec3::ZERO);
+        let _ = cursor::take_pending();
+        // Second call with same value: no new request queued.
+        f.set_active(true, Vec3::new(99.0, 99.0, 99.0));
+        let (grab, vis) = cursor::take_pending();
+        assert_eq!(grab, None, "idempotent set_active shouldn't re-queue");
+        assert_eq!(vis, None);
+        // Position should NOT be overwritten by an idempotent call.
+        assert_eq!(f.position, Vec3::ZERO);
+    }
+
+    #[test]
+    fn toggle_cursor_grab_flips_within_active() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new();
+        f.set_active(true, Vec3::ZERO);
+        let _ = cursor::take_pending();
+
+        f.toggle_cursor_grab();
+        assert!(f.active(), "toggle doesn't change active");
+        assert!(!f.cursor_grabbed());
+        assert!(!f.controller.use_raw_delta);
+        let (grab, vis) = cursor::take_pending();
+        assert_eq!(grab, Some(cursor::GrabMode::None));
+        assert_eq!(vis, Some(true));
+
+        f.toggle_cursor_grab();
+        assert!(f.cursor_grabbed());
+        assert!(f.controller.use_raw_delta);
+    }
+
+    #[test]
+    fn toggle_cursor_grab_noop_when_inactive() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new();
+        f.toggle_cursor_grab();
+        assert!(!f.active());
+        assert!(!f.cursor_grabbed());
+        let (grab, vis) = cursor::take_pending();
+        assert_eq!(grab, None);
+        assert_eq!(vis, None);
+    }
+
+    #[test]
+    fn advance_noop_when_inactive() {
+        let mut f = Freecam::new();
+        let mut cam = make_camera();
+        let cam_before = cam;
+        let pos_before = f.position;
+        let input = FrameInput {
+            mouse_raw_delta: glam::Vec2::new(100.0, 50.0),
+            move_forward: 1.0,
+            ..Default::default()
+        };
+        f.advance(input, &mut cam, 0.016);
+        assert_eq!(cam.position, cam_before.position);
+        assert_eq!(cam.forward, cam_before.forward);
+        assert_eq!(f.position, pos_before);
+    }
+
+    #[test]
+    fn advance_noop_when_cursor_released() {
+        let mut f = Freecam::new();
+        f.set_active(true, Vec3::ZERO);
+        f.toggle_cursor_grab(); // release
+        let mut cam = make_camera();
+        let cam_before = cam;
+        let input = FrameInput {
+            mouse_raw_delta: glam::Vec2::new(100.0, 50.0),
+            move_forward: 1.0,
+            ..Default::default()
+        };
+        f.advance(input, &mut cam, 0.016);
+        assert_eq!(cam.forward, cam_before.forward, "look frozen when released");
+    }
+
+    #[test]
+    fn advance_integrates_forward_motion() {
+        let _ = cursor::take_pending();
+        let mut f = Freecam::new().with_speed(2.0);
+        f.set_active(true, Vec3::ZERO);
+        let mut cam = make_camera();
+        cam.position = Vec3::ZERO;
+        cam.forward = -Vec3::Z; // forward = -Z
+        let input = FrameInput {
+            move_forward: 1.0,
+            ..Default::default()
+        };
+        f.advance(input, &mut cam, 0.5);
+        // speed * dt = 2.0 * 0.5 = 1.0 unit, in -Z direction.
+        let expected = Vec3::new(0.0, 0.0, -1.0);
+        assert!(
+            (f.position - expected).length() < 1e-5,
+            "expected {expected:?}, got {:?}",
+            f.position,
+        );
+        assert!((cam.position - expected).length() < 1e-5);
+    }
+}

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -79,6 +79,7 @@ pub mod args;
 #[cfg(any(not(feature = "capture"), target_arch = "wasm32"))]
 #[path = "capture_stub.rs"]
 pub mod capture;
+pub mod cursor;
 pub mod fps;
 pub mod frame_pacing;
 pub mod keymap;
@@ -1138,6 +1139,23 @@ impl<A: App> ApplicationHandler for Runner<A> {
             }
         }
     }
+
+    /// Device-level events (mouse motion independent of cursor position,
+    /// raw scroll wheel, etc.). The only one we currently consume is
+    /// `MouseMotion`, which gives uncapped deltas that don't stop when the
+    /// cursor hits the screen edge. Routed into `InputState::accumulate_raw_motion`
+    /// so consumers (camera controllers, primarily) that grab the cursor can
+    /// read it via `FrameInput::mouse_raw_delta`.
+    fn device_event(
+        &mut self,
+        _elwt: &ActiveEventLoop,
+        _device_id: winit::event::DeviceId,
+        ev: winit::event::DeviceEvent,
+    ) {
+        if let winit::event::DeviceEvent::MouseMotion { delta } = ev {
+            self.input.accumulate_raw_motion(delta.0, delta.1);
+        }
+    }
 }
 
 impl<A: App> Runner<A> {
@@ -1167,6 +1185,30 @@ impl<A: App> Runner<A> {
             };
             let _ = rd.set_present_mode(target);
         }
+
+        // Pending cursor grab requests from `rye_app::cursor`. Native only;
+        // browser Pointer Lock requires a recent user gesture that console
+        // commands don't satisfy, so wasm freecam currently has the
+        // cursor-escape limitation documented in the cursor module. Confined
+        // mode (not Locked) keeps the cursor pinned inside the window while
+        // letting the OS report raw motion via DeviceEvent::MouseMotion.
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(grab) = cursor::take_pending() {
+            use winit::window::CursorGrabMode;
+            let grab_mode = if grab {
+                CursorGrabMode::Confined
+            } else {
+                CursorGrabMode::None
+            };
+            // Confined mode is widely supported on Windows + macOS + Linux/X11.
+            // Fall back to Locked if Confined isn't accepted; either gives us
+            // the raw-delta behavior we need.
+            if win.set_cursor_grab(grab_mode).is_err() && grab {
+                let _ = win.set_cursor_grab(CursorGrabMode::Locked);
+            }
+            win.set_cursor_visible(!grab);
+        }
+
         let Some(rd) = self.rd.as_ref() else { return };
 
         // Frame-rate cap. The `fps` console command pokes

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -84,6 +84,7 @@ pub mod frame_pacing;
 pub mod keymap;
 pub mod log;
 pub mod trace;
+pub mod version;
 pub mod vsync;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -81,6 +81,7 @@ pub mod args;
 pub mod capture;
 pub mod cursor;
 pub mod fps;
+pub mod freecam;
 pub mod frame_pacing;
 pub mod keymap;
 pub mod log;
@@ -1186,27 +1187,48 @@ impl<A: App> Runner<A> {
             let _ = rd.set_present_mode(target);
         }
 
-        // Pending cursor grab requests from `rye_app::cursor`. Native only;
-        // browser Pointer Lock requires a recent user gesture that console
-        // commands don't satisfy, so wasm freecam currently has the
-        // cursor-escape limitation documented in the cursor module. Confined
-        // mode (not Locked) keeps the cursor pinned inside the window while
-        // letting the OS report raw motion via DeviceEvent::MouseMotion.
+        // Pending cursor grab + visibility transitions from
+        // `rye_app::cursor`. Native only; browser Pointer Lock requires a
+        // recent user gesture that console commands don't satisfy (the
+        // cursor module emits a one-time tracing::warn on wasm).
+        //
+        // Grab + visibility are independent. The runner translates the
+        // engine-level `GrabMode` to winit's `CursorGrabMode` and falls
+        // back from `Locked` to `Confined` (or vice versa) if the platform
+        // doesn't support the requested mode (macOS + Linux/X11 vary on
+        // which they prefer; Windows accepts both). The fallback chain
+        // preserves the user's intent (some form of grab) rather than
+        // silently dropping to `None`.
         #[cfg(not(target_arch = "wasm32"))]
-        if let Some(grab) = cursor::take_pending() {
+        {
             use winit::window::CursorGrabMode;
-            let grab_mode = if grab {
-                CursorGrabMode::Confined
-            } else {
-                CursorGrabMode::None
-            };
-            // Confined mode is widely supported on Windows + macOS + Linux/X11.
-            // Fall back to Locked if Confined isn't accepted; either gives us
-            // the raw-delta behavior we need.
-            if win.set_cursor_grab(grab_mode).is_err() && grab {
-                let _ = win.set_cursor_grab(CursorGrabMode::Locked);
+            let (pending_grab, pending_vis) = cursor::take_pending();
+            let mut applied = cursor::current_state();
+            if let Some(mode) = pending_grab {
+                let primary = match mode {
+                    cursor::GrabMode::None => CursorGrabMode::None,
+                    cursor::GrabMode::Confined => CursorGrabMode::Confined,
+                    cursor::GrabMode::Locked => CursorGrabMode::Locked,
+                };
+                if win.set_cursor_grab(primary).is_err()
+                    && mode != cursor::GrabMode::None
+                {
+                    let fallback = match mode {
+                        cursor::GrabMode::Locked => CursorGrabMode::Confined,
+                        cursor::GrabMode::Confined => CursorGrabMode::Locked,
+                        cursor::GrabMode::None => CursorGrabMode::None,
+                    };
+                    let _ = win.set_cursor_grab(fallback);
+                }
+                applied.grab = mode;
             }
-            win.set_cursor_visible(!grab);
+            if let Some(visible) = pending_vis {
+                win.set_cursor_visible(visible);
+                applied.visible = visible;
+            }
+            if pending_grab.is_some() || pending_vis.is_some() {
+                cursor::mark_applied(applied.grab, applied.visible);
+            }
         }
 
         let Some(rd) = self.rd.as_ref() else { return };

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -81,8 +81,8 @@ pub mod args;
 pub mod capture;
 pub mod cursor;
 pub mod fps;
-pub mod freecam;
 pub mod frame_pacing;
+pub mod freecam;
 pub mod keymap;
 pub mod log;
 pub mod trace;
@@ -1210,9 +1210,7 @@ impl<A: App> Runner<A> {
                     cursor::GrabMode::Confined => CursorGrabMode::Confined,
                     cursor::GrabMode::Locked => CursorGrabMode::Locked,
                 };
-                if win.set_cursor_grab(primary).is_err()
-                    && mode != cursor::GrabMode::None
-                {
+                if win.set_cursor_grab(primary).is_err() && mode != cursor::GrabMode::None {
                     let fallback = match mode {
                         cursor::GrabMode::Locked => CursorGrabMode::Confined,
                         cursor::GrabMode::Confined => CursorGrabMode::Locked,
@@ -1228,6 +1226,19 @@ impl<A: App> Runner<A> {
             }
             if pending_grab.is_some() || pending_vis.is_some() {
                 cursor::mark_applied(applied.grab, applied.visible);
+            }
+            // Warp-to-center request. Applied AFTER the grab/visibility
+            // transition so the new cursor state is in effect first; warping
+            // a still-Locked cursor would be a no-op (winit pins it to the
+            // center already), but pairing the warp with a release lands the
+            // pointer where the user was aiming when they Alt-tabbed out.
+            if cursor::take_pending_warp_center() {
+                let size = win.inner_size();
+                let center = winit::dpi::PhysicalPosition::new(
+                    size.width as f64 / 2.0,
+                    size.height as f64 / 2.0,
+                );
+                let _ = win.set_cursor_position(center);
             }
         }
 

--- a/crates/rye-app/src/trace.rs
+++ b/crates/rye-app/src/trace.rs
@@ -365,8 +365,18 @@ impl PerfOverlay {
             0.0
         };
 
+        // Position: top-right by default, but `.movable(true)` lets the user
+        // drag it anywhere. egui persists the resulting offset by `Id` so the
+        // overlay re-opens where the user last left it (within the session).
+        // `Area::default_pos` is honored once; subsequent frames read the
+        // persisted position from `ctx.memory`. Use `default_pos` instead of
+        // `anchor` because anchored areas ignore drag.
+        let screen = ctx.content_rect();
+        let default_x = (screen.right() - 12.0 - 260.0).max(0.0);
         egui::Area::new(egui::Id::new("rye-perf-overlay"))
-            .anchor(egui::Align2::RIGHT_TOP, [-12.0, 12.0])
+            .default_pos(egui::pos2(default_x, 12.0))
+            .movable(true)
+            .order(egui::Order::Foreground)
             .show(ctx, |ui| {
                 egui::Frame::popup(ui.style())
                     .stroke(egui::Stroke::new(1.0, egui::Color32::from_rgb(60, 60, 75)))

--- a/crates/rye-app/src/version.rs
+++ b/crates/rye-app/src/version.rs
@@ -1,0 +1,59 @@
+//! Console command that prints the demo's build identity. Sibling to
+//! [`crate::trace`], [`crate::fps`], [`crate::vsync`] in structure.
+//!
+//! ## What it shows
+//!
+//! - Crate name (passed by the caller; the demo's binary name).
+//! - Crate version (from `CARGO_PKG_VERSION` at compile time).
+//! - Git short hash + dirty marker (from the demo's `build.rs` baking
+//!   `BUILD_HASH` and `BUILD_DIRTY` env vars; if a demo's `build.rs`
+//!   doesn't bake these, the demo passes empty strings and the output
+//!   degrades gracefully).
+//!
+//! Example output: `polytope_playground v0.1.0 (a3f9c1d2+dirty)`.
+//!
+//! ## Wiring (per demo)
+//!
+//! ```ignore
+//! rye_app::version::register_command(
+//!     &mut console,
+//!     env!("CARGO_PKG_NAME"),
+//!     env!("CARGO_PKG_VERSION"),
+//!     env!("BUILD_HASH"),
+//!     env!("BUILD_DIRTY"),
+//! );
+//! ```
+
+use rye_egui::{cmd, Console};
+
+/// Register the `version` console command for a demo.
+///
+/// Pass `env!()` strings from the demo's own crate so each demo reports
+/// its own name + version + build hash. The hash and dirty fields can be
+/// empty if the demo doesn't have a `build.rs` baking those env vars; the
+/// output collapses to just the crate name + version.
+pub fn register_command<Ctx: 'static>(
+    console: &mut Console<Ctx>,
+    crate_name: &'static str,
+    crate_version: &'static str,
+    build_hash: &'static str,
+    build_dirty: &'static str,
+) {
+    console.register(
+        cmd(
+            "version",
+            "show the demo's crate version + git build hash",
+            move |_args, _ctx: &mut Ctx, out| {
+                let line = if build_hash.is_empty() {
+                    format!("{crate_name} v{crate_version}")
+                } else {
+                    format!(
+                        "{crate_name} v{crate_version} ({build_hash}{build_dirty})"
+                    )
+                };
+                out.line(line);
+                Ok(())
+            },
+        ),
+    );
+}

--- a/crates/rye-app/src/version.rs
+++ b/crates/rye-app/src/version.rs
@@ -39,21 +39,17 @@ pub fn register_command<Ctx: 'static>(
     build_hash: &'static str,
     build_dirty: &'static str,
 ) {
-    console.register(
-        cmd(
-            "version",
-            "show the demo's crate version + git build hash",
-            move |_args, _ctx: &mut Ctx, out| {
-                let line = if build_hash.is_empty() {
-                    format!("{crate_name} v{crate_version}")
-                } else {
-                    format!(
-                        "{crate_name} v{crate_version} ({build_hash}{build_dirty})"
-                    )
-                };
-                out.line(line);
-                Ok(())
-            },
-        ),
-    );
+    console.register(cmd(
+        "version",
+        "show the demo's crate version + git build hash",
+        move |_args, _ctx: &mut Ctx, out| {
+            let line = if build_hash.is_empty() {
+                format!("{crate_name} v{crate_version}")
+            } else {
+                format!("{crate_name} v{crate_version} ({build_hash}{build_dirty})")
+            };
+            out.line(line);
+            Ok(())
+        },
+    ));
 }

--- a/crates/rye-camera/src/controller.rs
+++ b/crates/rye-camera/src/controller.rs
@@ -192,6 +192,13 @@ impl<S: Space<Point = Vec3, Vector = Vec3>> CameraController<S> for OrbitControl
 pub struct FirstPersonController<S: Space> {
     pub yaw: f32,
     pub pitch: f32,
+    /// When `true`, integrate [`FrameInput::mouse_raw_delta`] instead of
+    /// `mouse_delta`. Pair with a grabbed cursor (see `rye_app::cursor`):
+    /// the OS reports raw device motion that doesn't cap at the screen
+    /// edge, so a fast horizontal flick can yaw the camera arbitrarily far
+    /// without the cursor "running out of room." Default off (uses the
+    /// clamped delta), which is what the orbit-mode camera consumers want.
+    pub use_raw_delta: bool,
     _marker: PhantomData<S>,
 }
 
@@ -200,6 +207,7 @@ impl<S: Space<Point = Vec3, Vector = Vec3>> FirstPersonController<S> {
         Self {
             yaw,
             pitch: pitch.clamp(FIRST_PERSON_MIN_PITCH, FIRST_PERSON_MAX_PITCH),
+            use_raw_delta: false,
             _marker: PhantomData,
         }
     }
@@ -207,8 +215,13 @@ impl<S: Space<Point = Vec3, Vector = Vec3>> FirstPersonController<S> {
 
 impl<S: Space<Point = Vec3, Vector = Vec3>> CameraController<S> for FirstPersonController<S> {
     fn advance(&mut self, input: FrameInput, camera: &mut Camera<S>, _space: &S, _dt: f32) {
-        self.yaw -= input.mouse_delta.x * FIRST_PERSON_MOUSE_SENSITIVITY;
-        self.pitch = (self.pitch - input.mouse_delta.y * FIRST_PERSON_MOUSE_SENSITIVITY)
+        let delta = if self.use_raw_delta {
+            input.mouse_raw_delta
+        } else {
+            input.mouse_delta
+        };
+        self.yaw -= delta.x * FIRST_PERSON_MOUSE_SENSITIVITY;
+        self.pitch = (self.pitch - delta.y * FIRST_PERSON_MOUSE_SENSITIVITY)
             .clamp(FIRST_PERSON_MIN_PITCH, FIRST_PERSON_MAX_PITCH);
 
         let yaw_q = Quat::from_rotation_y(self.yaw);

--- a/crates/rye-egui/src/console/panel.rs
+++ b/crates/rye-egui/src/console/panel.rs
@@ -28,6 +28,7 @@
 //! frame), so the user can click outside the window to give keyboard back to the app.
 
 use egui::{
+    text::{LayoutJob, TextFormat},
     Color32, FontId, Frame, Label, Layout, Margin, Order, RichText, ScrollArea, Sense, Stroke,
     TextEdit, TextWrapMode,
 };
@@ -269,28 +270,68 @@ fn draw_scrollback<Ctx>(ui: &mut egui::Ui, console: &Console<Ctx>, height: f32, 
                             bottom: 4,
                         })
                         .show(ui, |ui| {
-                            // Tight per-line vertical spacing keeps the scrollback
-                            // dense without crowding wrapped continuation rows.
-                            ui.spacing_mut().item_spacing.y = 2.0;
-                            for line in &console.history {
-                                ui.add(Label::new(line_text(line)).wrap_mode(TextWrapMode::Wrap));
-                            }
+                            // Single selectable Label backed by a multi-color
+                            // LayoutJob. Lets the user drag-select across line
+                            // boundaries and Ctrl-C / context-menu copy to the
+                            // platform clipboard. The previous per-line Label
+                            // setup rendered the same text but at the canvas
+                            // level: glyphs got rasterized into the wgpu
+                            // surface with no DOM text behind them, so the
+                            // browser's selection rectangle highlighted pixels
+                            // but Ctrl-C copied an empty string. Building one
+                            // LayoutJob preserves per-line color styling
+                            // (Input vs Output vs Error vs System) while
+                            // giving egui's selection a single span to track.
+                            ui.add(
+                                Label::new(scrollback_layout_job(&console.history))
+                                    .wrap_mode(TextWrapMode::Wrap)
+                                    .selectable(true),
+                            );
                         });
                 });
         },
     );
 }
 
-fn line_text(line: &HistoryLine) -> RichText {
-    let color = match line.kind {
+/// Color for a given line kind. Pulled out so the LayoutJob builder + any
+/// future per-line widget can agree.
+fn line_color(kind: LineKind) -> Color32 {
+    match kind {
         LineKind::Input => COLOR_INPUT_ECHO,
         LineKind::Output => COLOR_OUTPUT,
         LineKind::Error => COLOR_ERROR,
         LineKind::System => COLOR_SYSTEM,
-    };
-    RichText::new(&line.text)
-        .color(color)
-        .font(FontId::monospace(FONT_SIZE))
+    }
+}
+
+/// Build a single `LayoutJob` for the scrollback history. Each line gets
+/// its kind-appropriate color via per-section `TextFormat`s; `\n`
+/// separators between lines are appended in the default (`Output`) color
+/// because egui doesn't render the newline glyph itself, only positions
+/// the next section below.
+///
+/// One Label wrapping this job is selectable across line boundaries and
+/// copyable to the platform clipboard via Ctrl-C / right-click menu;
+/// see the call site in `draw_scrollback` for why one job beats N labels.
+fn scrollback_layout_job(history: &std::collections::VecDeque<HistoryLine>) -> LayoutJob {
+    let mut job = LayoutJob::default();
+    let font = FontId::monospace(FONT_SIZE);
+    let last = history.len().saturating_sub(1);
+    for (i, line) in history.iter().enumerate() {
+        let fmt = TextFormat {
+            font_id: font.clone(),
+            color: line_color(line.kind),
+            ..Default::default()
+        };
+        job.append(&line.text, 0.0, fmt);
+        if i < last {
+            // Newline carries no visible glyph but determines layout
+            // wrap position; use a minimal default format so it never
+            // contributes color.
+            job.append("\n", 0.0, TextFormat::default());
+        }
+    }
+    job
 }
 
 fn draw_input_row<Ctx: 'static>(

--- a/crates/rye-egui/src/console/panel.rs
+++ b/crates/rye-egui/src/console/panel.rs
@@ -430,3 +430,104 @@ fn draw_input_row<Ctx: 'static>(
         },
     );
 }
+
+#[cfg(test)]
+mod tests {
+    //! Tests for `scrollback_layout_job`, the LayoutJob builder backing the
+    //! single-Label scrollback (so Ctrl-C cross-line copy works in browser +
+    //! native). These verify the structural invariants the UI path relies on:
+    //! one section per line, per-kind coloring, newline separators between
+    //! lines. UI rendering itself is not exercised; we read the LayoutJob
+    //! `sections` vector directly.
+    use super::*;
+    use std::collections::VecDeque;
+
+    fn history(lines: &[(LineKind, &str)]) -> VecDeque<HistoryLine> {
+        lines
+            .iter()
+            .map(|(kind, text)| HistoryLine {
+                kind: *kind,
+                text: (*text).to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn empty_history_yields_empty_job() {
+        let job = scrollback_layout_job(&VecDeque::new());
+        assert!(job.text.is_empty());
+        assert!(job.sections.is_empty());
+    }
+
+    /// One line in -> one colored section (no trailing newline; the trailing
+    /// `\n` is only inserted BETWEEN lines so the last line stays single-section).
+    #[test]
+    fn single_line_emits_one_colored_section() {
+        let h = history(&[(LineKind::Output, "hello")]);
+        let job = scrollback_layout_job(&h);
+        assert_eq!(job.text, "hello");
+        assert_eq!(job.sections.len(), 1);
+        assert_eq!(job.sections[0].format.color, COLOR_OUTPUT);
+    }
+
+    /// N lines -> 2N-1 sections (N line sections + N-1 newline separators).
+    /// The newline sections carry the default format so they don't accidentally
+    /// recolor empty regions.
+    #[test]
+    fn multiple_lines_alternate_with_newline_separators() {
+        let h = history(&[
+            (LineKind::Input, "> reset"),
+            (LineKind::Output, "ok"),
+            (LineKind::Error, "boom"),
+        ]);
+        let job = scrollback_layout_job(&h);
+        assert_eq!(job.text, "> reset\nok\nboom");
+        // 3 line sections + 2 newline separators = 5 total.
+        assert_eq!(job.sections.len(), 5);
+    }
+
+    /// Each LineKind gets its kind-appropriate color in the LayoutJob section.
+    /// If a future edit changes the per-kind palette without updating
+    /// `line_color`, this test catches the drift.
+    #[test]
+    fn per_line_color_matches_line_kind() {
+        let h = history(&[
+            (LineKind::Input, "in"),
+            (LineKind::Output, "out"),
+            (LineKind::Error, "err"),
+            (LineKind::System, "sys"),
+        ]);
+        let job = scrollback_layout_job(&h);
+        // Sections in order: input, "\n", output, "\n", error, "\n", system.
+        let input_section = &job.sections[0];
+        let output_section = &job.sections[2];
+        let error_section = &job.sections[4];
+        let system_section = &job.sections[6];
+        assert_eq!(input_section.format.color, COLOR_INPUT_ECHO);
+        assert_eq!(output_section.format.color, COLOR_OUTPUT);
+        assert_eq!(error_section.format.color, COLOR_ERROR);
+        assert_eq!(system_section.format.color, COLOR_SYSTEM);
+    }
+
+    /// All line sections use the monospace font at FONT_SIZE. The Ctrl-C copy
+    /// behavior relies on text inside one Label (one font config) so cross-line
+    /// drag-select works without breaks; if a future edit mixes fonts within
+    /// the job, selection would visually split.
+    #[test]
+    fn all_line_sections_share_monospace_font() {
+        let h = history(&[
+            (LineKind::Input, "a"),
+            (LineKind::Output, "b"),
+            (LineKind::Error, "c"),
+        ]);
+        let job = scrollback_layout_job(&h);
+        let expected_font = FontId::monospace(FONT_SIZE);
+        // Sections 0, 2, 4 are line content; 1, 3 are newlines.
+        for idx in [0, 2, 4] {
+            assert_eq!(
+                job.sections[idx].format.font_id, expected_font,
+                "section {idx} (line content) should be monospace",
+            );
+        }
+    }
+}

--- a/crates/rye-input/src/lib.rs
+++ b/crates/rye-input/src/lib.rs
@@ -29,12 +29,23 @@ pub const SCROLL_PIXELS_PER_LINE: f32 = 50.0;
 
 /// Accumulated input for one simulation tick, consumed by [`InputState::take_frame`].
 ///
-/// `mouse_delta` and `scroll_lines` reset to zero each frame. `left_mouse_down` persists
-/// until the button is released. `move_*` axes are recomputed from held keys each frame:
-/// +1 / 0 / -1, not accumulated.
+/// `mouse_delta` / `mouse_raw_delta` / `scroll_lines` reset to zero each frame.
+/// `left_mouse_down` persists until the button is released. `move_*` axes are
+/// recomputed from held keys each frame: +1 / 0 / -1, not accumulated.
+///
+/// `mouse_delta` is the OS-clamped cursor delta (`WindowEvent::CursorMoved`).
+/// It stops accumulating when the cursor hits the screen edge or leaves the
+/// window. Right for orbit controllers and any UI-facing handler that wants
+/// the cursor's actual position to mean something.
+///
+/// `mouse_raw_delta` is the raw device delta (`DeviceEvent::MouseMotion`).
+/// It accumulates regardless of cursor position; the OS reports the
+/// underlying mouse motion before clamping. Right for FPS-style mouse-look
+/// where you grab the cursor and want infinite-yaw / infinite-pitch.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct FrameInput {
     pub mouse_delta: Vec2,
+    pub mouse_raw_delta: Vec2,
     pub scroll_lines: f32,
     pub left_mouse_down: bool,
     /// WASD forward/back: W = +1, S = −1.
@@ -129,8 +140,18 @@ impl InputState {
 
         let frame = self.frame;
         self.frame.mouse_delta = Vec2::ZERO;
+        self.frame.mouse_raw_delta = Vec2::ZERO;
         self.frame.scroll_lines = 0.0;
         frame
+    }
+
+    /// Accumulate raw device motion (`DeviceEvent::MouseMotion`) into
+    /// `FrameInput::mouse_raw_delta`. Independent of `cursor_moved`; both
+    /// accumulators run in parallel and the consumer picks one. Right for
+    /// FPS-style mouse-look that wants infinite-yaw delta past the screen
+    /// edge.
+    pub fn accumulate_raw_motion(&mut self, dx: f64, dy: f64) {
+        self.frame.mouse_raw_delta += Vec2::new(dx as f32, dy as f32);
     }
 }
 

--- a/crates/rye-input/src/lib.rs
+++ b/crates/rye-input/src/lib.rs
@@ -150,6 +150,12 @@ impl InputState {
     /// accumulators run in parallel and the consumer picks one. Right for
     /// FPS-style mouse-look that wants infinite-yaw delta past the screen
     /// edge.
+    ///
+    /// Internal: only the runner's `device_event` handler is expected to
+    /// call this. Exposed `pub` because the runner lives in a separate
+    /// crate (`rye-app`) and Rust's visibility doesn't have a workspace-
+    /// internal mode. `#[doc(hidden)]` to keep it out of demo-facing docs.
+    #[doc(hidden)]
     pub fn accumulate_raw_motion(&mut self, dx: f64, dy: f64) {
         self.frame.mouse_raw_delta += Vec2::new(dx as f32, dy as f32);
     }

--- a/crates/rye-render/src/raymarch/hyperslice4d.rs
+++ b/crates/rye-render/src/raymarch/hyperslice4d.rs
@@ -1185,6 +1185,32 @@ fn rye_scene_max_t(ro: vec3<f32>, rd: vec3<f32>) -> f32 {
             .expect("hyperslice4d kernel + Scene4 emit should validate");
     }
 
+    /// Same scene + kernel composition as `kernel_validates_with_real_scene_union`, but
+    /// against the gated emit form (`to_hyperslice_wgsl_gated`). Catches WGSL drift when
+    /// the runtime halfspace toggle is wired into the kernel via `u.params.x`. The kernel
+    /// already declares `params: vec4<f32>` in its uniform struct, so the gate expression
+    /// resolves at parse time.
+    #[test]
+    fn kernel_validates_with_gated_scene() {
+        use glam::Vec4;
+        use rye_scene::{Scene4, SceneNode4};
+
+        let scene = Scene4::new(
+            SceneNode4::hypersphere(Vec4::new(0.0, 1.0, 0.0, 0.0), 0.5)
+                .union(SceneNode4::halfspace(Vec4::Y, 0.0)),
+        );
+        let scene_wgsl = scene.to_hyperslice_wgsl_gated("u.w_slice", "u.params.x");
+        let polytope = super::super::polytope_data::polytope_extended_sdfs_wgsl();
+        let source = format!("{HYPERSLICE_KERNEL_WGSL}\n{polytope}\n{scene_wgsl}");
+        let module = naga::front::wgsl::parse_str(&source)
+            .expect("gated Scene4 emit should parse against the kernel");
+        let flags = naga::valid::ValidationFlags::all();
+        let caps = naga::valid::Capabilities::empty();
+        naga::valid::Validator::new(flags, caps)
+            .validate(&module)
+            .expect("gated Scene4 emit should validate against the kernel");
+    }
+
     /// `BODY_KIND_INVALID` must not appear in either dispatch chain. The whole point of the
     /// sentinel is that no branch matches it, so the SDF accumulator passes through unchanged. If
     /// a future edit adds a comparison against `BODY_KIND_INVALID` (in either operand order),

--- a/crates/rye-scene/src/scene4.rs
+++ b/crates/rye-scene/src/scene4.rs
@@ -117,7 +117,8 @@ impl Scene4 {
         let mut helpers = String::new();
         let mut body = String::new();
         let mut counter = 0u32;
-        let (d_root, _k_root) = emit_node_4d(&self.root, &mut counter, &mut helpers, &mut body);
+        let (d_root, _k_root) =
+            emit_node_4d(&self.root, &mut counter, &mut helpers, &mut body, None);
         let kind_consts = SCENE_KIND_CONSTANTS;
         format!(
             "// ---- rye-scene scene4 (native 4D) ----\n\
@@ -140,40 +141,32 @@ impl Scene4 {
     /// Kind tracking: union picks the closer leaf, intersection picks the farther (boundary)
     /// leaf, difference returns `RYE_PRIM_OTHER`.
     pub fn to_hyperslice_wgsl(&self, w_slice_expr: &str) -> String {
-        let mut helpers = String::new();
-        let mut body = String::new();
-        let mut counter = 0u32;
-        let (d_root, k_root) = emit_node_4d(&self.root, &mut counter, &mut helpers, &mut body);
-        let kind_consts = SCENE_KIND_CONSTANTS;
-        let max_t_body = emit_max_t_body(&self.root);
-        // Use a distinct parameter name `p3` and an inner `let p` for the 4D point. WGSL
-        // forbids declaring a `let` with the same name as the function parameter (no shadowing);
-        // naming the parameter `p3` keeps the helper-emit convention (which calls `sdfN_pK(p)`)
-        // intact while sidestepping the collision.
-        format!(
-            "// ---- rye-scene scene4 (hyperslice at w = {w_slice_expr}) ----\n\
-             {kind_consts}\
-             struct RyeSceneHit {{ dist: f32, kind: u32 }}\n\
-             {helpers}\
-             fn rye_scene_at(p3: vec3<f32>) -> RyeSceneHit {{\n\
-             \tlet p = vec4<f32>(p3, {w_slice_expr});\n\
-             {body}\
-             \treturn RyeSceneHit({d_root}, {k_root});\n\
-             }}\n\
-             fn rye_scene_sdf(p3: vec3<f32>) -> f32 {{\n\
-             \treturn rye_scene_at(p3).dist;\n\
-             }}\n\
-             // Analytical upper bound on march distance: ray-plane intersection\n\
-             // for every HalfSpace4D leaf in the scene whose 3D-projected\n\
-             // normal points against the ray. Returns +infinity if no leaf\n\
-             // contributes; the kernel uses this to terminate near-horizon\n\
-             // rays that would otherwise exhaust the iteration budget.\n\
-             fn rye_scene_max_t(ro: vec3<f32>, rd: vec3<f32>) -> f32 {{\n\
-             \tvar t_max: f32 = 1.0e9;\n\
-             {max_t_body}\
-             \treturn t_max;\n\
-             }}\n"
-        )
+        emit_hyperslice(self, w_slice_expr, None)
+    }
+
+    /// Like [`Self::to_hyperslice_wgsl`] but with a runtime gate on every
+    /// [`Shape::HalfSpace4D`] leaf: when the WGSL expression
+    /// `halfspace_gate_expr` evaluates to `< 0.5` at runtime, every
+    /// halfspace SDF returns `1.0e9` (effectively absent) AND every
+    /// halfspace's contribution to `rye_scene_max_t` is skipped. When the
+    /// gate evaluates to `>= 0.5`, behavior matches the ungated emit.
+    ///
+    /// Use-case: per-frame toggle of floor / ceiling / cutaway planes via
+    /// a single uniform read, without re-compiling the shader on every
+    /// flip. Caller writes a `f32` into the uniform pointed at by
+    /// `halfspace_gate_expr` (typically a slot of `u.params`).
+    ///
+    /// `halfspace_gate_expr` should be a scalar `f32` WGSL expression in
+    /// scope at the call sites (`rye_scene_at`, `rye_scene_max_t`).
+    /// Examples: `"u.params.x"`, `"u.floor_enabled"`, `"1.0"` (always on,
+    /// equivalent to the ungated emit), `"0.0"` (always off; every
+    /// halfspace silently disappears).
+    pub fn to_hyperslice_wgsl_gated(
+        &self,
+        w_slice_expr: &str,
+        halfspace_gate_expr: &str,
+    ) -> String {
+        emit_hyperslice(self, w_slice_expr, Some(halfspace_gate_expr))
     }
 
     pub fn from_ron(src: &str) -> Result<Self, ron::error::SpannedError> {
@@ -192,39 +185,103 @@ const RYE_PRIM_HYPERSPHERE4D: u32 = 0u;\n\
 const RYE_PRIM_HALFSPACE4D: u32 = 1u;\n\
 const RYE_PRIM_OTHER: u32 = 255u;\n";
 
+/// Shared emit driver for [`Scene4::to_hyperslice_wgsl`] and
+/// [`Scene4::to_hyperslice_wgsl_gated`]. The optional `halfspace_gate_expr` wraps
+/// every `HalfSpace4D` leaf's SDF call in `select(1.0e9, raw, <expr> >= 0.5)`
+/// AND skips its `rye_scene_max_t` contribution under the same condition. When
+/// `None`, the emit is identical to the original ungated form.
+fn emit_hyperslice(
+    scene: &Scene4,
+    w_slice_expr: &str,
+    halfspace_gate_expr: Option<&str>,
+) -> String {
+    let mut helpers = String::new();
+    let mut body = String::new();
+    let mut counter = 0u32;
+    let (d_root, k_root) = emit_node_4d(
+        &scene.root,
+        &mut counter,
+        &mut helpers,
+        &mut body,
+        halfspace_gate_expr,
+    );
+    let kind_consts = SCENE_KIND_CONSTANTS;
+    let max_t_body = emit_max_t_body(&scene.root, halfspace_gate_expr);
+    // Use a distinct parameter name `p3` and an inner `let p` for the 4D point. WGSL
+    // forbids declaring a `let` with the same name as the function parameter (no shadowing);
+    // naming the parameter `p3` keeps the helper-emit convention (which calls `sdfN_pK(p)`)
+    // intact while sidestepping the collision.
+    format!(
+        "// ---- rye-scene scene4 (hyperslice at w = {w_slice_expr}) ----\n\
+         {kind_consts}\
+         struct RyeSceneHit {{ dist: f32, kind: u32 }}\n\
+         {helpers}\
+         fn rye_scene_at(p3: vec3<f32>) -> RyeSceneHit {{\n\
+         \tlet p = vec4<f32>(p3, {w_slice_expr});\n\
+         {body}\
+         \treturn RyeSceneHit({d_root}, {k_root});\n\
+         }}\n\
+         fn rye_scene_sdf(p3: vec3<f32>) -> f32 {{\n\
+         \treturn rye_scene_at(p3).dist;\n\
+         }}\n\
+         // Analytical upper bound on march distance: ray-plane intersection\n\
+         // for every HalfSpace4D leaf in the scene whose 3D-projected\n\
+         // normal points against the ray. Returns +infinity if no leaf\n\
+         // contributes; the kernel uses this to terminate near-horizon\n\
+         // rays that would otherwise exhaust the iteration budget.\n\
+         fn rye_scene_max_t(ro: vec3<f32>, rd: vec3<f32>) -> f32 {{\n\
+         \tvar t_max: f32 = 1.0e9;\n\
+         {max_t_body}\
+         \treturn t_max;\n\
+         }}\n"
+    )
+}
+
 /// Emit the body of `rye_scene_max_t`: ray-plane intersection check for each `HalfSpace4D`
 /// leaf. Only the 3D part of the normal is used (the slice fixes `p.w`). Combinator-agnostic:
 /// visit every leaf, fold into `t_max` via `min` to get a conservative bound.
-fn emit_max_t_body(node: &SceneNode4) -> String {
+fn emit_max_t_body(node: &SceneNode4, halfspace_gate_expr: Option<&str>) -> String {
     let mut body = String::new();
-    walk_max_t(node, &mut body);
+    walk_max_t(node, &mut body, halfspace_gate_expr);
     body
 }
 
-fn walk_max_t(node: &SceneNode4, body: &mut String) {
+fn walk_max_t(node: &SceneNode4, body: &mut String, halfspace_gate_expr: Option<&str>) {
     match node {
         SceneNode4::Leaf(Shape::HalfSpace4D { normal, offset }) => {
             // t = (offset - dot(ro, n)) / dot(rd, n), guarded by dot(rd, n) < 0 so we only
-            // catch rays heading toward the plane's solid side.
-            body.push_str(&format!(
-                "\t{{\n\
-                 \t\tlet n = vec3<f32>({nx:.6}, {ny:.6}, {nz:.6});\n\
+            // catch rays heading toward the plane's solid side. When a runtime gate is set,
+            // wrap the entire t-contribution in `if (<gate> >= 0.5)` so a gated-off halfspace
+            // contributes no early-termination bound (rays march to the global cap instead).
+            let inner = format!(
+                "\t\tlet n = vec3<f32>({nx:.6}, {ny:.6}, {nz:.6});\n\
                  \t\tlet dr = dot(rd, n);\n\
                  \t\tif (dr < -1.0e-4) {{\n\
                  \t\t\tlet t = ({offset:.6} - dot(ro, n)) / dr;\n\
                  \t\t\tif (t > 0.0 && t < t_max) {{ t_max = t; }}\n\
-                 \t\t}}\n\
-                 \t}}\n",
+                 \t\t}}\n",
                 nx = normal.x,
                 ny = normal.y,
                 nz = normal.z,
                 offset = offset,
-            ));
+            );
+            match halfspace_gate_expr {
+                None => {
+                    body.push_str("\t{\n");
+                    body.push_str(&inner);
+                    body.push_str("\t}\n");
+                }
+                Some(gate) => {
+                    body.push_str(&format!("\tif ({gate} >= 0.5) {{\n"));
+                    body.push_str(&inner);
+                    body.push_str("\t}\n");
+                }
+            }
         }
         SceneNode4::Leaf(_) => {} // Other primitives: no closed-form bound.
         SceneNode4::Union(l, r) | SceneNode4::Intersection(l, r) | SceneNode4::Difference(l, r) => {
-            walk_max_t(l, body);
-            walk_max_t(r, body);
+            walk_max_t(l, body, halfspace_gate_expr);
+            walk_max_t(r, body, halfspace_gate_expr);
         }
     }
 }
@@ -240,12 +297,15 @@ fn primitive_kind_constant(shape: &Shape) -> &'static str {
 
 /// Walk the 4D scene tree, append helper functions to `helpers` and `let` bindings to `body`.
 /// Returns `(dist_var, kind_var)`, the WGSL identifiers holding this node's signed distance and
-/// closest-primitive kind.
+/// closest-primitive kind. When `halfspace_gate_expr` is Some, every `HalfSpace4D` leaf's SDF
+/// call is wrapped in `select(1.0e9, raw, <expr> >= 0.5)` so the leaf disappears from the
+/// scene when the gate evaluates to off at runtime.
 fn emit_node_4d(
     node: &SceneNode4,
     counter: &mut u32,
     helpers: &mut String,
     body: &mut String,
+    halfspace_gate_expr: Option<&str>,
 ) -> (String, String) {
     let idx = *counter;
     *counter += 1;
@@ -256,13 +316,25 @@ fn emit_node_4d(
             let d_var = format!("d{idx}");
             let k_var = format!("k{idx}");
             let kind = primitive_kind_constant(prim);
-            body.push_str(&format!("\tlet {d_var} = {fn_name}(p);\n"));
+            // Halfspace leaves with an active gate route through `select`; everything else
+            // emits the raw SDF call unchanged. Keeping the gate confined to HalfSpace4D
+            // avoids polluting hypersphere / polytope SDFs that have no toggle semantic.
+            let gated = matches!(prim, Shape::HalfSpace4D { .. }) && halfspace_gate_expr.is_some();
+            if gated {
+                let gate = halfspace_gate_expr.expect("gated branch implies Some");
+                body.push_str(&format!("\tlet {d_var}_raw = {fn_name}(p);\n"));
+                body.push_str(&format!(
+                    "\tlet {d_var} = select(1.0e9, {d_var}_raw, {gate} >= 0.5);\n"
+                ));
+            } else {
+                body.push_str(&format!("\tlet {d_var} = {fn_name}(p);\n"));
+            }
             body.push_str(&format!("\tlet {k_var}: u32 = {kind};\n"));
             (d_var, k_var)
         }
         SceneNode4::Union(left, right) => {
-            let (ld, lk) = emit_node_4d(left, counter, helpers, body);
-            let (rd, rk) = emit_node_4d(right, counter, helpers, body);
+            let (ld, lk) = emit_node_4d(left, counter, helpers, body, halfspace_gate_expr);
+            let (rd, rk) = emit_node_4d(right, counter, helpers, body, halfspace_gate_expr);
             let d_var = format!("d{idx}");
             let k_var = format!("k{idx}");
             body.push_str(&format!("\tlet {d_var} = min({ld}, {rd});\n"));
@@ -273,8 +345,8 @@ fn emit_node_4d(
             (d_var, k_var)
         }
         SceneNode4::Intersection(left, right) => {
-            let (ld, lk) = emit_node_4d(left, counter, helpers, body);
-            let (rd, rk) = emit_node_4d(right, counter, helpers, body);
+            let (ld, lk) = emit_node_4d(left, counter, helpers, body, halfspace_gate_expr);
+            let (rd, rk) = emit_node_4d(right, counter, helpers, body, halfspace_gate_expr);
             let d_var = format!("d{idx}");
             let k_var = format!("k{idx}");
             body.push_str(&format!("\tlet {d_var} = max({ld}, {rd});\n"));
@@ -285,8 +357,8 @@ fn emit_node_4d(
             (d_var, k_var)
         }
         SceneNode4::Difference(left, right) => {
-            let (ld, _lk) = emit_node_4d(left, counter, helpers, body);
-            let (rd, _rk) = emit_node_4d(right, counter, helpers, body);
+            let (ld, _lk) = emit_node_4d(left, counter, helpers, body, halfspace_gate_expr);
+            let (rd, _rk) = emit_node_4d(right, counter, helpers, body, halfspace_gate_expr);
             let d_var = format!("d{idx}");
             let k_var = format!("k{idx}");
             body.push_str(&format!("\tlet {d_var} = max({ld}, -({rd}));\n"));
@@ -411,5 +483,63 @@ mod tests {
         );
         let wgsl = scene.to_hyperslice_wgsl("u.w_slice");
         assert!(wgsl.contains(": u32 = RYE_PRIM_OTHER;"));
+    }
+
+    /// Gated emit wraps every HalfSpace4D leaf's SDF in a `select(1.0e9, raw, gate >= 0.5)`
+    /// so a runtime uniform flip makes the halfspace effectively invisible. Hyperspheres
+    /// (and any other non-halfspace primitive) are untouched by the gate.
+    #[test]
+    fn hyperslice_gated_wraps_halfspaces_only() {
+        let scene = Scene4::new(
+            SceneNode4::hypersphere(Vec4::ZERO, 0.5).union(SceneNode4::halfspace(Vec4::Y, 0.0)),
+        );
+        let wgsl = scene.to_hyperslice_wgsl_gated("u.w_slice", "u.params.x");
+        // The halfspace leaf gets routed through select; the gate expression must appear
+        // verbatim in the emit. Hypersphere leaf stays a plain `sdfN_pK(p)` call.
+        assert!(
+            wgsl.contains("select(1.0e9,"),
+            "gated halfspace must emit select(1.0e9, ...)"
+        );
+        assert!(
+            wgsl.contains("u.params.x >= 0.5"),
+            "gate expression must appear in the select"
+        );
+        // The hypersphere leaf's helper is still called raw (no select wrapper around it).
+        // The first leaf (sdf4_p1, since p0 is the union root in traversal order;
+        // leaves are hypersphere=p1, halfspace=p2 in pre-order). Assert that at least
+        // one leaf binds without `_raw`.
+        assert!(wgsl.contains("let d1 = sdf4_p1(p);"));
+    }
+
+    /// Gated emit also wraps the `rye_scene_max_t` halfspace contribution in
+    /// `if (gate >= 0.5) { ... }` so a gated-off halfspace doesn't terminate rays early.
+    /// Without this, the marcher would still treat the floor as a far-clip even after
+    /// the SDF goes to 1.0e9, capping near-horizon rays prematurely.
+    #[test]
+    fn hyperslice_gated_skips_max_t_when_off() {
+        let scene = Scene4::new(SceneNode4::halfspace(Vec4::Y, 0.0));
+        let wgsl = scene.to_hyperslice_wgsl_gated("u.w_slice", "u.params.x");
+        // The if-guard appears in the max_t body around the t_max update.
+        assert!(
+            wgsl.contains("if (u.params.x >= 0.5) {"),
+            "gated max_t must guard the halfspace's t-contribution"
+        );
+        // The `t_max = t` update is still emitted inside the guarded block.
+        assert!(wgsl.contains("t_max = t;"));
+    }
+
+    /// The ungated `to_hyperslice_wgsl` must produce identical output to the gated form
+    /// with no halfspace gate active (i.e. when there are no halfspaces at all to gate).
+    /// Catches regressions where the gated path diverges from the canonical emit on a
+    /// halfspace-free scene.
+    #[test]
+    fn hyperslice_gated_matches_ungated_when_no_halfspaces() {
+        let scene = Scene4::new(SceneNode4::hypersphere(Vec4::ZERO, 0.5));
+        let ungated = scene.to_hyperslice_wgsl("u.w_slice");
+        let gated = scene.to_hyperslice_wgsl_gated("u.w_slice", "u.params.x");
+        assert_eq!(
+            ungated, gated,
+            "scenes without halfspaces shouldn't diverge under gating"
+        );
     }
 }

--- a/crates/rye-time/src/frame_trace.rs
+++ b/crates/rye-time/src/frame_trace.rs
@@ -154,17 +154,21 @@ thread_local! {
     static MAX_EVER: RefCell<std::collections::HashMap<&'static str, Duration>> =
         RefCell::new(std::collections::HashMap::new());
     /// Threshold above which `end_frame` emits a `tracing::warn!` naming the
-    /// offending section + its elapsed time + the frame index. Default chosen
-    /// to catch user-visible stalls (>= 50ms ≈ 3 vsync intervals at 60Hz)
-    /// without flooding on common 25ms variance.
+    /// offending section + its elapsed time + the frame index. Default of
+    /// 250ms is "user-perceptible freeze": at 4fps the demo is clearly
+    /// stuck on something. Below that, routine wasm GC stalls and 120/600-
+    /// cell wireframe rebuilds (50-150ms) drown the log. Perf work that
+    /// wants to characterize the 50-100ms range lowers the threshold via
+    /// [`set_spike_threshold`] at startup.
     ///
     /// Architectural note: tracing::warn! goes to console.warn on wasm
-    /// (selectable + copyable in DevTools) and to stderr on native; both are
-    /// the right surfaces for "something just went pathological for one
-    /// frame." If this becomes too chatty under load, raise the threshold or
-    /// add a "first N per session" gate rather than turning it off.
+    /// (selectable + copyable in DevTools) and to stderr on native; both
+    /// are the right surfaces for "something just went pathological for
+    /// one frame." If this is still too chatty under load, raise further;
+    /// the prior 50ms default produced per-frame log spam on polytope
+    /// playground in browser.
     static SPIKE_THRESHOLD: std::cell::Cell<Duration> =
-        const { std::cell::Cell::new(Duration::from_millis(50)) };
+        const { std::cell::Cell::new(Duration::from_millis(250)) };
     /// Strictly-increasing frame counter for the spike log message, so a
     /// human reading three "spike at frame 1247" messages can tell they're
     /// genuinely separate events vs. one redraw firing the warn multiple

--- a/crates/tesseract_demo/src/main.rs
+++ b/crates/tesseract_demo/src/main.rs
@@ -262,6 +262,13 @@ impl App for TesseractApp {
         rye_app::trace::register_command(&mut console);
         rye_app::fps::register_command(&mut console);
         rye_app::vsync::register_command(&mut console);
+        rye_app::version::register_command(
+            &mut console,
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            env!("BUILD_HASH"),
+            env!("BUILD_DIRTY"),
+        );
         rye_app::log::register_command(&mut console);
         let perf = rye_app::trace::PerfOverlay::new();
 

--- a/crates/tesseract_demo/src/main.rs
+++ b/crates/tesseract_demo/src/main.rs
@@ -22,8 +22,8 @@
 use anyhow::Result;
 use glam::{Mat4, Vec2, Vec3};
 use rye_app::{
-    egui, App, Camera, CameraController, FirstPersonController, FrameCtx, OrbitController,
-    RenderCtx, RunConfig, SetupCtx,
+    egui, freecam::Freecam, App, Camera, CameraController, FrameCtx, OrbitController, RenderCtx,
+    RunConfig, SetupCtx,
 };
 
 // Per-frame allocation telemetry. Wraps the system allocator with a counter
@@ -102,16 +102,12 @@ struct TesseractApp {
     camera: Camera<EuclideanR3>,
     /// Orbit controller for the default mode. Reused across toggles.
     orbit: OrbitController<EuclideanR3>,
-    /// Free-roam controller. Constructed lazily on the first toggle so it
-    /// inherits the orbit camera's pose as its starting point.
-    free_roam: FirstPersonController<EuclideanR3>,
+    /// Freecam preset (mouse-look + WASD + cursor grab). Owns its own
+    /// yaw / pitch / position / grab state; the demo only toggles
+    /// `set_active` on mode change and calls `advance` per frame.
+    freecam: Freecam,
     /// Active controller selection.
     mode: CameraMode,
-    /// World-space position of the camera in free-roam mode. The translation
-    /// piece is owned by the demo rather than the controller because the
-    /// `FirstPersonController` advance only sets `right/up/forward`; we
-    /// integrate position from input on top of it.
-    free_roam_pos: Vec3,
     /// Accumulated 4D rotor describing the polytope's current orientation.
     rotor: Rotor4,
     /// Continuous-spin angular velocity. Multiplied by `dt` each tick and
@@ -255,8 +251,10 @@ impl App for TesseractApp {
         let mut orbit: OrbitController<EuclideanR3> = OrbitController::default();
         orbit.set_orbit(5.0, -0.15);
 
-        let free_roam = FirstPersonController::<EuclideanR3>::new(0.0, 0.0);
-        let free_roam_pos = camera.position;
+        // Freecam preset; inactive at startup. `F` toggles it on (mouse-
+        // look + WASD); the preset grabs the cursor + seeds its position
+        // from the camera's current pose at activation time.
+        let freecam = Freecam::new().with_speed(2.5);
 
         let mut console = Console::<()>::new();
         rye_app::trace::register_command(&mut console);
@@ -276,9 +274,8 @@ impl App for TesseractApp {
             lines,
             camera,
             orbit,
-            free_roam,
+            freecam,
             mode: CameraMode::Orbit,
-            free_roam_pos,
             rotor: Rotor4::IDENTITY,
             // `Bivector4::basis(2)` is the xw plane in `Plane4`'s ordering
             // (0=xy, 1=xz, 2=xw, 3=yz, 4=yw, 5=zw). Times the args-or-default
@@ -344,28 +341,16 @@ impl App for TesseractApp {
         }
 
         // Camera advance. Mode-aware; both controllers consume the drained
-        // input but only one shapes the resulting frame.
+        // input but only one shapes the resulting frame. Freecam preset
+        // handles its own cursor-grab gating (no-ops when released via
+        // Alt) and look + WASD position integration in one call.
         match self.mode {
             CameraMode::Orbit => {
                 self.orbit
                     .advance(ctx.input, &mut self.camera, &EuclideanR3, dt);
             }
             CameraMode::FreeRoam => {
-                self.free_roam
-                    .advance(ctx.input, &mut self.camera, &EuclideanR3, dt);
-                // `FrameInput` already aggregates WASD + Space/Shift into the
-                // `move_forward`, `move_right`, `move_up` axes (+1 / 0 / -1
-                // each frame). Combine with the camera's local basis to get
-                // a world-space velocity vector.
-                let speed = 2.5; // units/sec
-                let mut delta = self.camera.forward * ctx.input.move_forward
-                    + self.camera.right * ctx.input.move_right
-                    + Vec3::Y * ctx.input.move_up;
-                if delta.length_squared() > 1e-6 {
-                    delta = delta.normalize();
-                    self.free_roam_pos += delta * speed * dt;
-                    self.camera.position = self.free_roam_pos;
-                }
+                self.freecam.advance(ctx.input, &mut self.camera, dt);
             }
         }
     }
@@ -393,13 +378,28 @@ impl App for TesseractApp {
         {
             match code {
                 KeyCode::KeyF => {
-                    // Toggle camera mode. Free-roam picks up where orbit left
-                    // off so the view doesn't snap.
+                    // Toggle camera mode. Freecam preset grabs the cursor +
+                    // seeds its position from the current camera pose on
+                    // activation, releases on deactivation; the toggle
+                    // feels continuous rather than teleporting.
                     self.mode = match self.mode {
-                        CameraMode::Orbit => CameraMode::FreeRoam,
-                        CameraMode::FreeRoam => CameraMode::Orbit,
+                        CameraMode::Orbit => {
+                            self.freecam.set_active(true, self.camera.position);
+                            CameraMode::FreeRoam
+                        }
+                        CameraMode::FreeRoam => {
+                            self.freecam.set_active(false, self.camera.position);
+                            CameraMode::Orbit
+                        }
                     };
-                    self.free_roam_pos = self.camera.position;
+                }
+                // Alt toggles the cursor grab while in freecam, releasing
+                // the mouse for UI interaction (e.g., dragging the console
+                // panel). Mode stays FreeRoam; only the grab flips.
+                KeyCode::AltLeft | KeyCode::AltRight
+                    if matches!(self.mode, CameraMode::FreeRoam) =>
+                {
+                    self.freecam.toggle_cursor_grab();
                 }
                 // T always toggles pause; Space ALSO toggles pause, but only
                 // outside FreeRoam (where Space is the jump-up axis and would

--- a/crates/tesseract_demo/src/main.rs
+++ b/crates/tesseract_demo/src/main.rs
@@ -369,13 +369,27 @@ impl App for TesseractApp {
         if let WindowEvent::KeyboardInput {
             event:
                 KeyEvent {
-                    state: ElementState::Pressed,
+                    state,
                     physical_key: PhysicalKey::Code(code),
                     ..
                 },
             ..
         } = ev
         {
+            // Alt is the only key that needs BOTH edges: the freecam
+            // preset's `on_alt(pressed)` interprets press + release
+            // according to its `cursor_mode` (Hold by default, MMO-style:
+            // cursor released while held, re-grabbed on release). Toggle
+            // mode ignores release internally.
+            if matches!(code, KeyCode::AltLeft | KeyCode::AltRight)
+                && matches!(self.mode, CameraMode::FreeRoam)
+            {
+                self.freecam.on_alt(matches!(state, ElementState::Pressed));
+                return;
+            }
+            if !matches!(state, ElementState::Pressed) {
+                return;
+            }
             match code {
                 KeyCode::KeyF => {
                     // Toggle camera mode. Freecam preset grabs the cursor +
@@ -392,14 +406,6 @@ impl App for TesseractApp {
                             CameraMode::Orbit
                         }
                     };
-                }
-                // Alt toggles the cursor grab while in freecam, releasing
-                // the mouse for UI interaction (e.g., dragging the console
-                // panel). Mode stays FreeRoam; only the grab flips.
-                KeyCode::AltLeft | KeyCode::AltRight
-                    if matches!(self.mode, CameraMode::FreeRoam) =>
-                {
-                    self.freecam.toggle_cursor_grab();
                 }
                 // T always toggles pause; Space ALSO toggles pause, but only
                 // outside FreeRoam (where Space is the jump-up axis and would


### PR DESCRIPTION
## Summary

Polish pass on polytope_playground plus three engine lifts.

### Demo polish
- HUD: `build:` label with symmetric inset (was the bare hash with asymmetric padding)
- Wireframe color modes: `vertex-gradient` (default), `unique-edge` (greedy line-graph coloring), `w-depth` (signed-w with fixed canonical band, matches `tesseract_demo`), `active`
- Wireframe knobs: `wireframe width <px>`, `wireframe alpha <N>` (when `nearest-active` off)
- Surface knobs: `surface scale <N>` (0.05..=10.0), `surface alpha <N>` (dual depth-write pipelines so wireframe shows through translucent caps)
- `points` moved under `wireframe points`; sprites honor the active color mode + cell-center inset (no more dual-polytope-vertex coincidence)
- `floor on|off` toggle (zero per-frame cost via new engine API)
- W slider range scales with `surface_scale`
- `PerfOverlay` (F3) lifted into the demo + draggable

### Freecam (engine + both demos)
- `camera freecam speed=<N>` and `camera freecam cursor_mode <hold|toggle>` (Toggle default, FPS-sticky)
- Alt-release warps cursor to window center via new `rye_app::cursor::request_warp_to_center`

### Engine
- `rye_scene::Scene4::to_hyperslice_wgsl_gated(w_slice, halfspace_gate_expr)` — emits per-halfspace `select(1e9, raw, expr >= 0.5)` + matching `max_t` guard; replaces the demo's string-replace hack
- `rye_app::version` console command + `polytope_playground/build.rs` git-hash bake
- `unique_edge_palette` memoized by `Polytope4` variant (drops O(E²) per-frame on 600-cell)

### Tests
26 new (656 total): Scene4 gated emit + kernel parity (5), color helpers `hsv_to_rgb` / `unique_edge_palette` / `w_depth_color` / `compute_cell_strengths` (15), cursor warp one-shot (1), console scrollback `LayoutJob` structure (5).

`scripts/audit.sh`: 12/12 PASS.

## Test plan
- [x] `wireframe color w-depth` on the tesseract reads cube-within-cube (inner cool, outer warm)
- [x] `surface scale 4` widens W slider; `surface alpha 0.6` shows wireframe through caps
- [x] `floor off` hides the checkerboard; `floor on` restores it
- [x] F3 toggles perf overlay; drag relocates it
- [x] Freecam: Alt-press releases cursor at screen center; `camera freecam cursor_mode hold` switches to MMO-style
- [x] `wireframe points` enables sprites; color matches the active wireframe mode