### PR TITLE
Feat/wasm v2 closeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,21 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --no-deps --workspace
+
+  wasm-build:
+    name: wasm32 build (polytope_playground)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      # Regression gate for the wasm32 target. M5/M6/M7 work touches
+      # rye-app / rye-render / rye-egui, any of which can silently break
+      # the wasm bundle (cfg-shims, web-time, OffscreenCanvas worker
+      # plumbing). `--no-default-features` drops polytope_playground's
+      # native-only `capture` feature so the native encoder crates stay
+      # out of the wasm dep tree, matching `index.html`'s
+      # `data-cargo-no-default-features` directive.
+      - run: cargo build --target wasm32-unknown-unknown -p polytope_playground --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      # Regression gate for the wasm32 target. M5/M6/M7 work touches
-      # rye-app / rye-render / rye-egui, any of which can silently break
-      # the wasm bundle (cfg-shims, web-time, OffscreenCanvas worker
-      # plumbing). `--no-default-features` drops polytope_playground's
-      # native-only `capture` feature so the native encoder crates stay
-      # out of the wasm dep tree, matching `index.html`'s
-      # `data-cargo-no-default-features` directive.
+      # Add the wasm target to the toolchain `rust-toolchain.toml` pins
+      # (currently 1.95.0). The `targets:` input on the action above would
+      # add it to `stable` instead, which the toml override then bypasses
+      # at `cargo build` time, leaving the pinned toolchain without a
+      # wasm32 std (the "can't find crate for `std`" failure). Running
+      # `rustup target add` inside the checked-out repo respects the
+      # override, so the target lands on the toolchain cargo actually uses.
+      - run: rustup target add wasm32-unknown-unknown
+      # Regression gate for the wasm32 target. Engine work on rye-app /
+      # rye-render / rye-egui can silently break the wasm bundle (cfg-shims,
+      # web-time, OffscreenCanvas worker plumbing). `--no-default-features`
+      # drops polytope_playground's native-only `capture` feature so the
+      # native encoder crates stay out of the wasm dep tree, matching
+      # `index.html`'s `data-cargo-no-default-features` directive.
       - run: cargo build --target wasm32-unknown-unknown -p polytope_playground --no-default-features

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,7 @@ scripts/
 *.gif
 /out.*
 
-# Trunk wasm build output (per-demo bundles emit into ./dist; rebuild any time)
+# Trunk wasm build output (workspace root + per-demo bundles emit into dist/;
+# rebuild any time)
 /dist/
+crates/*/dist/

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,5 +1,13 @@
 # Trunk: wasm packager for the rye engine demos.
 #
+# Tested with Trunk 0.21.x. Trunk is a local-dev tool only: it is NOT in the
+# CI build path (the `wasm-build` job in .github/workflows/ci.yml runs raw
+# `cargo build --target wasm32-unknown-unknown`, which is what gates wasm
+# regressions). Install with `cargo install --locked trunk` to pin the
+# transitive dep tree. If a future Trunk release changes the `[serve]` or
+# `data-trunk rel="inline"` semantics this file relies on, pin explicitly via
+# `cargo install --locked --version 0.21 trunk`.
+#
 # Each demo lives in its own workspace member crate under `crates/<name>/`, with a
 # `Cargo.toml` registering an implicit `[[bin]]` (from `src/main.rs`) and an
 # `index.html` next to the Cargo.toml that points Trunk at it. The dev loop is:

--- a/crates/polytope_playground/index.html
+++ b/crates/polytope_playground/index.html
@@ -57,59 +57,20 @@
             display: block;
             background: #0e0e12;
         }
-        /* Launch overlay: covers the host; clicking anywhere fires
-           the worker's Start signal. The worker has already rendered
-           ONE preview frame into the canvas underneath;
-           `backdrop-filter: blur(...)` blurs that frame so the viewer
-           sees a softened preview of the demo's initial state. */
-        .rye-demo-launch {
-            position: absolute;
-            top: 0; left: 0; right: 0; bottom: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font: inherit;
-            font-size: 14px;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            color: #d8d8df;
-            background: rgba(14, 14, 18, 0.35);
-            backdrop-filter: blur(14px);
-            -webkit-backdrop-filter: blur(14px);
-            border: none;
-            cursor: pointer;
-            transition: background 200ms ease, opacity 200ms ease;
-        }
-        .rye-demo-launch::after {
-            content: 'Click anywhere to launch';
-            display: inline-block;
-            padding: 14px 28px;
-            border: 1px solid rgba(200, 200, 220, 0.5);
-            border-radius: 6px;
-            background: rgba(20, 20, 28, 0.55);
-        }
-        .rye-demo-launch:hover {
-            background: rgba(14, 14, 18, 0.25);
-        }
-        .rye-demo-launch:hover::after {
-            background: rgba(28, 28, 38, 0.65);
-            border-color: rgba(220, 220, 240, 0.7);
-        }
-        .rye-demo-launch:active {
-            background: rgba(14, 14, 18, 0.4);
-        }
+        /* `.rye-demo-launch` (the click-to-start overlay) is injected by
+           `rye_app::wasm::launch::inject_launch_overlay` along with its
+           CSS. Override by shipping a stylesheet later in the cascade. */
     </style>
 </head>
 <body>
     <!-- `data-mode="manual"` opts into click-to-start. The wasm runtime
-         sees this attribute, installs a one-shot click handler on
-         `#rye-launch`, transfers the `#rye-canvas` to a fresh Worker on
-         click, and runs the App lifecycle inside the worker. Remove the
-         attribute for auto-start on page load (legacy main-thread mode). -->
+         sees this attribute, injects the `#rye-launch` overlay as a child
+         of this host, installs a one-shot click handler that transfers
+         `#rye-canvas` to a fresh Worker on click, and runs the App
+         lifecycle inside the worker. Remove the attribute for auto-start
+         on page load (legacy main-thread mode). -->
     <div id="rye-canvas-host" data-mode="manual">
         <canvas id="rye-canvas" width="1280" height="800"></canvas>
-        <button id="rye-launch" class="rye-demo-launch" type="button"
-                aria-label="Launch demo"></button>
     </div>
 </body>
 </html>

--- a/crates/polytope_playground/index.html
+++ b/crates/polytope_playground/index.html
@@ -59,7 +59,11 @@
         }
         /* `.rye-demo-launch` (the click-to-start overlay) is injected by
            `rye_app::wasm::launch::inject_launch_overlay` along with its
-           CSS. Override by shipping a stylesheet later in the cascade. */
+           CSS. Override by shipping a stylesheet later in the cascade.
+           The static `#rye-page-loader` spinner that covers the
+           wasm-init window is inlined into `#rye-canvas-host` below
+           via `data-trunk rel="inline"`; the engine removes it once
+           the worker posts `preview_ready`. */
     </style>
 </head>
 <body>
@@ -71,6 +75,10 @@
          on page load (legacy main-thread mode). -->
     <div id="rye-canvas-host" data-mode="manual">
         <canvas id="rye-canvas" width="1280" height="800"></canvas>
+        <!-- Engine-owned static spinner. The fragment lives in
+             `crates/rye-app/static/page_loader.html`; Trunk inlines it
+             here at build time. -->
+        <link data-trunk rel="inline" href="../rye-app/static/page_loader.html" />
     </div>
 </body>
 </html>

--- a/crates/polytope_playground/src/active.rs
+++ b/crates/polytope_playground/src/active.rs
@@ -15,6 +15,20 @@ use rye_app::egui;
 use rye_math::Plane4;
 
 use crate::consts::CONTROL_H;
+
+/// Wrap a degree value into `(-720, 720]` so the slider handle stays
+/// inside the widget's clamping range while continuous spin advances
+/// the raw angle past one period. `1440` is the full two-cycle range
+/// (`+720` minus `-720`); `rem_euclid` keeps the result non-negative,
+/// then we re-center.
+fn wrap_slider_deg(d: f32) -> f32 {
+    let m = d.rem_euclid(1440.0);
+    if m > 720.0 {
+        m - 1440.0
+    } else {
+        m
+    }
+}
 use crate::state::Demo;
 
 /// Name a recognizable combination of active planes. Indices match
@@ -118,12 +132,18 @@ impl Demo {
         value_w: f32,
     ) {
         let plane = Plane4::ALL[plane_idx];
-        // Slider value is the *displayed* angle (base + spin contribution).
-        // Range is the rotor's full period in Spin(4): 720° for a single
-        // plane (going around once in physical rotation flips the rotor to
-        // -1; twice returns to +1). Wider than -360..=360 so the user can
-        // see the full cycle without the slider clamping mid-rotation.
-        let mut deg = self.active_displayed_angle(plane_idx).to_degrees();
+        // Slider value is the *displayed* angle (base + spin contribution),
+        // wrapped into (-720°, 720°]. The wrap is purely for the slider
+        // handle: during continuous spin the raw displayed angle grows
+        // unboundedly, which would pin the slider against its 720° clamp
+        // and stop showing motion. Wrapping into the period keeps the
+        // handle moving cyclically. `active_rotor()` uses the RAW
+        // displayed angle (no wrap), so the rotor itself is identical
+        // regardless of how this value is normalized for display --
+        // `exp(plane * (x + 2π·k))` is the same rotor for any integer k
+        // when the plane is a simple unit bivector.
+        let raw_deg = self.active_displayed_angle(plane_idx).to_degrees();
+        let mut deg = wrap_slider_deg(raw_deg);
         ui.add_sized(
             [checkbox_w, 18.0],
             egui::Checkbox::new(&mut self.active[plane_idx], ""),

--- a/crates/polytope_playground/src/active.rs
+++ b/crates/polytope_playground/src/active.rs
@@ -1,6 +1,26 @@
-//! Active-set rotation mode: six basis-plane checkboxes drive the
-//! angular velocity. Sum-of-bivectors is commutative, so toggle order
-//! doesn't matter; only the active set does.
+//! Active-set rotation mode: six basis-plane checkboxes + per-plane angle
+//! sliders.
+//!
+//! ## Source of truth
+//!
+//! Active mode's orientation is NOT stored in `rot_state` directly; it is
+//! DERIVED each frame. The truth is `Demo::base_angles[6]` (the user's set
+//! angle per plane) plus `Demo::rot_time` (the spin clock). The displayed
+//! angle of plane `i` is `base_angles[i] + (rot_time * rate if active[i])`,
+//! and the rotor is the ORDERED PRODUCT `∏ᵢ exp(planeᵢ · displayed_angle[i])`
+//! (see `Demo::active_rotor` / `Demo::active_rotor_at`). `rot_state` is
+//! recomputed from that product every frame.
+//!
+//! This is a product, not a sum: `exp(a·xy) · exp(b·xz) ≠ exp(a·xy + b·xz)`
+//! when the planes don't commute (Baker-Campbell-Hausdorff). The product form
+//! is what makes each slider an independent factor, so dragging one slider
+//! doesn't redistribute the others. The cost is that the rotor is BCH-coupled
+//! internally and `log(rot_state)` will NOT return the user-set angles -- so
+//! Active mode never reads back through `log`; the sliders are the source of
+//! truth. Composer mode, by contrast, keeps the sum-of-bivectors model
+//! throughout. Every t-scrub / filmstrip site routes through
+//! `Demo::rotor_at_time`, which dispatches between the two so the scrub
+//! matches the spin path's math in either mode.
 //!
 //! This module owns:
 //!
@@ -198,6 +218,56 @@ impl Demo {
             self.base_angles[plane_idx] = target_rad - spin_contribution;
             self.rot_state = self.active_rotor();
             self.write_all(self.rot_state);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wrap_slider_deg;
+
+    #[test]
+    fn wrap_is_identity_inside_range() {
+        // Values already in (-720, 720] pass through unchanged.
+        for d in [0.0_f32, 359.0, -359.0, 720.0, -719.0, 123.456] {
+            assert_eq!(wrap_slider_deg(d), d, "in-range value {d} changed");
+        }
+    }
+
+    #[test]
+    fn wrap_folds_one_period_past_the_top() {
+        // 721 is one degree past the +720 top; folds to -719.
+        assert_eq!(wrap_slider_deg(721.0), -719.0);
+        // 1080 (1.5 periods) folds to -360.
+        assert_eq!(wrap_slider_deg(1080.0), -360.0);
+    }
+
+    #[test]
+    fn wrap_folds_below_the_bottom() {
+        // -721 is one degree below the -720 bottom; folds to +719.
+        assert_eq!(wrap_slider_deg(-721.0), 719.0);
+    }
+
+    #[test]
+    fn wrap_period_multiples_land_on_zero() {
+        // Exact multiples of the 1440 two-cycle period map to 0.
+        assert_eq!(wrap_slider_deg(1440.0), 0.0);
+        assert_eq!(wrap_slider_deg(-1440.0), 0.0);
+        assert_eq!(wrap_slider_deg(2880.0), 0.0);
+    }
+
+    #[test]
+    fn wrap_result_always_in_range() {
+        // Sweep a wide span (continuous spin pushes the raw angle far past
+        // one period) and confirm every result lands in (-720, 720].
+        let mut d = -5000.0_f32;
+        while d <= 5000.0 {
+            let w = wrap_slider_deg(d);
+            assert!(
+                w > -720.0 && w <= 720.0,
+                "d={d} wrapped to {w} out of range"
+            );
+            d += 7.3;
         }
     }
 }

--- a/crates/polytope_playground/src/active.rs
+++ b/crates/polytope_playground/src/active.rs
@@ -12,7 +12,7 @@
 //!   `render_active_mode` and `render_plane_slider_cell`.
 
 use rye_app::egui;
-use rye_math::{Bivector, Plane4, Rotor};
+use rye_math::Plane4;
 
 use crate::consts::CONTROL_H;
 use crate::state::Demo;
@@ -102,6 +102,12 @@ impl Demo {
     /// One plane cell. All component widths pinned by the caller
     /// so the cell renders identically regardless of which row
     /// or column it's in.
+    ///
+    /// The slider reads/writes `base_angles[plane_idx]` via the
+    /// displayed-angle formula (`base + spin_contribution`), so each
+    /// slider only mutates its own plane's factor in the active-mode
+    /// rotor product. Independent sliders, no log/exp round-trips,
+    /// no cross-slider redistribution.
     pub(crate) fn render_plane_slider_cell(
         &mut self,
         ui: &mut egui::Ui,
@@ -112,15 +118,12 @@ impl Demo {
         value_w: f32,
     ) {
         let plane = Plane4::ALL[plane_idx];
-        let bivec = self.rot_state.log();
-        let current_rad = bivec.component(plane);
-        // Slider range matches the rotor's actual period.
-        // `Rotor4` lives in Spin(4), the double cover of SO(4):
-        // a 360° physical rotation maps to the rotor `-1`, and
-        // 720° brings the rotor back to `+1`. So the natural
-        // period of any single-plane rotor parameter is 720°,
-        // and `Rotor4::log` returns values across [-360, 360].
-        let mut deg = current_rad.to_degrees();
+        // Slider value is the *displayed* angle (base + spin contribution).
+        // Range is the rotor's full period in Spin(4): 720° for a single
+        // plane (going around once in physical rotation flips the rotor to
+        // -1; twice returns to +1). Wider than -360..=360 so the user can
+        // see the full cycle without the slider clamping mid-rotation.
+        let mut deg = self.active_displayed_angle(plane_idx).to_degrees();
         ui.add_sized(
             [checkbox_w, 18.0],
             egui::Checkbox::new(&mut self.active[plane_idx], ""),
@@ -129,7 +132,7 @@ impl Demo {
             [label_w, 18.0],
             egui::Label::new(egui::RichText::new(plane.label()).monospace()),
         );
-        let slider = egui::Slider::new(&mut deg, -360.0..=360.0)
+        let slider = egui::Slider::new(&mut deg, -720.0..=720.0)
             .show_value(false)
             .smart_aim(false)
             .clamping(egui::SliderClamping::Always);
@@ -151,7 +154,7 @@ impl Demo {
                     .context_menu(|ui| {
                         let drag_resp = ui.add(
                             egui::DragValue::new(&mut deg)
-                                .range(-360.0..=360.0)
+                                .range(-720.0..=720.0)
                                 .suffix("°")
                                 .fixed_decimals(1),
                         );
@@ -162,9 +165,18 @@ impl Demo {
             },
         );
         if slider_resp.changed() || popup_changed {
-            let mut new_bivec = bivec;
-            new_bivec.set_component(plane, deg.to_radians());
-            self.rot_state = new_bivec.exp();
+            // Solve for base_angles so the displayed angle matches the
+            // slider's new position:
+            //     displayed = base + spin_contribution
+            //  => base = displayed - spin_contribution
+            let target_rad = deg.to_radians();
+            let spin_contribution = if self.active[plane_idx] {
+                self.rot_time * crate::consts::BASE_ROTATION_RATE
+            } else {
+                0.0
+            };
+            self.base_angles[plane_idx] = target_rad - spin_contribution;
+            self.rot_state = self.active_rotor();
             self.write_all(self.rot_state);
         }
     }

--- a/crates/polytope_playground/src/composer.rs
+++ b/crates/polytope_playground/src/composer.rs
@@ -375,20 +375,35 @@ impl Demo {
                                     ui.horizontal(|ui| {
                                         let term = &self.seq[term_idx];
                                         if let Some(phi) = term.scalar {
+                                            // Inline editor: a DragValue
+                                            // sized + colored to match the
+                                            // previous read-only label. Drag
+                                            // the value to adjust; click to
+                                            // enter text-edit mode. The old
+                                            // right-click->menu->menu->DragValue
+                                            // chain stayed defocused on click
+                                            // so the value never committed.
                                             let phi_color = egui::Color32::from_rgb(255, 150, 150);
-                                            ui.add(
-                                                egui::Label::new(
-                                                    egui::RichText::new(format!(
-                                                        "{:.2}°",
-                                                        phi.to_degrees()
-                                                    ))
-                                                    .monospace()
-                                                    .color(phi_color),
-                                                )
-                                                .selectable(false),
-                                            )
-                                            .on_hover_text(
-                                                "Right-click the term to edit or remove",
+                                            let mut deg = phi.to_degrees();
+                                            let drag_resp = ui
+                                                .scope(|ui| {
+                                                    ui.visuals_mut().override_text_color =
+                                                        Some(phi_color);
+                                                    ui.add(
+                                                        egui::DragValue::new(&mut deg)
+                                                            .suffix("°")
+                                                            .speed(1.0)
+                                                            .fixed_decimals(2)
+                                                            .range(-720.0..=720.0),
+                                                    )
+                                                })
+                                                .inner;
+                                            if drag_resp.changed() {
+                                                edit_scalar = Some((term_idx, deg.to_radians()));
+                                            }
+                                            drag_resp.on_hover_text(
+                                                "Drag to adjust; click to type. \
+                                                     Right-click the term to remove the scalar.",
                                             );
                                             ui.monospace("·");
                                         }
@@ -443,23 +458,11 @@ impl Demo {
                     let scalar_now = self.seq[term_idx].scalar;
                     let menu_resp = card_resp.interact(egui::Sense::click());
                     menu_resp.context_menu(|ui| {
-                        if let Some(phi) = scalar_now {
-                            let current_deg = phi.to_degrees();
-                            ui.menu_button(format!("Edit scalar ({current_deg:.2}°)"), |ui| {
-                                let mut deg = current_deg;
-                                if ui
-                                    .add(
-                                        egui::DragValue::new(&mut deg)
-                                            .suffix("°")
-                                            .speed(1.0)
-                                            .fixed_decimals(2)
-                                            .range(-720.0..=720.0),
-                                    )
-                                    .changed()
-                                {
-                                    edit_scalar = Some((term_idx, deg.to_radians()));
-                                }
-                            });
+                        // Editing the scalar is now inline on the card itself
+                        // (the colored DragValue above), so the context menu
+                        // only owns the irreversible actions: add/remove the
+                        // scalar field, delete the whole term.
+                        if scalar_now.is_some() {
                             if ui.button("Remove scalar (φ)").clicked() {
                                 remove_scalar = Some(term_idx);
                                 ui.close_kind(egui::UiKind::Menu);

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -849,16 +849,15 @@ impl Demo {
         );
     }
 
-    pub(crate) fn on_event(&mut self, ev: &winit::event::WindowEvent, _ctx: &mut FrameCtx<'_>) {
-        use winit::event::{ElementState, WindowEvent};
-        use winit::keyboard::{KeyCode, PhysicalKey};
-        let WindowEvent::KeyboardInput { event, .. } = ev else {
-            return;
-        };
-        let PhysicalKey::Code(kc) = event.physical_key else {
-            return;
-        };
-        let pressed = event.state == ElementState::Pressed;
+    pub(crate) fn on_key(
+        &mut self,
+        kc: winit::keyboard::KeyCode,
+        state: winit::event::ElementState,
+        _ctx: &mut FrameCtx<'_>,
+    ) {
+        use winit::event::ElementState;
+        use winit::keyboard::KeyCode;
+        let pressed = state == ElementState::Pressed;
         match kc {
             KeyCode::ArrowUp => self.slider_up_held = pressed,
             KeyCode::ArrowDown => self.slider_down_held = pressed,
@@ -2282,16 +2281,21 @@ impl App for RotatePolytopesApp {
         self.last_egui_keyboard = ctx.wants_keyboard_input();
     }
 
-    fn on_event(&mut self, ev: &winit::event::WindowEvent, ctx: &mut FrameCtx<'_>) {
+    fn on_key(
+        &mut self,
+        code: winit::keyboard::KeyCode,
+        state: winit::event::ElementState,
+        ctx: &mut FrameCtx<'_>,
+    ) {
         // Suppress demo keybinds when egui is actively capturing
         // keyboard input (any TextEdit focused: console, formula
         // bar, etc.) so typing `reset` into the console doesn't
         // also fire the R hotkey, etc. When the user clicks
         // outside the egui widget that had focus, egui releases
-        // keyboard focus and the next frame's `on_event` routes
+        // keyboard focus and the next frame's `on_key` routes
         // hotkeys back to the demo as normal.
         if !self.last_egui_keyboard {
-            self.demo.on_event(ev, ctx);
+            self.demo.on_key(code, state, ctx);
         }
     }
 

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -505,7 +505,6 @@ impl Demo {
                 window_pos: egui::Pos2::new(220.0, 120.0),
                 open: false,
             },
-            overlay_pinned_width: None,
             show_formula: false,
             show_controls: true,
             view_mode: ViewMode::Shapes,

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -2014,6 +2014,13 @@ impl RotatePolytopesApp {
                         })?,
                         None => SurfaceMode::Off,
                     };
+                    if next == SurfaceMode::Sdf && demo.sdf_blocked_by_heavy_polychora() {
+                        return Err(anyhow!(
+                            "surface sdf disabled while 120-cell or 600-cell is in the row \
+                             (the SDF kernel crashes the browser tab on those); remove the \
+                             heavy polychora first, or use `surface raster`"
+                        ));
+                    }
                     if next != demo.surface_mode {
                         demo.surface_mode = next;
                         // Re-emit the SDF body list: switching INTO Sdf mode makes the

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -494,6 +494,7 @@ impl Demo {
             // characteristic 4D rotation, pulling the visible x-axis
             // through the hidden w-axis.
             active: [false, false, true, false, false, false],
+            base_angles: [0.0; 6],
             rate_scale: 1.0,
             rot_time: 0.0,
             t_slider_max: T_SLIDER_INITIAL,
@@ -578,13 +579,7 @@ impl Demo {
         if self.rotate {
             // Animation time advances by `dt_real * rate_scale`
             // so the rate buttons make `t` count faster/slower
-            // (per-real-second). The integrated rotation is
-            // `exp(omega_animation * dt_animation)` per frame,
-            // which = `exp(omega_animation * rate_scale * dt_real)`.
-            // This way `rot_state` and `rot_time` stay in sync:
-            // dragging `t` to N reproduces what the spin would
-            // have integrated to at animation time N, regardless
-            // of how the rate varied along the way.
+            // (per-real-second).
             let dt_animation = dt_secs * self.rate_scale;
             self.rot_time += dt_animation;
             // Grow the t-slider's max range when the spin has
@@ -601,10 +596,24 @@ impl Demo {
                     self.rot_time = T_SLIDER_CAP;
                 }
             }
-            let omega = self.omega_animation() * dt_animation;
-            if omega.magnitude_squared() > 0.0 {
-                let delta = omega.exp();
-                self.rot_state = (delta * self.rot_state).normalize();
+        }
+        // Recompose `rot_state` each frame so spin advances (Active mode
+        // reads `rot_time` through `active_displayed_angle`; Composer
+        // integrates the omega-bivector into rot_state directly via the
+        // legacy path below).
+        match self.rotation_mode {
+            RotationMode::Active => {
+                self.rot_state = self.active_rotor();
+            }
+            RotationMode::Composer => {
+                if self.rotate {
+                    let dt_animation = dt_secs * self.rate_scale;
+                    let omega = self.omega_animation() * dt_animation;
+                    if omega.magnitude_squared() > 0.0 {
+                        let delta = omega.exp();
+                        self.rot_state = (delta * self.rot_state).normalize();
+                    }
+                }
             }
         }
         self.write_all(self.rot_state);

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -548,8 +548,9 @@ impl Demo {
         }
 
         // Time scrub (t axis, left/right arrow keys). Mirrors the
-        // t-slider drag: rebuild `rot_state` from the new
-        // `rot_time` via `exp(omega_animation * rot_time)`.
+        // t-slider drag: rebuild `rot_state` from the new `rot_time`
+        // via `rotor_at_time`, which dispatches Active (product) vs
+        // Composer (sum) so the scrub matches the spin path's math.
         // Right = forward in time, left = back. Floors `rot_time`
         // at zero (the t slider's lower bound).
         let t_dir = (self.slider_right_held as i32 - self.slider_left_held as i32) as f32;
@@ -565,8 +566,7 @@ impl Demo {
                     self.rot_time = T_SLIDER_CAP;
                 }
             }
-            let omega = self.omega_animation();
-            self.rot_state = (omega * self.rot_time).exp().normalize();
+            self.rot_state = self.rotor_at_time(self.rot_time);
         }
 
         // 4D rotation animation. Both bodies share the same rotor
@@ -955,7 +955,6 @@ impl Demo {
                 (false, false) => (1, 1, true),
             };
             let col_vps = viewport.split_horizontal(cols as u32);
-            let omega = self.omega_animation();
             let mut grid_cells: Vec<(Viewport, f32, BodyUniform)> = Vec::with_capacity(cols * rows);
             for (col_idx, col_vp) in col_vps.into_iter().enumerate() {
                 let row_vps = col_vp.split_vertical(rows as u32);
@@ -985,12 +984,17 @@ impl Demo {
                         let t_norm = t_idx as f32 / (t_n - 1) as f32;
                         t_norm * self.strip_t_extent
                     };
-                    // Cell's rotor: spin from `rot_state` by
-                    // `omega * t_offset` (animation-time offset).
+                    // Cell's rotor: the orientation at animation time
+                    // `rot_time + t_offset`, via the same `rotor_at_time`
+                    // dispatch the spin + t-scrub use. For Composer this
+                    // equals the old `exp(omega * t_offset) * rot_state`
+                    // (omega commutes with itself); for Active it's the
+                    // product-of-exp sampled at the future time, which the
+                    // old sum-based offset got wrong with 2+ active planes.
                     let cell_rotor = if t_offset == 0.0 {
                         self.rot_state
                     } else {
-                        ((omega * t_offset).exp() * self.rot_state).normalize()
+                        self.rotor_at_time(self.rot_time + t_offset)
                     };
                     let body = BodyUniform::polytope_with_rotor(
                         [0.0, BODY_Y, 0.0, 0.0],

--- a/crates/polytope_playground/src/shapes.rs
+++ b/crates/polytope_playground/src/shapes.rs
@@ -190,17 +190,9 @@ impl Demo {
             .interact(egui::Sense::click());
         // Right-click directly removes the card when more than one is in
         // the row (matches the keep-at-least-one invariant the rest of
-        // the shape-row code enforces). The previous behavior popped a
-        // single-item "Remove from row" context menu; left commented out
-        // below because the popup primitive is still wanted when we add
-        // per-shape configuration later (color, label override, etc.).
-        let removed = row_len > 1 && resp.clicked_by(egui::PointerButton::Secondary);
-        // resp.context_menu(|ui| {
-        //     if row_len > 1 && ui.button("Remove from row").clicked() {
-        //         removed = true;
-        //         ui.close_kind(egui::UiKind::Menu);
-        //     }
-        // });
-        removed
+        // the shape-row code enforces). When per-shape configuration
+        // lands (color, label override), this is where a context menu
+        // would replace the bare right-click.
+        row_len > 1 && resp.clicked_by(egui::PointerButton::Secondary)
     }
 }

--- a/crates/polytope_playground/src/shapes.rs
+++ b/crates/polytope_playground/src/shapes.rs
@@ -184,17 +184,23 @@ impl Demo {
                     );
                 });
         });
-        let mut removed = false;
-        drag_resp
+        let resp = drag_resp
             .on_hover_cursor(egui::CursorIcon::Grab)
             .on_hover_text(entry.long_name)
-            .interact(egui::Sense::click())
-            .context_menu(|ui| {
-                if row_len > 1 && ui.button("Remove from row").clicked() {
-                    removed = true;
-                    ui.close_kind(egui::UiKind::Menu);
-                }
-            });
+            .interact(egui::Sense::click());
+        // Right-click directly removes the card when more than one is in
+        // the row (matches the keep-at-least-one invariant the rest of
+        // the shape-row code enforces). The previous behavior popped a
+        // single-item "Remove from row" context menu; left commented out
+        // below because the popup primitive is still wanted when we add
+        // per-shape configuration later (color, label override, etc.).
+        let removed = row_len > 1 && resp.clicked_by(egui::PointerButton::Secondary);
+        // resp.context_menu(|ui| {
+        //     if row_len > 1 && ui.button("Remove from row").clicked() {
+        //         removed = true;
+        //         ui.close_kind(egui::UiKind::Menu);
+        //     }
+        // });
         removed
     }
 }

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -339,6 +339,20 @@ pub(crate) fn compose_active_rotor(base_angles: &[f32; 6], active: &[bool; 6], t
     r.normalize()
 }
 
+/// True when `row` contains a 120-cell or 600-cell, the two polychora whose
+/// SDFs overrun the browser WebGPU shader budget (120 / 600 face hyperplanes
+/// each, against the per-pixel Wolfe-greedy projection) and crash the tab.
+/// Free function so the gate is unit-testable without a GPU-backed `Demo`;
+/// [`Demo::sdf_blocked_by_heavy_polychora`] is the `self.row` specialization.
+pub(crate) fn row_blocks_sdf(row: &[ShapeEntry]) -> bool {
+    row.iter().any(|e| {
+        matches!(
+            e.shape,
+            RaymarchShape::Polytope(Polytope4::Cell120 | Polytope4::Cell600)
+        )
+    })
+}
+
 pub(crate) fn angular_velocity_from_seq(seq: &[RotorTerm], rate_scale: f32) -> Bivector4 {
     let mut omega = Bivector4::ZERO;
     for term in seq {
@@ -614,11 +628,6 @@ pub(crate) struct Demo {
     /// the same way.
     pub(crate) example_callout: rye_egui::CalloutState,
 
-    /// Cached natural overlay width on first frame. Used as the fixed width of the
-    /// overlay regardless of the current window size, so resizing the demo window
-    /// doesn't stretch the controls. Set lazily on first render.
-    pub(crate) overlay_pinned_width: Option<f32>,
-
     /// Whether the top-right rotation-formula popup is rendered. Off by default; the
     /// formula is dense for newcomers; the expanded section has a checkbox to turn it on
     /// for users who want to see exactly which bivectors and scalars compose into the
@@ -820,12 +829,7 @@ impl Demo {
     /// The console `surface sdf` command and the UI radio gate on this
     /// to keep the demo crash-free.
     pub(crate) fn sdf_blocked_by_heavy_polychora(&self) -> bool {
-        self.row.iter().any(|e| {
-            matches!(
-                e.shape,
-                RaymarchShape::Polytope(Polytope4::Cell120 | Polytope4::Cell600)
-            )
-        })
+        row_blocks_sdf(&self.row)
     }
 
     /// Effective `w` slider half-range after [`Self::surface_scale`]. The
@@ -907,8 +911,20 @@ impl Demo {
 
 #[cfg(test)]
 mod tests {
-    use super::{active_plane_angle, compose_active_rotor, BASE_ROTATION_RATE};
+    use super::{active_plane_angle, compose_active_rotor, row_blocks_sdf, BASE_ROTATION_RATE};
+    use crate::catalog::ShapeEntry;
     use rye_math::{Bivector, Plane4, Rotor4};
+    use rye_physics::polytope::Polytope4;
+    use rye_render::raymarch::RaymarchShape;
+
+    fn entry(shape: RaymarchShape) -> ShapeEntry {
+        ShapeEntry {
+            shape,
+            body_color: [0.5, 0.5, 0.5],
+            label: "test",
+            long_name: "test shape",
+        }
+    }
 
     const NONE: [bool; 6] = [false; 6];
 
@@ -992,5 +1008,26 @@ mod tests {
             rotor_close(composed, reverse, 1e-6),
             "{composed:?} vs {reverse:?}"
         );
+    }
+
+    #[test]
+    fn row_blocks_sdf_only_for_heavy_polychora() {
+        // Empty row: nothing to block.
+        assert!(!row_blocks_sdf(&[]));
+        // Lighter shapes (default-row members): SDF stays available.
+        let light = [
+            entry(RaymarchShape::Polytope(Polytope4::Tesseract)),
+            entry(RaymarchShape::Polytope(Polytope4::Cell24)),
+        ];
+        assert!(!row_blocks_sdf(&light));
+        // A 120-cell anywhere in the row blocks SDF.
+        let with_120 = [
+            entry(RaymarchShape::Polytope(Polytope4::Tesseract)),
+            entry(RaymarchShape::Polytope(Polytope4::Cell120)),
+        ];
+        assert!(row_blocks_sdf(&with_120));
+        // A 600-cell does too.
+        let with_600 = [entry(RaymarchShape::Polytope(Polytope4::Cell600))];
+        assert!(row_blocks_sdf(&with_600));
     }
 }

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -11,7 +11,7 @@
 use std::collections::HashMap;
 
 use rye_app::{freecam::Freecam, Camera, OrbitController};
-use rye_math::{Bivector4, EuclideanR3, Plane4, Rotor4};
+use rye_math::{Bivector, Bivector4, EuclideanR3, Plane4, Rotor4};
 use rye_physics::polytope::Polytope4;
 use rye_render::raymarch::{BodyUniform, Hyperslice4DNode, RaymarchShape};
 
@@ -535,10 +535,22 @@ pub(crate) struct Demo {
 
     pub(crate) rotate: bool,
     pub(crate) rot_state: Rotor4,
-    /// Toggle bitmap for the six rotation planes; sum of active planes' unit bivectors
-    /// becomes the per-frame angular velocity. See [`Plane4::ALL`] for the index ->
-    /// plane mapping.
+    /// Toggle bitmap for the six rotation planes; an active plane participates in the
+    /// spin (`rot_time` advances its displayed angle). See [`Plane4::ALL`] for the
+    /// index -> plane mapping.
     pub(crate) active: [bool; 6],
+    /// User-set baseline angle per plane in radians. Active mode treats the displayed
+    /// angle of plane i as `base_angles[i] + rot_time * RATE * active[i]` and composes
+    /// `rot_state` as the ORDERED PRODUCT `∏ᵢ exp(planeᵢ · displayed_angle[i])`. This
+    /// is the "comprehensive set of rotors" parameterization: each plane is its own
+    /// simple-rotation factor in a product instead of a term in a single summed
+    /// bivector. The sliders read/write `base_angles` directly, so changing one
+    /// slider only mutates that plane's factor; the others stay put. The math
+    /// underneath is still BCH-coupled (the product of exps of non-commuting plane
+    /// bivectors isn't itself an exp of a sum), but the UI commits to "what the user
+    /// set is what we use" instead of trying to read back from `log(rot_state)`,
+    /// which has no faithful decomposition into 6 plane angles.
+    pub(crate) base_angles: [f32; 6],
     pub(crate) rate_scale: f32,
     /// Accumulated time spent rotating (advances only while `rotate == true`; resets on
     /// **R**). Useful for spotting periodicities in compound-bivector animations.
@@ -665,6 +677,11 @@ impl Demo {
     /// Per-animation-second angular velocity (the bivector that, integrated over
     /// animation time, produces `rot_state`). Independent of `rate_scale`. Active mode
     /// sums the toggled basis bivectors; Composer mode delegates to the seq walker.
+    ///
+    /// Note: Active mode composes its rotor as a *product* (see [`active_rotor`]), so
+    /// the returned bivector is only meaningful in the BCH-trivial direction (single
+    /// active plane) or as a coarse "this is the direction the rotation is going."
+    /// Composer mode uses the sum semantics throughout, so its omega is exact.
     pub(crate) fn omega_animation(&self) -> Bivector4 {
         match self.rotation_mode {
             RotationMode::Active => {
@@ -678,6 +695,40 @@ impl Demo {
             }
             RotationMode::Composer => angular_velocity_from_seq(&self.seq, 1.0),
         }
+    }
+
+    /// Displayed angle for plane `i` in Active mode: the user's stored baseline
+    /// plus, if the plane is active, the spin's accumulated contribution at
+    /// `rot_time`. The slider reads this value; writing the slider sets
+    /// `base_angles[i]` so the new displayed value matches what the user dropped
+    /// the handle at (so dragging a spinning slider doesn't snap back to the
+    /// pre-drag baseline).
+    pub(crate) fn active_displayed_angle(&self, plane_idx: usize) -> f32 {
+        let spin = if self.active[plane_idx] {
+            self.rot_time * BASE_ROTATION_RATE
+        } else {
+            0.0
+        };
+        self.base_angles[plane_idx] + spin
+    }
+
+    /// Active-mode rotor: ORDERED PRODUCT of per-plane simple rotations in
+    /// `Plane4::ALL` order. Sliders are independent because each `base_angles[i]`
+    /// contributes to exactly one factor; changing one slider only mutates one
+    /// factor in the product. The product across non-commuting planes is still
+    /// BCH-coupled in the rotor itself (so `log(rot_state).component(plane)`
+    /// won't give back the user-set angles), but we don't read back through `log`
+    /// in Active mode -- the sliders are the source of truth.
+    pub(crate) fn active_rotor(&self) -> Rotor4 {
+        let mut r = Rotor4::IDENTITY;
+        for i in 0..6 {
+            let angle = self.active_displayed_angle(i);
+            if angle != 0.0 {
+                let bivec = Plane4::ALL[i].unit_bivector() * angle;
+                r = bivec.exp() * r;
+            }
+        }
+        r.normalize()
     }
 
     /// Build the SDF body uniform for a single row entry, with polychora opt-out based on
@@ -796,6 +847,7 @@ impl Demo {
         // Restore the xw-only default active set so a first-time
         // user resetting and then hitting Spin sees motion.
         self.active = [false, false, true, false, false, false];
+        self.base_angles = [0.0; 6];
         self.rot_state = Rotor4::IDENTITY;
         self.rot_time = 0.0;
         self.t_slider_max = T_SLIDER_INITIAL;

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use rye_app::{freecam::Freecam, Camera, OrbitController};
 use rye_math::{Bivector4, EuclideanR3, Plane4, Rotor4};
 use rye_physics::polytope::Polytope4;
-use rye_render::raymarch::{BodyUniform, Hyperslice4DNode};
+use rye_render::raymarch::{BodyUniform, Hyperslice4DNode, RaymarchShape};
 
 use crate::catalog::ShapeEntry;
 use crate::consts::{BASE_ROTATION_RATE, BODY_SIZE, BODY_X_SPACING, BODY_Y, T_SLIDER_INITIAL};
@@ -710,6 +710,22 @@ impl Demo {
     /// cross-section caps.
     pub(crate) fn effective_body_size(&self) -> f32 {
         BODY_SIZE * self.surface_scale
+    }
+
+    /// True when entering `SurfaceMode::Sdf` would put a 120-cell or
+    /// 600-cell into the live SDF kernel. The 120-cell carries 120 face
+    /// hyperplanes and the 600-cell carries 600; combined with the
+    /// per-pixel Wolfe-greedy projection they exhaust the browser
+    /// WebGPU shader budget (Chrome crashed the tab on first attempt).
+    /// The console `surface sdf` command and the UI radio gate on this
+    /// to keep the demo crash-free.
+    pub(crate) fn sdf_blocked_by_heavy_polychora(&self) -> bool {
+        self.row.iter().any(|e| {
+            matches!(
+                e.shape,
+                RaymarchShape::Polytope(Polytope4::Cell120 | Polytope4::Cell600)
+            )
+        })
     }
 
     /// Effective `w` slider half-range after [`Self::surface_scale`]. The

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -313,6 +313,32 @@ pub(crate) fn render_bivector_sum(parts: &[String]) -> Option<String> {
 /// one unit term with `scalar = None`. The app-level `omega_per_sec` dispatcher inlines
 /// that walk over the `[bool; 6]` directly to avoid allocating a transient seq each
 /// frame.
+/// Displayed angle of one Active-mode plane at animation time `t`: the user's
+/// baseline plus the spin contribution `t * BASE_ROTATION_RATE` when the plane
+/// is active. Free function (not a `Demo` method) so the rotor composition is
+/// unit-testable without a GPU-backed `Demo`.
+pub(crate) fn active_plane_angle(base: f32, active: bool, t: f32) -> f32 {
+    base + if active { t * BASE_ROTATION_RATE } else { 0.0 }
+}
+
+/// Active-mode rotor at animation time `t`: the ORDERED PRODUCT
+/// `∏ᵢ exp(planeᵢ · active_plane_angle(base[i], active[i], t))` over the six
+/// planes in `Plane4::ALL` order. See the module doc of `active.rs` for why
+/// this is a product (independent sliders) rather than a single
+/// `exp(sum)` (which would reintroduce BCH coupling). Free function so the
+/// composition is testable without constructing a `Demo`.
+pub(crate) fn compose_active_rotor(base_angles: &[f32; 6], active: &[bool; 6], t: f32) -> Rotor4 {
+    let mut r = Rotor4::IDENTITY;
+    for i in 0..6 {
+        let angle = active_plane_angle(base_angles[i], active[i], t);
+        if angle != 0.0 {
+            let bivec = Plane4::ALL[i].unit_bivector() * angle;
+            r = bivec.exp() * r;
+        }
+    }
+    r.normalize()
+}
+
 pub(crate) fn angular_velocity_from_seq(seq: &[RotorTerm], rate_scale: f32) -> Bivector4 {
     let mut omega = Bivector4::ZERO;
     for term in seq {
@@ -678,7 +704,7 @@ impl Demo {
     /// animation time, produces `rot_state`). Independent of `rate_scale`. Active mode
     /// sums the toggled basis bivectors; Composer mode delegates to the seq walker.
     ///
-    /// Note: Active mode composes its rotor as a *product* (see [`active_rotor`]), so
+    /// Note: Active mode composes its rotor as a *product* (see [`Self::active_rotor`]), so
     /// the returned bivector is only meaningful in the BCH-trivial direction (single
     /// active plane) or as a coarse "this is the direction the rotation is going."
     /// Composer mode uses the sum semantics throughout, so its omega is exact.
@@ -697,38 +723,61 @@ impl Demo {
         }
     }
 
-    /// Displayed angle for plane `i` in Active mode: the user's stored baseline
-    /// plus, if the plane is active, the spin's accumulated contribution at
-    /// `rot_time`. The slider reads this value; writing the slider sets
-    /// `base_angles[i]` so the new displayed value matches what the user dropped
-    /// the handle at (so dragging a spinning slider doesn't snap back to the
-    /// pre-drag baseline).
-    pub(crate) fn active_displayed_angle(&self, plane_idx: usize) -> f32 {
-        let spin = if self.active[plane_idx] {
-            self.rot_time * BASE_ROTATION_RATE
-        } else {
-            0.0
-        };
-        self.base_angles[plane_idx] + spin
+    /// Angle for plane `i` in Active mode at animation time `t`: the user's
+    /// stored baseline plus, if the plane is active, the spin's accumulated
+    /// contribution `t * BASE_ROTATION_RATE`. Parameterized over `t` so the
+    /// filmstrip can sample future times; [`Self::active_displayed_angle`]
+    /// is the `t = rot_time` specialization the sliders read.
+    pub(crate) fn active_angle_at(&self, plane_idx: usize, t: f32) -> f32 {
+        active_plane_angle(self.base_angles[plane_idx], self.active[plane_idx], t)
     }
 
-    /// Active-mode rotor: ORDERED PRODUCT of per-plane simple rotations in
-    /// `Plane4::ALL` order. Sliders are independent because each `base_angles[i]`
-    /// contributes to exactly one factor; changing one slider only mutates one
-    /// factor in the product. The product across non-commuting planes is still
-    /// BCH-coupled in the rotor itself (so `log(rot_state).component(plane)`
-    /// won't give back the user-set angles), but we don't read back through `log`
-    /// in Active mode -- the sliders are the source of truth.
+    /// Displayed angle for plane `i` in Active mode at the current `rot_time`.
+    /// The slider reads this; writing the slider sets `base_angles[i]` so the
+    /// new displayed value matches where the user dropped the handle (dragging
+    /// a spinning slider doesn't snap back to the pre-drag baseline).
+    pub(crate) fn active_displayed_angle(&self, plane_idx: usize) -> f32 {
+        self.active_angle_at(plane_idx, self.rot_time)
+    }
+
+    /// Active-mode rotor at animation time `t`: ORDERED PRODUCT of per-plane
+    /// simple rotations in `Plane4::ALL` order. Sliders are independent because
+    /// each `base_angles[i]` contributes to exactly one factor; changing one
+    /// slider only mutates one factor in the product. The product across
+    /// non-commuting planes is still BCH-coupled in the rotor itself (so
+    /// `log(rot_state).component(plane)` won't give back the user-set angles),
+    /// but we don't read back through `log` in Active mode -- the sliders are
+    /// the source of truth.
+    pub(crate) fn active_rotor_at(&self, t: f32) -> Rotor4 {
+        compose_active_rotor(&self.base_angles, &self.active, t)
+    }
+
+    /// Active-mode rotor at the current `rot_time`. The `t = rot_time`
+    /// specialization of [`Self::active_rotor_at`].
     pub(crate) fn active_rotor(&self) -> Rotor4 {
-        let mut r = Rotor4::IDENTITY;
-        for i in 0..6 {
-            let angle = self.active_displayed_angle(i);
-            if angle != 0.0 {
-                let bivec = Plane4::ALL[i].unit_bivector() * angle;
-                r = bivec.exp() * r;
-            }
+        self.active_rotor_at(self.rot_time)
+    }
+
+    /// Orientation rotor at animation time `t`, dispatched on the active
+    /// rotation mode. This is the single source of truth for "what does the
+    /// orientation look like at animation time `t`" and MUST be used by every
+    /// t-scrub and filmstrip-offset site so they agree with the spin path:
+    ///
+    /// - **Active**: product-of-exp via [`Self::active_rotor_at`]. The 6 plane
+    ///   sliders are independent factors; summing them (the Composer model)
+    ///   would reintroduce the BCH coupling the Active rework removed.
+    /// - **Composer**: `exp(omega_animation * t)`, the sum-of-bivectors model
+    ///   the Composer UI is built around.
+    ///
+    /// For a single active plane the two modes coincide (no BCH coupling); the
+    /// distinction only bites with two or more non-commuting active planes,
+    /// which is exactly where a naive sum-everywhere t-scrub diverged from the
+    /// product-based spin.
+    pub(crate) fn rotor_at_time(&self, t: f32) -> Rotor4 {
+        match self.rotation_mode {
+            RotationMode::Active => self.active_rotor_at(t),
+            RotationMode::Composer => (self.omega_animation() * t).exp().normalize(),
         }
-        r.normalize()
     }
 
     /// Build the SDF body uniform for a single row entry, with polychora opt-out based on
@@ -853,5 +902,95 @@ impl Demo {
         self.t_slider_max = T_SLIDER_INITIAL;
         self.draft.clear();
         self.write_all(Rotor4::IDENTITY);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{active_plane_angle, compose_active_rotor, BASE_ROTATION_RATE};
+    use rye_math::{Bivector, Plane4, Rotor4};
+
+    const NONE: [bool; 6] = [false; 6];
+
+    fn rotor_close(a: Rotor4, b: Rotor4, eps: f32) -> bool {
+        (a.s - b.s).abs() < eps
+            && (a.xy - b.xy).abs() < eps
+            && (a.xz - b.xz).abs() < eps
+            && (a.xw - b.xw).abs() < eps
+            && (a.yz - b.yz).abs() < eps
+            && (a.yw - b.yw).abs() < eps
+            && (a.zw - b.zw).abs() < eps
+            && (a.xyzw - b.xyzw).abs() < eps
+    }
+
+    #[test]
+    fn active_plane_angle_adds_spin_only_when_active() {
+        // Inactive plane: angle is the baseline regardless of t.
+        assert_eq!(active_plane_angle(0.5, false, 3.0), 0.5);
+        // Active plane: baseline plus t * rate.
+        assert_eq!(
+            active_plane_angle(0.5, true, 2.0),
+            0.5 + 2.0 * BASE_ROTATION_RATE
+        );
+        // t = 0 collapses to the baseline even when active.
+        assert_eq!(active_plane_angle(0.5, true, 0.0), 0.5);
+    }
+
+    #[test]
+    fn compose_all_zero_is_identity() {
+        let r = compose_active_rotor(&[0.0; 6], &NONE, 0.0);
+        assert!(rotor_close(r, Rotor4::IDENTITY, 1e-6), "got {r:?}");
+    }
+
+    #[test]
+    fn compose_is_always_unit_norm() {
+        // A messy multi-plane configuration must still produce a unit rotor
+        // (the function normalizes). Norm-squared within 1e-5 of 1.
+        let base = [0.3, -1.1, 2.0, 0.7, -0.4, 1.6];
+        let active = [true, false, true, true, false, true];
+        for &t in &[0.0_f32, 0.5, 3.0, 50.0] {
+            let n2 = compose_active_rotor(&base, &active, t).norm_squared();
+            assert!((n2 - 1.0).abs() < 1e-5, "t={t} norm_squared={n2}");
+        }
+    }
+
+    #[test]
+    fn compose_single_plane_equals_direct_exp() {
+        // One plane (xw = index 2) at a baseline angle, no spin: the product
+        // collapses to a single factor, which must equal exp(plane * angle)
+        // directly. This is the BCH-trivial case where product == the obvious
+        // single rotation.
+        let theta = 0.8_f32;
+        let mut base = [0.0; 6];
+        base[2] = theta; // Plane4::Xw
+        let composed = compose_active_rotor(&base, &NONE, 0.0);
+        let direct = (Plane4::Xw.unit_bivector() * theta).exp().normalize();
+        assert!(
+            rotor_close(composed, direct, 1e-6),
+            "{composed:?} vs {direct:?}"
+        );
+    }
+
+    #[test]
+    fn compose_orthogonal_pair_is_order_independent() {
+        // xy (index 0) and zw (index 5) are absolutely orthogonal: their
+        // bivectors commute, so exp(a*xy) * exp(b*zw) == exp(b*zw) * exp(a*xy).
+        // `compose_active_rotor` walks Plane4::ALL order (xy before zw); build
+        // the reverse by hand and confirm they match. (This is the case where
+        // the product genuinely equals exp(sum); the non-commuting case is
+        // exactly why Active mode uses the product, tested implicitly by the
+        // unit-norm + single-plane invariants above.)
+        let (a, b) = (0.6_f32, -0.9_f32);
+        let mut base = [0.0; 6];
+        base[0] = a; // xy
+        base[5] = b; // zw
+        let composed = compose_active_rotor(&base, &NONE, 0.0);
+        let xy = (Plane4::Xy.unit_bivector() * a).exp();
+        let zw = (Plane4::Zw.unit_bivector() * b).exp();
+        let reverse = (xy * zw).normalize();
+        assert!(
+            rotor_close(composed, reverse, 1e-6),
+            "{composed:?} vs {reverse:?}"
+        );
     }
 }

--- a/crates/polytope_playground/src/ui.rs
+++ b/crates/polytope_playground/src/ui.rs
@@ -358,10 +358,6 @@ impl Demo {
         const OVERLAY_MIN_WIDTH: f32 = 280.0;
         let natural_w = screen.width() - 2.0 * pad;
         let area_w = natural_w.clamp(OVERLAY_MIN_WIDTH, OVERLAY_MAX_WIDTH);
-        // `overlay_pinned_width` is kept for backwards compatibility
-        // with any saved state but no longer load-bearing now that the
-        // width is capped.
-        let _ = self.overlay_pinned_width.get_or_insert(area_w);
 
         let visuals = &ctx.style().visuals;
         let frame = egui::Frame::default()

--- a/crates/polytope_playground/src/ui.rs
+++ b/crates/polytope_playground/src/ui.rs
@@ -13,7 +13,7 @@ use rye_egui::{
     media::{chevron_button, play_pause_button, rate_toggle, refresh_button},
     slider_with_edit,
 };
-use rye_math::{Bivector, Rotor4};
+use rye_math::Rotor4;
 
 use crate::consts::{CONTROL_H, CONTROL_W, PLAY_PAUSE_W};
 use crate::state::{
@@ -356,8 +356,8 @@ impl Demo {
         // Falls back to the window width if the window is narrower.
         const OVERLAY_MAX_WIDTH: f32 = 768.0;
         const OVERLAY_MIN_WIDTH: f32 = 280.0;
-        let natural_w = (screen.width() - 2.0 * pad).max(OVERLAY_MIN_WIDTH);
-        let area_w = natural_w.min(OVERLAY_MAX_WIDTH).max(OVERLAY_MIN_WIDTH);
+        let natural_w = screen.width() - 2.0 * pad;
+        let area_w = natural_w.clamp(OVERLAY_MIN_WIDTH, OVERLAY_MAX_WIDTH);
         // `overlay_pinned_width` is kept for backwards compatibility
         // with any saved state but no longer load-bearing now that the
         // width is capped.
@@ -475,13 +475,11 @@ impl Demo {
             t_dragged = interaction.dragged;
         });
         if t_dragged {
-            // Scrub uses the rate-independent `omega_animation`;
-            // `rot_time` is animation time (already rate-scaled at
-            // integration), so `exp(omega_animation * rot_time)`
-            // equals what the continuous-spin path would have
-            // integrated.
-            let omega = self.omega_animation();
-            self.rot_state = (omega * self.rot_time).exp().normalize();
+            // `rotor_at_time` dispatches Active (product-of-exp) vs
+            // Composer (sum-of-bivectors), so scrubbing the t slider
+            // reproduces exactly what the continuous-spin path would
+            // have integrated to at this `rot_time` in either mode.
+            self.rot_state = self.rotor_at_time(self.rot_time);
             self.write_all(self.rot_state);
         }
     }

--- a/crates/polytope_playground/src/ui.rs
+++ b/crates/polytope_playground/src/ui.rs
@@ -350,9 +350,20 @@ impl Demo {
     pub(crate) fn render_overlay(&mut self, ctx: &egui::Context) {
         let screen = ctx.content_rect();
         let pad = 16.0;
-        let natural_w = (screen.width() - 2.0 * pad).max(280.0);
-        let pinned = *self.overlay_pinned_width.get_or_insert(natural_w);
-        let area_w = pinned.min(natural_w).max(280.0);
+        // Cap the overlay width to roughly the 800x600 layout (the
+        // shape the demo was designed against; full-screen widths
+        // stretched the slider strip into a usability problem).
+        // Falls back to the window width if the window is narrower.
+        const OVERLAY_MAX_WIDTH: f32 = 768.0;
+        const OVERLAY_MIN_WIDTH: f32 = 280.0;
+        let natural_w = (screen.width() - 2.0 * pad).max(OVERLAY_MIN_WIDTH);
+        let area_w = natural_w
+            .min(OVERLAY_MAX_WIDTH)
+            .max(OVERLAY_MIN_WIDTH);
+        // `overlay_pinned_width` is kept for backwards compatibility
+        // with any saved state but no longer load-bearing now that the
+        // width is capped.
+        let _ = self.overlay_pinned_width.get_or_insert(area_w);
 
         let visuals = &ctx.style().visuals;
         let frame = egui::Frame::default()

--- a/crates/polytope_playground/src/ui.rs
+++ b/crates/polytope_playground/src/ui.rs
@@ -146,6 +146,9 @@ impl Demo {
         // inside the closure would need `&mut self` while `&mut self.show_render_panel`
         // is still active.
         let prev_surface = self.surface_mode;
+        // Computed BEFORE the destructure so the closure can read it as a captured value
+        // (the destructure exclusively borrows `self.row`).
+        let sdf_disabled = self.sdf_blocked_by_heavy_polychora();
         // Destructure-borrow the fields the panel writes so the closure doesn't capture
         // a whole `&mut self`. This sidesteps the borrow conflict with `show_render_panel`
         // and lets the closure remain a plain `FnOnce(&mut Ui)`.
@@ -171,7 +174,20 @@ impl Demo {
             |ui| {
                 ui.label(egui::RichText::new("Surface").strong());
                 ui.radio_value(surface_mode, SurfaceMode::Raster, "Raster (default)");
-                ui.radio_value(surface_mode, SurfaceMode::Sdf, "SDF raymarch");
+                // SDF disabled when the row contains a 120-cell or 600-cell. Those
+                // SDF kernels overrun the browser's WebGPU shader budget and crash
+                // the tab; the user has to remove the heavy polychora first. The
+                // disabled radio surfaces the reason via tooltip so they're not
+                // wondering why the option grayed out.
+                ui.add_enabled_ui(!sdf_disabled, |ui| {
+                    let resp = ui.radio_value(surface_mode, SurfaceMode::Sdf, "SDF raymarch");
+                    if sdf_disabled {
+                        resp.on_disabled_hover_text(
+                            "Disabled: 120-cell/600-cell SDFs crash the browser tab. \
+                             Remove the heavy polychora to re-enable.",
+                        );
+                    }
+                });
                 ui.radio_value(surface_mode, SurfaceMode::Off, "Off");
                 ui.separator();
 

--- a/crates/polytope_playground/src/ui.rs
+++ b/crates/polytope_playground/src/ui.rs
@@ -357,9 +357,7 @@ impl Demo {
         const OVERLAY_MAX_WIDTH: f32 = 768.0;
         const OVERLAY_MIN_WIDTH: f32 = 280.0;
         let natural_w = (screen.width() - 2.0 * pad).max(OVERLAY_MIN_WIDTH);
-        let area_w = natural_w
-            .min(OVERLAY_MAX_WIDTH)
-            .max(OVERLAY_MIN_WIDTH);
+        let area_w = natural_w.min(OVERLAY_MAX_WIDTH).max(OVERLAY_MIN_WIDTH);
         // `overlay_pinned_width` is kept for backwards compatibility
         // with any saved state but no longer load-bearing now that the
         // width is capped.

--- a/crates/rye-app/Cargo.toml
+++ b/crates/rye-app/Cargo.toml
@@ -82,6 +82,10 @@ web-sys = { version = "0.3", features = [
     "Element",
     "HtmlCanvasElement",
     "HtmlButtonElement",
+    # `HtmlStyleElement` + `HtmlHeadElement` for `inject_launch_overlay`
+    # (engine-side click-to-start markup + CSS injection).
+    "HtmlStyleElement",
+    "HtmlHeadElement",
     "Location",
     "UrlSearchParams",
     "Performance",

--- a/crates/rye-app/src/cursor.rs
+++ b/crates/rye-app/src/cursor.rs
@@ -36,13 +36,30 @@
 //!
 //! ## Wasm note
 //!
-//! Browser Pointer Lock API requires "transient activation" (a recent user
-//! gesture) before `element.requestPointerLock()` succeeds. Console
-//! commands issued via keystrokes do NOT count as the gesture from the
-//! browser's perspective. The runner's wasm path therefore does not call
-//! Pointer Lock at all today; a request on wasm emits a one-time
-//! [`tracing::warn!`] so the demo author notices the no-op, then stays
-//! silent for the rest of the session.
+//! On wasm32 the request channel routes through the worker → main DOM-
+//! action plumbing in [`crate::wasm::host_action`]. The worker drains
+//! [`take_pending`] at the end of each frame, translates the grab mode
+//! to a [`HostAction::PointerLockRequest`](crate::wasm::host_action::HostAction::PointerLockRequest)
+//! or [`HostAction::PointerLockRelease`](crate::wasm::host_action::HostAction::PointerLockRelease),
+//! and posts to the main thread. The main thread calls
+//! `canvas.requestPointerLock()` / `document.exitPointerLock()` and
+//! relays the resulting `pointerlockchange` event back to the worker as
+//! `InputMessage::PointerLockChanged`, which calls [`mark_applied`] so
+//! [`current_state`] stays accurate.
+//!
+//! Browser Pointer Lock requires "transient activation" (a recent user
+//! gesture). The keystroke that produced the console command opens a
+//! ~5-second window; the worker → main round-trip is sub-millisecond,
+//! so the activation token is still valid when `requestPointerLock`
+//! runs. If the user releases the lock with Esc (a browser-hardcoded
+//! shortcut we can't suppress), the demo learns via
+//! `PointerLockChanged(false)` and a canvas click re-engages it if the
+//! demo last requested grab.
+//!
+//! The [`GrabMode::Confined`] variant has no direct browser equivalent
+//! and is treated as a Pointer Lock request (the closest behavior we
+//! can deliver). Visibility requests are implicit on wasm: Pointer Lock
+//! auto-hides, release auto-shows.
 
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
@@ -105,11 +122,6 @@ static PENDING_WARP_CENTER: AtomicBool = AtomicBool::new(false);
 static APPLIED_GRAB: AtomicU8 = AtomicU8::new(GRAB_NONE);
 static APPLIED_VISIBLE: AtomicBool = AtomicBool::new(true);
 
-// One-time wasm "this API is a no-op here" warn flag. Avoids per-frame
-// spam if a demo polls request_grab in update() by mistake.
-#[cfg(target_arch = "wasm32")]
-static WASM_WARNED: AtomicBool = AtomicBool::new(false);
-
 fn grab_mode_to_code(mode: GrabMode) -> u8 {
     match mode {
         GrabMode::None => GRAB_NONE,
@@ -129,8 +141,6 @@ fn code_to_grab_mode(code: u8) -> GrabMode {
 /// Request the runner change the grab mode on its next redraw.
 pub fn request_grab_mode(mode: GrabMode) {
     PENDING_GRAB.store(grab_mode_to_code(mode), Ordering::Release);
-    #[cfg(target_arch = "wasm32")]
-    warn_wasm_once_if_grabbing(mode);
 }
 
 /// Request the runner show or hide the cursor on its next redraw.
@@ -200,19 +210,6 @@ pub fn current_state() -> CursorState {
     CursorState {
         grab: code_to_grab_mode(APPLIED_GRAB.load(Ordering::Acquire)),
         visible: APPLIED_VISIBLE.load(Ordering::Acquire),
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn warn_wasm_once_if_grabbing(mode: GrabMode) {
-    if mode != GrabMode::None && !WASM_WARNED.swap(true, Ordering::AcqRel) {
-        tracing::warn!(
-            "rye_app::cursor: grab requested on wasm32, but Pointer Lock \
-             requires a recent user gesture that console-driven commands \
-             don't satisfy. The request is silently a no-op; the cursor \
-             will not be confined or hidden. See the cursor module doc \
-             for the architectural fix (main-thread click handler)."
-        );
     }
 }
 

--- a/crates/rye-app/src/cursor.rs
+++ b/crates/rye-app/src/cursor.rs
@@ -36,20 +36,22 @@
 //!
 //! ## Wasm note
 //!
-//! On wasm32 the request channel routes through the worker → main DOM-
-//! action plumbing in [`crate::wasm::host_action`]. The worker drains
-//! [`take_pending`] at the end of each frame, translates the grab mode
-//! to a [`HostAction::PointerLockRequest`](crate::wasm::host_action::HostAction::PointerLockRequest)
-//! or [`HostAction::PointerLockRelease`](crate::wasm::host_action::HostAction::PointerLockRelease),
-//! and posts to the main thread. The main thread calls
-//! `canvas.requestPointerLock()` / `document.exitPointerLock()` and
-//! relays the resulting `pointerlockchange` event back to the worker as
+//! On wasm32 the request channel routes through the worker -> main DOM-
+//! action plumbing in `wasm::host_action` (plain reference, not an
+//! intra-doc link: that module is `#[cfg(target_arch = "wasm32")]` so
+//! it doesn't exist when docs build for the native target). The worker
+//! drains [`take_pending`] at the end of each frame, translates the
+//! grab mode to a `HostAction::PointerLockRequest` or
+//! `HostAction::PointerLockRelease`, and posts to the main thread. The
+//! main thread calls `canvas.requestPointerLock()` /
+//! `document.exitPointerLock()` and relays the resulting
+//! `pointerlockchange` event back to the worker as
 //! `InputMessage::PointerLockChanged`, which calls [`mark_applied`] so
 //! [`current_state`] stays accurate.
 //!
 //! Browser Pointer Lock requires "transient activation" (a recent user
 //! gesture). The keystroke that produced the console command opens a
-//! ~5-second window; the worker → main round-trip is sub-millisecond,
+//! ~5-second window; the worker -> main round-trip is sub-millisecond,
 //! so the activation token is still valid when `requestPointerLock`
 //! runs. If the user releases the lock with Esc (a browser-hardcoded
 //! shortcut we can't suppress), the demo learns via

--- a/crates/rye-app/src/frame_pacing.rs
+++ b/crates/rye-app/src/frame_pacing.rs
@@ -129,6 +129,10 @@ pub fn take_pending_vsync() -> Option<bool> {
 /// than Windows' default 15.625 ms timer tick is *imprecise*, not wider than
 /// the *whole* tick: `std::thread::sleep` rounds DOWN sometimes and UP others,
 /// and 2 ms of spin covers the worst-case overshoot we've seen on Win11.
+///
+/// Native-only: the sole consumer is [`sleep_until`], which is cfg'd out on
+/// wasm32 (the worker takes the skip-and-rerequest path instead of sleeping).
+#[cfg(not(target_arch = "wasm32"))]
 const SPIN_TAIL: Duration = Duration::from_millis(2);
 
 /// Sleep until `deadline`, hybrid coarse-sleep + spin-wait for sub-millisecond

--- a/crates/rye-app/src/frame_pacing.rs
+++ b/crates/rye-app/src/frame_pacing.rs
@@ -33,12 +33,16 @@ use std::time::Duration;
 // `std::time::Instant::now` panics on wasm32, so the swap is mandatory.
 use web_time::Instant;
 
-/// 60 fps in nanoseconds (≈16.667 ms). Initial value the runner uses unless a
-/// console command changes it. Picked because it matches the typical display
-/// refresh rate the browser RAF and most native vsync settings already
-/// enforce. i.e., the cap is mostly a no-op until the user explicitly raises
-/// or lowers it.
-const DEFAULT_PERIOD_NS: u64 = 16_666_667;
+/// Initial value the runner uses unless a console command changes it. `0`
+/// means "uncapped": native uses the surface's PresentMode (typically vsync
+/// at the display refresh rate) and wasm uses the browser RAF cadence. We
+/// previously defaulted to 60 fps (~16.667 ms) on the assumption that "most
+/// displays are 60 Hz so the cap is a no-op," but that assumption breaks on
+/// 120/144/240 Hz displays where the cap actively suppresses the native
+/// rate AND introduces RAF-jitter alternating-skip in the worker. Defaulting
+/// to uncapped means `fps <N>` is the only way to introduce a cap, which
+/// matches the principle of least surprise.
+const DEFAULT_PERIOD_NS: u64 = 0;
 
 /// Target frame period in nanoseconds. `0` means "uncapped"; the runner will
 /// not sleep / skip and lets the display refresh rate or browser RAF be the

--- a/crates/rye-app/src/freecam.rs
+++ b/crates/rye-app/src/freecam.rs
@@ -7,19 +7,23 @@
 //!
 //! ## What a Freecam does each frame
 //!
-//! When [`Freecam::active`] is `true` AND [`Freecam::cursor_grabbed`] is
-//! `true`:
+//! When [`Freecam::active`] is `true`:
 //!
-//! 1. The internal [`FirstPersonController`] consumes
+//! 1. WASD + Space/Shift on `FrameInput` integrate the world-space
+//!    `position` field at `speed` units/sec. Runs whenever active,
+//!    independent of cursor grab.
+//! 2. **When [`Freecam::cursor_grabbed`] is `true` as well**, the
+//!    internal [`FirstPersonController`] consumes
 //!    `FrameInput::mouse_raw_delta` to update yaw + pitch.
-//! 2. WASD + Space/Shift on `FrameInput` integrate the world-space
-//!    `position` field at `speed` units/sec.
 //! 3. The owning `Camera<EuclideanR3>` has its `position` + basis updated.
 //!
-//! When `active = false` OR `cursor_grabbed = false`: [`Freecam::advance`]
-//! is a no-op. The cursor-grab toggle lets the user release the mouse for
-//! UI access without leaving freecam mode entirely (the position + look
-//! direction freeze in place; resuming the grab continues from there).
+//! When `active = false`: [`Freecam::advance`] is a no-op. When
+//! `cursor_grabbed = false`: look-direction freezes (so releasing the
+//! cursor for UI access doesn't drag the camera), but WASD translation
+//! continues. This split is what lets the browser flavor work at all --
+//! on wasm, Pointer Lock requires a user gesture the engine doesn't
+//! deliver, so `cursor_grabbed` is permanently false; gating WASD on it
+//! would freeze freecam translation entirely there.
 //!
 //! ## Activation contract
 //!
@@ -278,14 +282,28 @@ impl Freecam {
     /// Caller still owns the higher-level mode switch (orbit vs freecam);
     /// this method assumes `Freecam` IS the active controller this frame.
     pub fn advance(&mut self, input: FrameInput, camera: &mut Camera<EuclideanR3>, dt: f32) {
-        if !self.active || !self.cursor_grabbed {
+        if !self.active {
             return;
         }
-        // Look direction: controller reads raw delta, updates yaw + pitch,
-        // writes the camera's right/up/forward.
-        self.controller.advance(input, camera, &EuclideanR3, dt);
-        // Position: integrate the WASD + Space/Shift axes in the camera's
-        // local frame.
+        // Look direction: needs `cursor_grabbed` because the controller
+        // reads raw mouse deltas, which only make sense while the OS has
+        // the pointer trapped inside the window (or, on wasm, while
+        // Pointer Lock is engaged). When the cursor is voluntarily
+        // released via Alt for UI access, look-direction freezes so the
+        // mouse can move over UI without dragging the camera with it.
+        if self.cursor_grabbed {
+            self.controller.advance(input, camera, &EuclideanR3, dt);
+        }
+        // Position: integrates WASD + Space/Shift in the camera's local
+        // frame whenever freecam is active. Keyboard input doesn't depend
+        // on cursor grab, and on wasm `cursor_grabbed` is always false
+        // because Pointer Lock requires a user gesture that the current
+        // engine plumbing doesn't deliver -- gating WASD on it would
+        // freeze translation in the browser permanently. On native this
+        // also keeps WASD moving while the user has Alt-released the
+        // cursor; in practice the demo's `if !ctx.ui_has_focus` gate
+        // upstream blocks the call once the user actually clicks into
+        // the UI, so the change is mostly transparent.
         let mut delta = camera.forward * input.move_forward
             + camera.right * input.move_right
             + Vec3::Y * input.move_up;
@@ -421,7 +439,7 @@ mod tests {
     }
 
     #[test]
-    fn advance_noop_when_cursor_released() {
+    fn advance_with_cursor_released_freezes_look_but_keeps_wasd() {
         let mut f = Freecam::new();
         f.set_active(true, Vec3::ZERO);
         f.toggle_cursor_grab(); // release
@@ -433,7 +451,14 @@ mod tests {
             ..Default::default()
         };
         f.advance(input, &mut cam, 0.016);
-        assert_eq!(cam.forward, cam_before.forward, "look frozen when released");
+        assert_eq!(
+            cam.forward, cam_before.forward,
+            "look frozen when cursor released"
+        );
+        assert_ne!(
+            cam.position, cam_before.position,
+            "WASD continues to translate when cursor released (matches wasm where Pointer Lock never engages)"
+        );
     }
 
     #[test]

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -1293,22 +1293,30 @@ impl<A: App> Runner<A> {
         // if individual frames overshoot. If we ran long (work + present took
         // longer than the period), we set `last_redraw_at = now` to "catch
         // up" instead of falling further behind on every subsequent frame.
-        let mut frame_anchor = Instant::now();
-        if let (Some(period), Some(last)) = (frame_pacing::target_period(), self.last_redraw_at) {
-            let deadline = last + period;
-            if frame_anchor < deadline {
-                #[cfg(target_arch = "wasm32")]
-                {
-                    win.request_redraw();
-                    return;
+        let now = Instant::now();
+        let frame_anchor =
+            if let (Some(period), Some(last)) = (frame_pacing::target_period(), self.last_redraw_at)
+            {
+                let deadline = last + period;
+                if now < deadline {
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        win.request_redraw();
+                        return;
+                    }
+                    // Native: sleep out the remainder and anchor on the
+                    // ideal deadline, not the wake-up time.
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        frame_pacing::precise_sleep_until(deadline);
+                        deadline
+                    }
+                } else {
+                    now
                 }
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    frame_pacing::precise_sleep_until(deadline);
-                    frame_anchor = deadline;
-                }
-            }
-        }
+            } else {
+                now
+            };
         self.last_redraw_at = Some(frame_anchor);
 
         // Mark frame start for `idle` measurement. `end_frame` subtracts this from

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -179,7 +179,35 @@ pub trait App: Sized + 'static {
     /// Custom `WindowEvent` handling beyond the input routing the framework runs first.
     /// Most apps don't need this; useful for keyboard-driven mode toggles,
     /// drag-and-drop, etc.
+    ///
+    /// **Wasm worker context: not called for keyboard events.** The worker can't
+    /// construct a `WindowEvent::KeyboardInput` (winit's `KeyEvent` has a
+    /// `pub(crate)` field) so hotkey handlers placed here fire on native only.
+    /// Use [`App::on_key`] for keyboard hotkeys instead; it fires on both paths.
     fn on_event(&mut self, _ev: &WindowEvent, _ctx: &mut FrameCtx<'_>) {}
+
+    /// Keyboard hotkey hook, fired for every key press AND release after
+    /// the framework's input routing. Use this for mode toggles, hotkeys,
+    /// and other key-driven UI flips. Default impl is empty; demos with no
+    /// hotkeys ignore it.
+    ///
+    /// Why a separate hook from [`App::on_event`]: the wasm worker has no
+    /// way to construct a `winit::event::KeyEvent` (one of its fields is
+    /// `pub(crate)`), so the worker can't route keyboard events through
+    /// `on_event` like the native runner does. `on_key` takes `KeyCode +
+    /// ElementState`, which both runners can produce, so demos that use
+    /// `on_key` see hotkeys on both native and wasm.
+    ///
+    /// Continuous WASD-style integration belongs in [`App::update`] reading
+    /// [`FrameInput`](rye_input::FrameInput) (held-key axes); use `on_key`
+    /// for edge-triggered toggles (Space, Tab, T, R, digits, etc.).
+    fn on_key(
+        &mut self,
+        _code: winit::keyboard::KeyCode,
+        _state: ElementState,
+        _ctx: &mut FrameCtx<'_>,
+    ) {
+    }
 
     /// Hot-reload notification: the framework polled `AssetWatcher`, applied events to
     /// `ShaderDb` against `self.space()`, and any consumer pipelines you built may be
@@ -1124,6 +1152,14 @@ impl<A: App> ApplicationHandler for Runner<A> {
                     _non_exhaustive: PhantomData,
                 };
                 app.on_event(&ev, &mut ctx);
+                // Mirror the wasm worker's contract: route keyboard events
+                // through `on_key` too, so demos with a single hotkey impl
+                // (in `on_key`) work the same on both runners.
+                if let WindowEvent::KeyboardInput { event, .. } = &ev {
+                    if let winit::keyboard::PhysicalKey::Code(code) = event.physical_key {
+                        app.on_key(code, event.state, &mut ctx);
+                    }
+                }
             }
         }
     }

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -1294,29 +1294,29 @@ impl<A: App> Runner<A> {
         // longer than the period), we set `last_redraw_at = now` to "catch
         // up" instead of falling further behind on every subsequent frame.
         let now = Instant::now();
-        let frame_anchor =
-            if let (Some(period), Some(last)) = (frame_pacing::target_period(), self.last_redraw_at)
-            {
-                let deadline = last + period;
-                if now < deadline {
-                    #[cfg(target_arch = "wasm32")]
-                    {
-                        win.request_redraw();
-                        return;
-                    }
-                    // Native: sleep out the remainder and anchor on the
-                    // ideal deadline, not the wake-up time.
-                    #[cfg(not(target_arch = "wasm32"))]
-                    {
-                        frame_pacing::precise_sleep_until(deadline);
-                        deadline
-                    }
-                } else {
-                    now
+        let frame_anchor = if let (Some(period), Some(last)) =
+            (frame_pacing::target_period(), self.last_redraw_at)
+        {
+            let deadline = last + period;
+            if now < deadline {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    win.request_redraw();
+                    return;
+                }
+                // Native: sleep out the remainder and anchor on the
+                // ideal deadline, not the wake-up time.
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    frame_pacing::precise_sleep_until(deadline);
+                    deadline
                 }
             } else {
                 now
-            };
+            }
+        } else {
+            now
+        };
         self.last_redraw_at = Some(frame_anchor);
 
         // Mark frame start for `idle` measurement. `end_frame` subtracts this from

--- a/crates/rye-app/src/lib.rs
+++ b/crates/rye-app/src/lib.rs
@@ -199,7 +199,7 @@ pub trait App: Sized + 'static {
     /// `on_key` see hotkeys on both native and wasm.
     ///
     /// Continuous WASD-style integration belongs in [`App::update`] reading
-    /// [`FrameInput`](rye_input::FrameInput) (held-key axes); use `on_key`
+    /// [`rye_input::FrameInput`] (held-key axes); use `on_key`
     /// for edge-triggered toggles (Space, Tab, T, R, digits, etc.).
     fn on_key(
         &mut self,

--- a/crates/rye-app/src/wasm/host_action.rs
+++ b/crates/rye-app/src/wasm/host_action.rs
@@ -1,4 +1,4 @@
-//! Worker → main-thread channel for DOM-touching actions.
+//! Worker -> main-thread channel for DOM-touching actions.
 //!
 //! ## Why this module exists
 //!
@@ -10,15 +10,14 @@
 //! Wake Lock, Audio focus resumption, the File System Access pickers --
 //! has to round-trip to the main thread.
 //!
-//! This module is the engine-side primitive for that round-trip. Demos
-//! call high-level APIs (`rye_app::cursor::request_grab`,
+//! This module is the engine-side primitive for that round-trip. Demos call
+//! high-level APIs (`rye_app::cursor::request_grab`, a future
 //! `rye_app::fullscreen::request_enter`, etc.); those APIs queue a
-//! [`HostAction`]; the worker's frame loop drains pending actions once
-//! per frame and posts them to the main thread via
-//! [`post_pending_actions`]. The main thread's listener in
-//! `main_launcher::install_host_action_handler` dispatches each one to
-//! the matching DOM call and (for stateful actions) listens for the
-//! browser's state-change event to ping the worker back.
+//! [`HostAction`]; the worker's frame loop drains pending actions once per
+//! frame and posts them to the main thread via [`post_pending_actions`]. The
+//! main thread's listener in `main_launcher::install_host_action_handler`
+//! dispatches each one to the matching DOM call and (for stateful actions)
+//! listens for the browser's state-change event to ping the worker back.
 //!
 //! ## Why not synchronous RPC
 //!
@@ -57,30 +56,28 @@ use std::cell::RefCell;
 
 use wasm_bindgen::JsValue;
 
-/// One worker → main DOM action. Variants name *intent*; the main
+/// One worker -> main DOM action. Variants name *intent*; the main
 /// thread translates each to the matching DOM call.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HostAction {
-    /// Engage Pointer Lock on the canvas. Locks the cursor to the
-    /// canvas center and reports raw motion deltas via
-    /// `MouseEvent.movementX/Y`. The main thread calls
-    /// `canvas.requestPointerLock()`; the actual transition fires a
-    /// `pointerlockchange` event the main thread relays back via
+    /// Engage Pointer Lock on the canvas. Locks the cursor to the canvas
+    /// center and reports raw motion deltas via `MouseEvent.movementX/Y`. The
+    /// main thread calls `canvas.requestPointerLock()`; the actual transition
+    /// fires a `pointerlockchange` event the main thread relays back via
     /// `InputMessage::PointerLockChanged(true)`.
     PointerLockRequest,
-    /// Release Pointer Lock. Main thread calls
-    /// `document.exitPointerLock()`. Browser also auto-releases on Esc
-    /// or tab switch; either path produces the same
-    /// `pointerlockchange` round-trip.
+    /// Release Pointer Lock. Main thread calls `document.exitPointerLock()`.
+    /// The browser also auto-releases on Esc or tab switch; either path
+    /// produces the same `pointerlockchange` round-trip back to the worker.
     PointerLockRelease,
 }
 
 thread_local! {
-    /// Per-worker pending action queue. Drained at the end of each
-    /// frame by [`post_pending_actions`]. A `thread_local` because the
-    /// engine APIs that produce these (`rye_app::cursor`,
-    /// `rye_app::fullscreen` later) have no direct handle to the worker
-    /// runner; they push into this static and the runner reads it.
+    /// Per-worker pending action queue. Drained at the end of each frame by
+    /// [`post_pending_actions`]. A `thread_local` because the engine APIs that
+    /// produce these (`rye_app::cursor`, a future `rye_app::fullscreen`) have
+    /// no direct handle to the worker runner; they push into this static and
+    /// the runner reads it.
     static PENDING: RefCell<Vec<HostAction>> = const { RefCell::new(Vec::new()) };
 }
 
@@ -113,9 +110,12 @@ pub fn post_pending_actions(scope: &web_sys::DedicatedWorkerGlobalScope) -> anyh
 
 /// Build the `{kind: "host_action", actions: [...]}` JS object for a
 /// drained action list. Each action is encoded as `{kind: "<variant
-/// lowercase>"}` with any per-variant fields tacked on. Kept separate
-/// from `post_pending_actions` so unit tests can exercise the encoding
-/// without needing a real `DedicatedWorkerGlobalScope`.
+/// lowercase>"}` with any per-variant fields tacked on. Split out from
+/// `post_pending_actions` so the encoding is exercisable in isolation
+/// (the natural home is a `wasm-bindgen-test`, since the `js_sys` /
+/// `JsValue` types only exist on the wasm target; that test harness is
+/// not yet wired into CI, so the encoding is currently covered only by
+/// the demos running without a malformed-message panic).
 fn encode_actions(actions: &[HostAction]) -> anyhow::Result<JsValue> {
     let msg = js_sys::Object::new();
     js_sys::Reflect::set(

--- a/crates/rye-app/src/wasm/host_action.rs
+++ b/crates/rye-app/src/wasm/host_action.rs
@@ -72,6 +72,20 @@ pub enum HostAction {
     PointerLockRelease,
 }
 
+impl HostAction {
+    /// The `kind` string this action serializes to on the wire. Single
+    /// source of truth for the contract: `encode_actions` writes it into
+    /// the per-action JS object, and `main_launcher`'s `host_action`
+    /// dispatch matches the same literals. Keep the two in lockstep when
+    /// adding a variant.
+    const fn kind_str(self) -> &'static str {
+        match self {
+            HostAction::PointerLockRequest => "pointer_lock_request",
+            HostAction::PointerLockRelease => "pointer_lock_release",
+        }
+    }
+}
+
 thread_local! {
     /// Per-worker pending action queue. Drained at the end of each frame by
     /// [`post_pending_actions`]. A `thread_local` because the engine APIs that
@@ -109,13 +123,13 @@ pub fn post_pending_actions(scope: &web_sys::DedicatedWorkerGlobalScope) -> anyh
 }
 
 /// Build the `{kind: "host_action", actions: [...]}` JS object for a
-/// drained action list. Each action is encoded as `{kind: "<variant
-/// lowercase>"}` with any per-variant fields tacked on. Split out from
-/// `post_pending_actions` so the encoding is exercisable in isolation
-/// (the natural home is a `wasm-bindgen-test`, since the `js_sys` /
-/// `JsValue` types only exist on the wasm target; that test harness is
-/// not yet wired into CI, so the encoding is currently covered only by
-/// the demos running without a malformed-message panic).
+/// drained action list. Each action is encoded as `{kind: <action.kind_str()>}`;
+/// per-variant fields (none today) would be tacked onto `item` here. Split
+/// out from `post_pending_actions` so the encoding is exercisable in
+/// isolation (the natural home is a `wasm-bindgen-test`, since the `js_sys`
+/// / `JsValue` types only exist on the wasm target; that test harness is not
+/// yet wired into CI, so the encoding is currently covered only by the demos
+/// running without a malformed-message panic).
 fn encode_actions(actions: &[HostAction]) -> anyhow::Result<JsValue> {
     let msg = js_sys::Object::new();
     js_sys::Reflect::set(
@@ -127,24 +141,12 @@ fn encode_actions(actions: &[HostAction]) -> anyhow::Result<JsValue> {
     let arr = js_sys::Array::new();
     for action in actions {
         let item = js_sys::Object::new();
-        match action {
-            HostAction::PointerLockRequest => {
-                js_sys::Reflect::set(
-                    &item,
-                    &JsValue::from_str("kind"),
-                    &JsValue::from_str("pointer_lock_request"),
-                )
-                .map_err(|e| anyhow::anyhow!("set pointer_lock_request: {e:?}"))?;
-            }
-            HostAction::PointerLockRelease => {
-                js_sys::Reflect::set(
-                    &item,
-                    &JsValue::from_str("kind"),
-                    &JsValue::from_str("pointer_lock_release"),
-                )
-                .map_err(|e| anyhow::anyhow!("set pointer_lock_release: {e:?}"))?;
-            }
-        }
+        js_sys::Reflect::set(
+            &item,
+            &JsValue::from_str("kind"),
+            &JsValue::from_str(action.kind_str()),
+        )
+        .map_err(|e| anyhow::anyhow!("set action kind: {e:?}"))?;
         arr.push(&item);
     }
     js_sys::Reflect::set(&msg, &JsValue::from_str("actions"), &arr)

--- a/crates/rye-app/src/wasm/host_action.rs
+++ b/crates/rye-app/src/wasm/host_action.rs
@@ -1,0 +1,153 @@
+//! Worker → main-thread channel for DOM-touching actions.
+//!
+//! ## Why this module exists
+//!
+//! The OffscreenCanvas-in-Worker architecture trades DOM access for GC
+//! isolation. The worker can't touch `document`, the canvas DOM element,
+//! `navigator`, or anything else that synchronously reads or mutates the
+//! page; those calls panic with a `ReferenceError`. Every browser API
+//! that requires DOM access -- Pointer Lock, Fullscreen, the Clipboard,
+//! Wake Lock, Audio focus resumption, the File System Access pickers --
+//! has to round-trip to the main thread.
+//!
+//! This module is the engine-side primitive for that round-trip. Demos
+//! call high-level APIs (`rye_app::cursor::request_grab`,
+//! `rye_app::fullscreen::request_enter`, etc.); those APIs queue a
+//! [`HostAction`]; the worker's frame loop drains pending actions once
+//! per frame and posts them to the main thread via
+//! [`post_pending_actions`]. The main thread's listener in
+//! `main_launcher::install_host_action_handler` dispatches each one to
+//! the matching DOM call and (for stateful actions) listens for the
+//! browser's state-change event to ping the worker back.
+//!
+//! ## Why not synchronous RPC
+//!
+//! `Atomics.wait` + `SharedArrayBuffer` could give the worker a blocking
+//! call into the main thread, but it would stall the worker's RAF loop
+//! while the main thread schedules the DOM call. The browser also
+//! gates `SharedArrayBuffer` behind COOP/COEP headers that complicate
+//! self-hosted demos. Async postMessage trades a millisecond of latency
+//! (well within Pointer Lock's transient-activation window) for never
+//! blocking either thread.
+//!
+//! ## Cadence
+//!
+//! Actions are batched per frame: the worker drains its pending list at
+//! the end of each frame (after `App::update`/`App::record`), constructs
+//! one `{kind: "host_action", actions: [...]}` message, and posts it.
+//! Empty drains skip the post. Per-frame batching means a console
+//! command that flips cursor grab + visibility + fullscreen all in one
+//! tick produces one postMessage, not three.
+//!
+//! ## Extending
+//!
+//! Adding a new DOM-action capability is:
+//! 1. New variant on [`HostAction`].
+//! 2. Drain-and-encode case in [`encode_actions`].
+//! 3. Main thread `host_action` dispatch arm in `main_launcher`.
+//! 4. If the action has observable state (Pointer Lock did/didn't
+//!    engage; Fullscreen did/didn't accept), wire the corresponding DOM
+//!    event listener on main thread to ping back via the existing
+//!    inbound `InputMessage` channel. Define a new `InputMessage`
+//!    variant if needed.
+//!
+//! No coupling between actions; each one's plumbing is local.
+
+use std::cell::RefCell;
+
+use wasm_bindgen::JsValue;
+
+/// One worker → main DOM action. Variants name *intent*; the main
+/// thread translates each to the matching DOM call.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostAction {
+    /// Engage Pointer Lock on the canvas. Locks the cursor to the
+    /// canvas center and reports raw motion deltas via
+    /// `MouseEvent.movementX/Y`. The main thread calls
+    /// `canvas.requestPointerLock()`; the actual transition fires a
+    /// `pointerlockchange` event the main thread relays back via
+    /// `InputMessage::PointerLockChanged(true)`.
+    PointerLockRequest,
+    /// Release Pointer Lock. Main thread calls
+    /// `document.exitPointerLock()`. Browser also auto-releases on Esc
+    /// or tab switch; either path produces the same
+    /// `pointerlockchange` round-trip.
+    PointerLockRelease,
+}
+
+thread_local! {
+    /// Per-worker pending action queue. Drained at the end of each
+    /// frame by [`post_pending_actions`]. A `thread_local` because the
+    /// engine APIs that produce these (`rye_app::cursor`,
+    /// `rye_app::fullscreen` later) have no direct handle to the worker
+    /// runner; they push into this static and the runner reads it.
+    static PENDING: RefCell<Vec<HostAction>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Queue a host action for the next frame's drain. Cheap (one push to a
+/// per-worker `Vec`). Safe to call from anywhere on the worker thread;
+/// engine modules wrap this in their own typed APIs.
+pub fn queue(action: HostAction) {
+    PENDING.with(|p| p.borrow_mut().push(action));
+}
+
+/// Drain pending actions and post them to the main thread as one
+/// `{kind: "host_action", actions: [...]}` message. No-op if the queue
+/// is empty. Called once per frame from the worker's frame loop.
+///
+/// Wrapped in a `Result` even though `post_message` on a worker's
+/// global scope rarely fails -- if it does (Firefox during teardown,
+/// rate-limited contexts), the caller logs it and we drop the actions
+/// for that frame. Re-queuing on failure would risk spinning if the
+/// transport is permanently down.
+pub fn post_pending_actions(scope: &web_sys::DedicatedWorkerGlobalScope) -> anyhow::Result<()> {
+    let actions = PENDING.with(|p| std::mem::take(&mut *p.borrow_mut()));
+    if actions.is_empty() {
+        return Ok(());
+    }
+    let msg = encode_actions(&actions)?;
+    scope
+        .post_message(&msg)
+        .map_err(|e| anyhow::anyhow!("post host_action: {e:?}"))
+}
+
+/// Build the `{kind: "host_action", actions: [...]}` JS object for a
+/// drained action list. Each action is encoded as `{kind: "<variant
+/// lowercase>"}` with any per-variant fields tacked on. Kept separate
+/// from `post_pending_actions` so unit tests can exercise the encoding
+/// without needing a real `DedicatedWorkerGlobalScope`.
+fn encode_actions(actions: &[HostAction]) -> anyhow::Result<JsValue> {
+    let msg = js_sys::Object::new();
+    js_sys::Reflect::set(
+        &msg,
+        &JsValue::from_str("kind"),
+        &JsValue::from_str("host_action"),
+    )
+    .map_err(|e| anyhow::anyhow!("set kind: {e:?}"))?;
+    let arr = js_sys::Array::new();
+    for action in actions {
+        let item = js_sys::Object::new();
+        match action {
+            HostAction::PointerLockRequest => {
+                js_sys::Reflect::set(
+                    &item,
+                    &JsValue::from_str("kind"),
+                    &JsValue::from_str("pointer_lock_request"),
+                )
+                .map_err(|e| anyhow::anyhow!("set pointer_lock_request: {e:?}"))?;
+            }
+            HostAction::PointerLockRelease => {
+                js_sys::Reflect::set(
+                    &item,
+                    &JsValue::from_str("kind"),
+                    &JsValue::from_str("pointer_lock_release"),
+                )
+                .map_err(|e| anyhow::anyhow!("set pointer_lock_release: {e:?}"))?;
+            }
+        }
+        arr.push(&item);
+    }
+    js_sys::Reflect::set(&msg, &JsValue::from_str("actions"), &arr)
+        .map_err(|e| anyhow::anyhow!("set actions: {e:?}"))?;
+    Ok(msg.into())
+}

--- a/crates/rye-app/src/wasm/launch.rs
+++ b/crates/rye-app/src/wasm/launch.rs
@@ -89,41 +89,47 @@ const LAUNCH_OVERLAY_CSS: &str = r#"
     background: rgba(20, 20, 28, 0.55);
 }
 
-/* Spinner overlay used by both `.initializing` and `.loading`. */
-.rye-demo-launch.initializing::before,
-.rye-demo-launch.loading::before {
-    content: '';
-    position: absolute;
-    width: 18px;
-    height: 18px;
-    right: calc(50% - 110px);
-    border: 2px solid rgba(200, 200, 220, 0.25);
-    border-top-color: rgba(220, 220, 240, 0.9);
-    border-radius: 50%;
-    animation: rye-demo-spinner 0.9s linear infinite;
+/* Default: chip + spinner both hidden. State classes opt in. */
+.rye-demo-launch::before,
+.rye-demo-launch::after {
+    display: none;
 }
 @keyframes rye-demo-spinner {
     to { transform: rotate(360deg); }
 }
 
-/* Initializing: the page just loaded; worker is spawning + the
-   preview frame hasn't rendered yet. Clicks blocked at the JS layer
-   (`fired` short-circuits) and the cursor reads as wait so the user
-   doesn't get hopeful. */
+/* Initializing: large centered spinner, no chip, no text. The worker
+   is spawning + warming pipelines; the user can't do anything yet,
+   so the visual is just "something's happening." Clicks blocked at
+   the JS layer (the `ready` class-name gate in `on_click`). */
 .rye-demo-launch.initializing {
     cursor: wait;
 }
-.rye-demo-launch.initializing::after {
-    content: 'Initializing\2026';
-    padding-right: 56px;
+.rye-demo-launch.initializing::before {
+    content: '';
+    display: inline-block;
+    width: 56px;
+    height: 56px;
+    border: 5px solid rgba(200, 200, 220, 0.2);
+    border-top-color: rgba(230, 230, 245, 0.95);
+    border-radius: 50%;
+    animation: rye-demo-spinner 0.9s linear infinite;
 }
 
-/* Ready: preview frame is behind the blur, click affordance live. */
+/* Ready: preview frame is behind the blur AND warmup is complete,
+   click affordance live. Clicking removes the overlay immediately
+   and starts the RAF loop -- no second loading state because the
+   worker pre-warmed pipelines before getting here. */
 .rye-demo-launch.ready {
     cursor: pointer;
 }
 .rye-demo-launch.ready::after {
+    display: inline-block;
     content: 'Click anywhere to launch';
+    padding: 14px 28px;
+    border: 1px solid rgba(200, 200, 220, 0.5);
+    border-radius: 6px;
+    background: rgba(20, 20, 28, 0.55);
 }
 .rye-demo-launch.ready:hover {
     background: rgba(14, 14, 18, 0.25);
@@ -134,16 +140,6 @@ const LAUNCH_OVERLAY_CSS: &str = r#"
 }
 .rye-demo-launch.ready:active {
     background: rgba(14, 14, 18, 0.4);
-}
-
-/* Loading: user clicked; worker is warming pipelines + cycling first
-   frames. Clicks blocked the same way as `.initializing`. */
-.rye-demo-launch.loading {
-    cursor: wait;
-}
-.rye-demo-launch.loading::after {
-    content: 'Loading\2026';
-    padding-right: 56px;
 }
 "#;
 

--- a/crates/rye-app/src/wasm/launch.rs
+++ b/crates/rye-app/src/wasm/launch.rs
@@ -34,14 +34,13 @@
 //! [`inject_launch_overlay`] reuses an existing element rather than duplicating
 //! it when one is already in the DOM.
 //!
-//! ## Non-goals (v1)
+//! ## Non-goals
 //!
-//! - **Pause / resume on IntersectionObserver.** Coming in v2 once the lifecycle
-//!   handle returned by `run_with_config` exposes a way to stop the redraw loop
-//!   without tearing down the wgpu device.
-//! - **Loading-progress UI.** The current implementation hides the launch button on
-//!   click and lets the canvas appear when ready (~the same time as the first
-//!   `RenderDevice::new` resolve). Pipeline-warming progress UI is a v2 piece.
+//! - **Pause / resume on scroll-out.** When a demo scrolls out of view in a
+//!   blog embed, the ideal behavior is to pause its RAF loop and reclaim GPU
+//!   resources. That belongs in the JS embed wrapper (an `IntersectionObserver`
+//!   that posts a `pause` message to the worker), not in this engine path; the
+//!   worker already has the lifecycle hooks a wrapper would drive.
 
 use anyhow::{anyhow, Context, Result};
 use wasm_bindgen::prelude::Closure;

--- a/crates/rye-app/src/wasm/launch.rs
+++ b/crates/rye-app/src/wasm/launch.rs
@@ -191,12 +191,14 @@ pub fn inject_launch_overlay(host_id: &str, button_id: &str) -> Result<HtmlButto
         .dyn_into::<HtmlButtonElement>()
         .map_err(|_| anyhow!("created element is not HtmlButtonElement"))?;
     button.set_id(button_id);
-    // Starts in `initializing` state: cursor=wait, label="Initializing…",
-    // spinner running. The worker's `preview_ready` message promotes
-    // the overlay to `.ready` once the blurred-preview frame is on the
-    // canvas; the click handler then promotes to `.loading` on user
-    // click; the `demo_ready` message removes the overlay entirely.
-    button.set_class_name("rye-demo-launch initializing");
+    // Starts with no state class -> CSS defaults hide the chip + spinner
+    // (only the blurred background + base layout apply). The static
+    // `#rye-page-loader` element in the demo's `index.html` carries the
+    // visible spinner from page load until the worker posts
+    // `preview_ready`; at that point the static loader is removed and
+    // this overlay gets the `.ready` class to show the click affordance.
+    // Click then removes the overlay entirely.
+    button.set_class_name("rye-demo-launch");
     button.set_type("button");
     button
         .set_attribute("aria-label", "Launch demo")

--- a/crates/rye-app/src/wasm/launch.rs
+++ b/crates/rye-app/src/wasm/launch.rs
@@ -91,6 +91,44 @@ const LAUNCH_OVERLAY_CSS: &str = r#"
 .rye-demo-launch:active {
     background: rgba(14, 14, 18, 0.4);
 }
+/* Loading state: applied to the overlay after the user clicks, before
+   the worker has rendered enough frames to be smooth. Cursor stays
+   default (not pointer), the click handler short-circuits subsequent
+   clicks, and a small spinner appears next to the label. The overlay
+   stays opaque (no pointer-events: none yet) so accidental click-spam
+   doesn't cascade into the canvas underneath while the demo is still
+   warming up. */
+.rye-demo-launch.loading {
+    cursor: wait;
+}
+.rye-demo-launch.loading::after {
+    content: 'Loading\2026';
+    padding-right: 56px;
+    background-image: linear-gradient(
+        from-left,
+        transparent,
+        transparent
+    );
+}
+.rye-demo-launch.loading::before {
+    content: '';
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    /* Same coordinate system as the chip text so the spinner sits
+       next to it. CSS pseudo-elements share the parent's flex layout
+       only if they're sized; we absolute-position relative to the
+       chip's rect via the parent's `display: flex; align-items:
+       center` and a small negative offset. */
+    right: calc(50% - 110px);
+    border: 2px solid rgba(200, 200, 220, 0.25);
+    border-top-color: rgba(220, 220, 240, 0.9);
+    border-radius: 50%;
+    animation: rye-demo-spinner 0.9s linear infinite;
+}
+@keyframes rye-demo-spinner {
+    to { transform: rotate(360deg); }
+}
 "#;
 
 const OVERLAY_STYLE_ID: &str = "rye-launch-overlay-styles";

--- a/crates/rye-app/src/wasm/launch.rs
+++ b/crates/rye-app/src/wasm/launch.rs
@@ -55,6 +55,15 @@ use web_sys::{HtmlButtonElement, HtmlStyleElement};
 /// reads the canvas underneath, so the worker's preview frame appears as
 /// a softened thumbnail until the viewer clicks.
 const LAUNCH_OVERLAY_CSS: &str = r#"
+/* Base: shared chrome (positioning, blur, font, transitions). State-
+   specific text + cursor + spinner live in the `.initializing`,
+   `.ready`, `.loading` subclasses below. `.initializing` is the
+   default injected at startup (worker still spawning + first frame
+   not rendered yet); the worker promotes the overlay to `.ready`
+   via the `preview_ready` message once the blurred-backdrop frame
+   is on the canvas, and the click handler promotes to `.loading`
+   when the user clicks. The `demo_ready` message removes the
+   overlay entirely. */
 .rye-demo-launch {
     position: absolute;
     top: 0; left: 0; right: 0; bottom: 0;
@@ -70,56 +79,23 @@ const LAUNCH_OVERLAY_CSS: &str = r#"
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
     border: none;
-    cursor: pointer;
     transition: background 200ms ease, opacity 200ms ease;
 }
 .rye-demo-launch::after {
-    content: 'Click anywhere to launch';
     display: inline-block;
     padding: 14px 28px;
     border: 1px solid rgba(200, 200, 220, 0.5);
     border-radius: 6px;
     background: rgba(20, 20, 28, 0.55);
 }
-.rye-demo-launch:hover {
-    background: rgba(14, 14, 18, 0.25);
-}
-.rye-demo-launch:hover::after {
-    background: rgba(28, 28, 38, 0.65);
-    border-color: rgba(220, 220, 240, 0.7);
-}
-.rye-demo-launch:active {
-    background: rgba(14, 14, 18, 0.4);
-}
-/* Loading state: applied to the overlay after the user clicks, before
-   the worker has rendered enough frames to be smooth. Cursor stays
-   default (not pointer), the click handler short-circuits subsequent
-   clicks, and a small spinner appears next to the label. The overlay
-   stays opaque (no pointer-events: none yet) so accidental click-spam
-   doesn't cascade into the canvas underneath while the demo is still
-   warming up. */
-.rye-demo-launch.loading {
-    cursor: wait;
-}
-.rye-demo-launch.loading::after {
-    content: 'Loading\2026';
-    padding-right: 56px;
-    background-image: linear-gradient(
-        from-left,
-        transparent,
-        transparent
-    );
-}
+
+/* Spinner overlay used by both `.initializing` and `.loading`. */
+.rye-demo-launch.initializing::before,
 .rye-demo-launch.loading::before {
     content: '';
     position: absolute;
     width: 18px;
     height: 18px;
-    /* Same coordinate system as the chip text so the spinner sits
-       next to it. CSS pseudo-elements share the parent's flex layout
-       only if they're sized; we absolute-position relative to the
-       chip's rect via the parent's `display: flex; align-items:
-       center` and a small negative offset. */
     right: calc(50% - 110px);
     border: 2px solid rgba(200, 200, 220, 0.25);
     border-top-color: rgba(220, 220, 240, 0.9);
@@ -128,6 +104,46 @@ const LAUNCH_OVERLAY_CSS: &str = r#"
 }
 @keyframes rye-demo-spinner {
     to { transform: rotate(360deg); }
+}
+
+/* Initializing: the page just loaded; worker is spawning + the
+   preview frame hasn't rendered yet. Clicks blocked at the JS layer
+   (`fired` short-circuits) and the cursor reads as wait so the user
+   doesn't get hopeful. */
+.rye-demo-launch.initializing {
+    cursor: wait;
+}
+.rye-demo-launch.initializing::after {
+    content: 'Initializing\2026';
+    padding-right: 56px;
+}
+
+/* Ready: preview frame is behind the blur, click affordance live. */
+.rye-demo-launch.ready {
+    cursor: pointer;
+}
+.rye-demo-launch.ready::after {
+    content: 'Click anywhere to launch';
+}
+.rye-demo-launch.ready:hover {
+    background: rgba(14, 14, 18, 0.25);
+}
+.rye-demo-launch.ready:hover::after {
+    background: rgba(28, 28, 38, 0.65);
+    border-color: rgba(220, 220, 240, 0.7);
+}
+.rye-demo-launch.ready:active {
+    background: rgba(14, 14, 18, 0.4);
+}
+
+/* Loading: user clicked; worker is warming pipelines + cycling first
+   frames. Clicks blocked the same way as `.initializing`. */
+.rye-demo-launch.loading {
+    cursor: wait;
+}
+.rye-demo-launch.loading::after {
+    content: 'Loading\2026';
+    padding-right: 56px;
 }
 "#;
 
@@ -179,7 +195,12 @@ pub fn inject_launch_overlay(host_id: &str, button_id: &str) -> Result<HtmlButto
         .dyn_into::<HtmlButtonElement>()
         .map_err(|_| anyhow!("created element is not HtmlButtonElement"))?;
     button.set_id(button_id);
-    button.set_class_name("rye-demo-launch");
+    // Starts in `initializing` state: cursor=wait, label="Initializing…",
+    // spinner running. The worker's `preview_ready` message promotes
+    // the overlay to `.ready` once the blurred-preview frame is on the
+    // canvas; the click handler then promotes to `.loading` on user
+    // click; the `demo_ready` message removes the overlay entirely.
+    button.set_class_name("rye-demo-launch initializing");
     button.set_type("button");
     button
         .set_attribute("aria-label", "Launch demo")

--- a/crates/rye-app/src/wasm/launch.rs
+++ b/crates/rye-app/src/wasm/launch.rs
@@ -1,31 +1,18 @@
 //! Wasm32-only helpers for the browser embedding lifecycle. Demos opt into
 //! click-to-start (so the page doesn't spin up a wgpu device + render loop until the
-//! user actually wants the demo) by:
+//! user actually wants the demo) by marking the host element in `index.html`:
 //!
-//! 1. Marking the host element in `index.html`:
+//! ```html
+//! <div id="rye-canvas-host" data-mode="manual">
+//!   <canvas id="rye-canvas" width="1280" height="800"></canvas>
+//! </div>
+//! ```
 //!
-//!    ```html
-//!    <div id="rye-canvas-host" data-mode="manual">
-//!      <button id="rye-launch" class="rye-demo-launch">
-//!        Launch demo
-//!      </button>
-//!    </div>
-//!    ```
-//!
-//! 2. Branching in `main`:
-//!
-//!    ```ignore
-//!    fn main() -> anyhow::Result<()> {
-//!        #[cfg(target_arch = "wasm32")]
-//!        if rye_app::wasm::is_manual_mode("rye-canvas-host") {
-//!            rye_app::wasm::wait_for_launch("rye-launch", || {
-//!                let _ = launch_app();
-//!            })?;
-//!            return Ok(());
-//!        }
-//!        launch_app()
-//!    }
-//!    ```
+//! [`inject_launch_overlay`] runs from the engine on startup and creates the
+//! `#rye-launch` button as a sibling of the canvas, along with a `<style>`
+//! element in `<head>` carrying [`LAUNCH_OVERLAY_CSS`]. Demos no longer ship
+//! the button markup or CSS themselves; one line of HTML wires up the entire
+//! click-to-start container.
 //!
 //! The wasm module still loads on page navigation (the bytes are downloaded and
 //! `init()` runs), but `run_with_config` doesn't fire until the click event. The
@@ -34,10 +21,18 @@
 //!
 //! ## Multi-demo per page
 //!
-//! Each demo has its own host element id. Calling `wait_for_launch` for several
-//! demos on the same page is supported as long as the button ids are unique. v1 ships
-//! single-demo embedding only (one wasm bundle per page); multi-demo lands once the
-//! per-bundle JS surface is decided.
+//! Each demo has its own host element id; the injected `<style>` element is
+//! keyed on a fixed id so multiple demos on one page only insert the CSS once.
+//! v1 ships single-demo embedding only (one wasm bundle per page); multi-demo
+//! lands once the per-bundle JS surface is decided.
+//!
+//! ## Theming
+//!
+//! Demos that want a custom look can either ship a stylesheet that comes later
+//! in the cascade and overrides the engine's `.rye-demo-launch` rules, or pre-
+//! create a `<button id="...">` with their own classes inside the host element;
+//! [`inject_launch_overlay`] reuses an existing element rather than duplicating
+//! it when one is already in the DOM.
 //!
 //! ## Non-goals (v1)
 //!
@@ -47,12 +42,114 @@
 //! - **Loading-progress UI.** The current implementation hides the launch button on
 //!   click and lets the canvas appear when ready (~the same time as the first
 //!   `RenderDevice::new` resolve). Pipeline-warming progress UI is a v2 piece.
-//! - **Custom button styling from Rust.** All styling lives in the page's CSS so
-//!   blog embedding can theme the button to match the surrounding content.
 
 use anyhow::{anyhow, Context, Result};
 use wasm_bindgen::prelude::Closure;
 use wasm_bindgen::{JsCast, JsValue};
+use web_sys::{HtmlButtonElement, HtmlStyleElement};
+
+/// Default CSS for the click-to-start overlay. Injected by
+/// [`inject_launch_overlay`] into `<head>` once per page; demos that want
+/// to theme the overlay can ship a stylesheet that comes later in the
+/// cascade (or use higher-specificity selectors) to override. The blur
+/// reads the canvas underneath, so the worker's preview frame appears as
+/// a softened thumbnail until the viewer clicks.
+const LAUNCH_OVERLAY_CSS: &str = r#"
+.rye-demo-launch {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font: inherit;
+    font-size: 14px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #d8d8df;
+    background: rgba(14, 14, 18, 0.35);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    border: none;
+    cursor: pointer;
+    transition: background 200ms ease, opacity 200ms ease;
+}
+.rye-demo-launch::after {
+    content: 'Click anywhere to launch';
+    display: inline-block;
+    padding: 14px 28px;
+    border: 1px solid rgba(200, 200, 220, 0.5);
+    border-radius: 6px;
+    background: rgba(20, 20, 28, 0.55);
+}
+.rye-demo-launch:hover {
+    background: rgba(14, 14, 18, 0.25);
+}
+.rye-demo-launch:hover::after {
+    background: rgba(28, 28, 38, 0.65);
+    border-color: rgba(220, 220, 240, 0.7);
+}
+.rye-demo-launch:active {
+    background: rgba(14, 14, 18, 0.4);
+}
+"#;
+
+const OVERLAY_STYLE_ID: &str = "rye-launch-overlay-styles";
+
+/// Inject a launch-overlay `<button>` as a child of `host_id` plus a
+/// `<style>` element carrying [`LAUNCH_OVERLAY_CSS`] into `<head>`. The
+/// style element is idempotent (keyed on a fixed id), so calling this
+/// for multiple demos on one page only inserts the CSS once.
+///
+/// Returns the freshly-created button so the caller can wire its click
+/// handler. If an element with `button_id` already exists in the DOM
+/// (because the demo's `index.html` ships a static button for legacy
+/// reasons or for theming reasons), this function reuses it instead of
+/// creating a duplicate.
+pub fn inject_launch_overlay(host_id: &str, button_id: &str) -> Result<HtmlButtonElement> {
+    let window = web_sys::window().ok_or_else(|| anyhow!("no global window"))?;
+    let document = window
+        .document()
+        .ok_or_else(|| anyhow!("no document on window"))?;
+    let host = document
+        .get_element_by_id(host_id)
+        .ok_or_else(|| anyhow!("no host element with id '{host_id}'"))?;
+
+    if document.get_element_by_id(OVERLAY_STYLE_ID).is_none() {
+        let head = document
+            .head()
+            .ok_or_else(|| anyhow!("no <head> element"))?;
+        let style = document
+            .create_element("style")
+            .map_err(|e| anyhow!("create <style>: {e:?}"))?
+            .dyn_into::<HtmlStyleElement>()
+            .map_err(|_| anyhow!("created element is not HtmlStyleElement"))?;
+        style.set_id(OVERLAY_STYLE_ID);
+        style.set_text_content(Some(LAUNCH_OVERLAY_CSS));
+        head.append_child(&style)
+            .map_err(|e| anyhow!("append <style>: {e:?}"))?;
+    }
+
+    if let Some(existing) = document.get_element_by_id(button_id) {
+        return existing
+            .dyn_into::<HtmlButtonElement>()
+            .map_err(|_| anyhow!("element '{button_id}' is not a button"));
+    }
+
+    let button = document
+        .create_element("button")
+        .map_err(|e| anyhow!("create <button>: {e:?}"))?
+        .dyn_into::<HtmlButtonElement>()
+        .map_err(|_| anyhow!("created element is not HtmlButtonElement"))?;
+    button.set_id(button_id);
+    button.set_class_name("rye-demo-launch");
+    button.set_type("button");
+    button
+        .set_attribute("aria-label", "Launch demo")
+        .map_err(|e| anyhow!("set aria-label: {e:?}"))?;
+    host.append_child(&button)
+        .map_err(|e| anyhow!("append button to host: {e:?}"))?;
+    Ok(button)
+}
 
 /// Returns true if the page opted into click-to-start by setting
 /// `data-mode="manual"` on the host element with the given id. Returns false on

--- a/crates/rye-app/src/wasm/launch.rs
+++ b/crates/rye-app/src/wasm/launch.rs
@@ -54,15 +54,14 @@ use web_sys::{HtmlButtonElement, HtmlStyleElement};
 /// reads the canvas underneath, so the worker's preview frame appears as
 /// a softened thumbnail until the viewer clicks.
 const LAUNCH_OVERLAY_CSS: &str = r#"
-/* Base: shared chrome (positioning, blur, font, transitions). State-
-   specific text + cursor + spinner live in the `.initializing`,
-   `.ready`, `.loading` subclasses below. `.initializing` is the
-   default injected at startup (worker still spawning + first frame
-   not rendered yet); the worker promotes the overlay to `.ready`
-   via the `preview_ready` message once the blurred-backdrop frame
-   is on the canvas, and the click handler promotes to `.loading`
-   when the user clicks. The `demo_ready` message removes the
-   overlay entirely. */
+/* Base: shared chrome (positioning, blur, font, transitions). The
+   overlay is injected with no state class, so the chip is hidden and
+   only the blurred backdrop shows. The worker's `preview_ready`
+   message promotes it to `.ready` once the blurred preview frame is
+   on the canvas AND pipelines are warm, which reveals the click
+   affordance; clicking then removes the overlay entirely. The
+   pre-`.ready` "something's happening" visual is the static
+   `#rye-page-loader` progress bar, not this overlay. */
 .rye-demo-launch {
     position: absolute;
     top: 0; left: 0; right: 0; bottom: 0;
@@ -80,39 +79,10 @@ const LAUNCH_OVERLAY_CSS: &str = r#"
     border: none;
     transition: background 200ms ease, opacity 200ms ease;
 }
-.rye-demo-launch::after {
-    display: inline-block;
-    padding: 14px 28px;
-    border: 1px solid rgba(200, 200, 220, 0.5);
-    border-radius: 6px;
-    background: rgba(20, 20, 28, 0.55);
-}
 
-/* Default: chip + spinner both hidden. State classes opt in. */
-.rye-demo-launch::before,
+/* Default (no state class): chip hidden. The `.ready` class opts in. */
 .rye-demo-launch::after {
     display: none;
-}
-@keyframes rye-demo-spinner {
-    to { transform: rotate(360deg); }
-}
-
-/* Initializing: large centered spinner, no chip, no text. The worker
-   is spawning + warming pipelines; the user can't do anything yet,
-   so the visual is just "something's happening." Clicks blocked at
-   the JS layer (the `ready` class-name gate in `on_click`). */
-.rye-demo-launch.initializing {
-    cursor: wait;
-}
-.rye-demo-launch.initializing::before {
-    content: '';
-    display: inline-block;
-    width: 56px;
-    height: 56px;
-    border: 5px solid rgba(200, 200, 220, 0.2);
-    border-top-color: rgba(230, 230, 245, 0.95);
-    border-radius: 50%;
-    animation: rye-demo-spinner 0.9s linear infinite;
 }
 
 /* Ready: preview frame is behind the blur AND warmup is complete,

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -232,7 +232,7 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
     // (or via the worker's handle_message queue) and applied on first frame.
     install_dom_input_forwarders(&worker, &canvas).context("install_dom_input_forwarders")?;
 
-    // Worker → main DOM-action channel + pointerlockchange forwarder +
+    // Worker -> main DOM-action channel + pointerlockchange forwarder +
     // canvas click-to-re-engage. This is the standard OffscreenCanvas-
     // in-Worker pattern for letting the worker drive DOM APIs that can
     // only be called from main thread.
@@ -310,7 +310,7 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
 
             // Worker pre-warmed pipelines before posting preview_ready,
             // so the demo is genuinely ready right now. Just remove the
-            // overlay; click → demo is one transition, no second wait.
+            // overlay; click -> demo is one transition, no second wait.
             overlay_for_click.remove();
         }) as Box<dyn FnMut()>);
         launch_overlay
@@ -761,8 +761,8 @@ fn install_preview_ready_handler(worker: &Worker, button_id: &str) -> Result<()>
     Ok(())
 }
 
-/// Install the worker → main DOM-action handler, the
-/// `pointerlockchange` → worker forwarder, and the canvas
+/// Install the worker -> main DOM-action handler, the
+/// `pointerlockchange` -> worker forwarder, and the canvas
 /// click-to-re-engage Pointer Lock helper.
 ///
 /// ## Architecture
@@ -813,7 +813,7 @@ fn install_host_action_handler(worker: &Worker, canvas: &HtmlCanvasElement) -> R
     // demo voluntarily released), the click does nothing.
     let want_locked: Rc<RefCell<bool>> = Rc::new(RefCell::new(false));
 
-    // Worker → main: drain a `host_action` message into DOM calls.
+    // Worker -> main: drain a `host_action` message into DOM calls.
     {
         let canvas_for_dispatch = canvas.clone();
         let document_for_dispatch = document.clone();

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -238,6 +238,13 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
     // only be called from main thread.
     install_host_action_handler(&worker, &canvas).context("install_host_action_handler")?;
 
+    // Listen for the worker's "demo_ready" signal -- sent once after the
+    // worker has rendered enough frames to be smooth (pipelines compiled,
+    // first sim ticks settled). On receipt, remove the launch overlay so
+    // input flows to the canvas; until then the overlay's `.loading`
+    // state absorbs the user's spam clicks.
+    install_demo_ready_handler(&worker, button_id)?;
+
     // Launch-overlay click handler. Spam-click defensive:
     // - FnMut closure (not `Closure::once`) so repeat invocations are
     //   guaranteed to be safe no-ops via the `fired` Cell guard. The
@@ -290,28 +297,17 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
                 }
             }
 
-            // Hide via pointer-events first (in case any queued clicks
-            // are still in-flight after our handler runs), THEN remove
-            // from the DOM on the next microtask. The
-            // pointer-events-none style alone would be sufficient to
-            // ignore subsequent clicks; the .remove() is cosmetic
-            // (the canvas underneath is what the viewer should see).
-            let style = overlay_for_click.style();
-            let _ = style.set_property("pointer-events", "none");
-            let _ = style.set_property("opacity", "0");
-            // Defer the actual DOM removal so the opacity transition
-            // (configured in CSS) can play out. 200ms matches the CSS
-            // `transition: opacity 200ms ease`.
-            let overlay_for_remove = overlay_for_click.clone();
-            let remove_cb = Closure::once_into_js(Box::new(move || {
-                overlay_for_remove.remove();
-            }) as Box<dyn FnOnce()>);
-            if let Some(window) = web_sys::window() {
-                let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
-                    remove_cb.unchecked_ref(),
-                    200,
-                );
-            }
+            // Switch the overlay to its loading state (spinner + "Loading…"
+            // chip text). We DON'T remove the overlay yet -- the worker
+            // is still warming pipelines / cycling first frames and any
+            // clicks landing on the canvas during that window are wasted
+            // work that contributes to the perceived hitching. The
+            // overlay's `pointer-events` stays auto so subsequent clicks
+            // hit it and the `fired` cell short-circuits them; once the
+            // worker reports steady-state via `demo_ready`, the inbound
+            // message listener (`install_demo_ready_handler`) removes the
+            // overlay and the demo becomes interactive.
+            overlay_for_click.set_class_name("rye-demo-launch loading");
         }) as Box<dyn FnMut()>);
         launch_overlay
             .add_event_listener_with_callback("click", on_click.as_ref().unchecked_ref())
@@ -680,6 +676,44 @@ fn set_msg_bool(obj: &js_sys::Object, key: &str, v: bool) {
 
 fn set_msg_string(obj: &js_sys::Object, key: &str, v: &str) {
     let _ = js_sys::Reflect::set(obj, &JsValue::from_str(key), &JsValue::from_str(v));
+}
+
+/// Listen for the worker's once-only `{kind: "demo_ready"}` message and
+/// remove the launch overlay when it arrives. The worker sends this
+/// after rendering a handful of warm-up frames (currently 10, per
+/// `worker.rs::DEMO_READY_FRAMES`), which is enough for the heavy
+/// per-pipeline shader compilations to settle and the first sim ticks
+/// to land at the target rate. Until then the launch overlay's
+/// `.loading` state absorbs spam clicks so they don't compound the
+/// startup hitch.
+fn install_demo_ready_handler(worker: &Worker, button_id: &str) -> Result<()> {
+    let button_id_owned: String = button_id.to_string();
+    let cb = Closure::wrap(Box::new(move |event: MessageEvent| {
+        let data: JsValue = event.data();
+        let kind = js_sys::Reflect::get(&data, &JsValue::from_str("kind"))
+            .ok()
+            .and_then(|v| v.as_string());
+        if kind.as_deref() != Some("demo_ready") {
+            return;
+        }
+        // Find the launch overlay by id and remove it. The overlay was
+        // injected by `inject_launch_overlay` so we look it up via
+        // `document.getElementById` rather than threading the element
+        // through this listener -- the lookup is once-per-page (the
+        // worker only sends `demo_ready` once) and avoids a long-lived
+        // Rc capture.
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Some(overlay) = document.get_element_by_id(&button_id_owned) {
+            overlay.remove();
+        }
+    }) as Box<dyn FnMut(MessageEvent)>);
+    worker
+        .add_event_listener_with_callback("message", cb.as_ref().unchecked_ref())
+        .map_err(|e| anyhow!("worker.addEventListener('message') for demo_ready: {e:?}"))?;
+    cb.forget();
+    Ok(())
 }
 
 /// Install the worker → main DOM-action handler, the

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -268,9 +268,10 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
                 tracing::debug!("rye_app::wasm::worker: launch click ignored (already fired)");
                 return;
             }
-            // Gate on the overlay being in `.ready` state. Clicks during
-            // `.initializing` (worker still spawning + preview frame not
-            // rendered) are absorbed silently so the user can spam-click
+            // Gate on the overlay being in `.ready` state. Before
+            // `preview_ready` lands (worker still spawning + preview
+            // frame not rendered) the overlay has no `.ready` class, so
+            // clicks are absorbed silently and the user can spam-click
             // without queueing a Start that fires before the worker is
             // actually ready to handle it.
             if !overlay_for_click.class_name().contains("ready") {
@@ -682,18 +683,12 @@ fn set_msg_string(obj: &js_sys::Object, key: &str, v: &str) {
     let _ = js_sys::Reflect::set(obj, &JsValue::from_str(key), &JsValue::from_str(v));
 }
 
-/// Listen for the worker's once-only `{kind: "demo_ready"}` message and
-/// remove the launch overlay when it arrives. The worker sends this
-/// after rendering a handful of warm-up frames (currently 10, per
-/// `worker.rs::DEMO_READY_FRAMES`), which is enough for the heavy
-/// per-pipeline shader compilations to settle and the first sim ticks
-/// to land at the target rate. Until then the launch overlay's
-/// `.loading` state absorbs spam clicks so they don't compound the
-/// startup hitch.
 /// Listen for `{kind: "preview_progress", pct: f64}` updates from the
-/// worker and drive the static `#rye-page-loader-fill` element's width.
-/// The bar is in `crates/rye-app/static/page_loader.html` (engine-owned,
-/// inlined into the demo's `index.html` via `data-trunk rel="inline"`).
+/// worker and drive the static `#rye-page-loader-fill` element's width
+/// plus the progress track's `aria-valuenow` (so a screen reader
+/// announces the loading percentage instead of silence). The bar is in
+/// `crates/rye-app/static/page_loader.html` (engine-owned, inlined into
+/// the demo's `index.html` via `data-trunk rel="inline"`).
 fn install_preview_progress_handler(worker: &Worker) -> Result<()> {
     let cb = Closure::wrap(Box::new(move |event: MessageEvent| {
         let data: JsValue = event.data();
@@ -708,15 +703,18 @@ fn install_preview_progress_handler(worker: &Worker) -> Result<()> {
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0)
             .clamp(0.0, 1.0);
+        let percent = pct * 100.0;
         let Some(document) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
         if let Some(fill) = document.get_element_by_id("rye-page-loader-fill") {
             let _ = fill.dyn_into::<web_sys::HtmlElement>().map(|el| {
-                let _ = el
-                    .style()
-                    .set_property("width", &format!("{}%", pct * 100.0));
+                let _ = el.style().set_property("width", &format!("{percent}%"));
             });
+        }
+        // Mirror the width into the progressbar's announced value.
+        if let Some(track) = document.query_selector("#rye-page-loader .rye-progress-track").ok().flatten() {
+            let _ = track.set_attribute("aria-valuenow", &format!("{}", percent.round() as i32));
         }
     }) as Box<dyn FnMut(MessageEvent)>);
     worker
@@ -726,12 +724,12 @@ fn install_preview_progress_handler(worker: &Worker) -> Result<()> {
     Ok(())
 }
 
-/// Listen for the worker's once-only `{kind: "preview_ready"}` message
-/// and promote the launch overlay from `.initializing` to `.ready` so
-/// the "Click to launch" affordance becomes visible only after the
-/// blurred preview frame has actually rendered. Before this, the
-/// overlay shows "Initializing…" with a spinner and the click handler
-/// short-circuits so spam clicks are absorbed.
+/// Listen for the worker's once-only `{kind: "preview_ready"}` message,
+/// remove the static `#rye-page-loader` progress bar, and add the
+/// `.ready` class to the launch overlay so the "Click to launch"
+/// affordance becomes visible only after the blurred preview frame has
+/// actually rendered. Before this, the page-loader bar is the visible
+/// state and the click handler short-circuits so spam clicks are absorbed.
 fn install_preview_ready_handler(worker: &Worker, button_id: &str) -> Result<()> {
     let button_id_owned: String = button_id.to_string();
     let cb = Closure::wrap(Box::new(move |event: MessageEvent| {

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -232,6 +232,12 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
     // (or via the worker's handle_message queue) and applied on first frame.
     install_dom_input_forwarders(&worker, &canvas).context("install_dom_input_forwarders")?;
 
+    // Worker → main DOM-action channel + pointerlockchange forwarder +
+    // canvas click-to-re-engage. This is the standard OffscreenCanvas-
+    // in-Worker pattern for letting the worker drive DOM APIs that can
+    // only be called from main thread.
+    install_host_action_handler(&worker, &canvas).context("install_host_action_handler")?;
+
     // Launch-overlay click handler. Spam-click defensive:
     // - FnMut closure (not `Closure::once`) so repeat invocations are
     //   guaranteed to be safe no-ops via the `fired` Cell guard. The
@@ -440,13 +446,26 @@ fn install_dom_input_forwarders(worker: &Worker, canvas: &HtmlCanvasElement) -> 
     // latest position. Result: at most 60 mouse-move postMessages per
     // second regardless of input device frequency.
     {
-        let pending: Rc<RefCell<Option<(f32, f32, u32)>>> = Rc::new(RefCell::new(None));
+        // Pending state carries: latest (x, y, buttons) plus the *summed*
+        // `movementX/Y` across all coalesced events since the last RAF
+        // tick. Latest absolute position is what the worker uses for the
+        // egui cursor; summed deltas are what the worker uses for FPS
+        // mouse-look (`mouse_raw_delta`) so intermediate sub-frame motion
+        // isn't lost when we coalesce.
+        let pending: Rc<RefCell<Option<(f32, f32, u32, f32, f32)>>> = Rc::new(RefCell::new(None));
         let pending_for_listener = pending.clone();
         let cb = Closure::wrap(Box::new(move |ev: web_sys::MouseEvent| {
-            *pending_for_listener.borrow_mut() = Some((
+            let mut p = pending_for_listener.borrow_mut();
+            let (sum_dx, sum_dy) = match *p {
+                Some((_, _, _, dx, dy)) => (dx, dy),
+                None => (0.0, 0.0),
+            };
+            *p = Some((
                 ev.offset_x() as f32,
                 ev.offset_y() as f32,
                 ev.buttons() as u32,
+                sum_dx + ev.movement_x() as f32,
+                sum_dy + ev.movement_y() as f32,
             ));
         }) as Box<dyn FnMut(web_sys::MouseEvent)>);
         canvas
@@ -460,11 +479,13 @@ fn install_dom_input_forwarders(worker: &Worker, canvas: &HtmlCanvasElement) -> 
         let raf_cb: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = Rc::new(RefCell::new(None));
         let raf_cb_for_closure = raf_cb.clone();
         *raf_cb.borrow_mut() = Some(Closure::wrap(Box::new(move || {
-            if let Some((x, y, buttons)) = pending_for_raf.borrow_mut().take() {
+            if let Some((x, y, buttons, dx, dy)) = pending_for_raf.borrow_mut().take() {
                 let msg = build_msg("mouse_move");
                 set_msg_f32(&msg, "x", x);
                 set_msg_f32(&msg, "y", y);
                 set_msg_u32(&msg, "buttons", buttons);
+                set_msg_f32(&msg, "dx", dx);
+                set_msg_f32(&msg, "dy", dy);
                 let _ = worker_for_raf.post_message(&msg);
             }
             let cb_ref = raf_cb_for_closure.borrow();
@@ -548,20 +569,29 @@ fn install_dom_input_forwarders(worker: &Worker, canvas: &HtmlCanvasElement) -> 
     // element has focus (game convention).
     //
     // `preventDefault()` is selective. The browser owns reload (F5,
-    // Ctrl+R), devtools (F12), fullscreen (F11), and Ctrl/Meta/Alt
-    // combinations generally; we leave those alone so the user retains
-    // an escape hatch. The demo owns Tab (otherwise focus walks to
-    // off-canvas DOM elements and subsequent keys never reach us),
-    // Space + arrows (otherwise the browser scrolls or activates a
-    // focused button), and slash + quote (Firefox quick-find). Letter
-    // keys never trigger a browser default action at the page level,
-    // so WASD / T / etc. need no special handling.
+    // Ctrl+R), devtools (F12), tab/window management (Ctrl+T / Ctrl+W /
+    // Ctrl+Tab), fullscreen (F11), and most modifier combos; we leave
+    // those alone so the user retains an escape hatch. The demo owns
+    // Tab (otherwise focus walks to off-canvas DOM elements and
+    // subsequent keys never reach us), Space + arrows (otherwise the
+    // browser scrolls or activates a focused button), slash + quote
+    // (Firefox quick-find), and Alt (Chrome/Firefox treat lone-Alt taps
+    // as menu-bar activation on the keyup edge; preventDefault on both
+    // edges suppresses). Letter keys never trigger a browser default
+    // action at the page level, so WASD / T / etc. need no handling.
     for (event_name, pressed) in [("keydown", true), ("keyup", false)] {
         let worker = worker.clone();
         let cb = Closure::wrap(Box::new(move |ev: web_sys::KeyboardEvent| {
+            let code = ev.code();
             let no_modifier = !ev.ctrl_key() && !ev.alt_key() && !ev.meta_key();
-            let owned = matches!(
-                ev.code().as_str(),
+            // Alt as the key itself: the `no_modifier` check excludes
+            // this case (ev.alt_key is true while Alt is the down key),
+            // so it gets its own check. Skip when Ctrl/Cmd is held so
+            // Ctrl+Alt / Cmd+Alt combos still work as intended.
+            let is_alt_self = matches!(code.as_str(), "AltLeft" | "AltRight");
+            let suppress_alt = is_alt_self && !ev.ctrl_key() && !ev.meta_key();
+            let owned_unmodified = matches!(
+                code.as_str(),
                 "Tab"
                     | "Space"
                     | "ArrowLeft"
@@ -571,11 +601,11 @@ fn install_dom_input_forwarders(worker: &Worker, canvas: &HtmlCanvasElement) -> 
                     | "Slash"
                     | "Quote",
             );
-            if owned && no_modifier {
+            if suppress_alt || (owned_unmodified && no_modifier) {
                 ev.prevent_default();
             }
             let msg = build_msg("key");
-            set_msg_string(&msg, "code", &ev.code());
+            set_msg_string(&msg, "code", &code);
             set_msg_string(&msg, "key", &ev.key());
             set_msg_bool(&msg, "pressed", pressed);
             set_msg_bool(&msg, "repeat", ev.repeat());
@@ -650,4 +680,170 @@ fn set_msg_bool(obj: &js_sys::Object, key: &str, v: bool) {
 
 fn set_msg_string(obj: &js_sys::Object, key: &str, v: &str) {
     let _ = js_sys::Reflect::set(obj, &JsValue::from_str(key), &JsValue::from_str(v));
+}
+
+/// Install the worker → main DOM-action handler, the
+/// `pointerlockchange` → worker forwarder, and the canvas
+/// click-to-re-engage Pointer Lock helper.
+///
+/// ## Architecture
+///
+/// The worker (in `wasm::worker`) posts
+/// `{kind: "host_action", actions: [{kind: "pointer_lock_request"}, ...]}`
+/// messages whenever an engine module (`rye_app::cursor`, future
+/// `fullscreen` / `clipboard` / ...) queues a DOM-touching action. Every
+/// browser API that needs DOM access has to round-trip through here
+/// because the worker has no `document` / `window` / canvas-element
+/// handle of its own; it owns only the `OffscreenCanvas` bitmap surface.
+///
+/// ## Pointer Lock specifically
+///
+/// `canvas.requestPointerLock()` succeeds when called inside the
+/// transient-activation window (~5 sec) opened by the user's last
+/// key/click. The worker can't see the activation token, but the main
+/// thread can: a console-driven freecam toggle starts as an `Enter`
+/// keydown on `document`, the worker processes it on the next frame,
+/// queues a `PointerLockRequest`, and the round-trip from key-event to
+/// `requestPointerLock` call is comfortably under that 5 sec window.
+///
+/// `document.exitPointerLock()` is always allowed (no activation
+/// needed); the browser also auto-releases on Esc, on tab switch, on
+/// visibility change. Each of those produces a `pointerlockchange`
+/// event we forward back to the worker as
+/// `InputMessage::PointerLockChanged(false)` so the engine cursor state
+/// stays accurate.
+///
+/// ## Click-to-re-engage
+///
+/// When the browser auto-releases lock (e.g., Esc) but the demo still
+/// wants it (the worker last requested grab; `want_locked = true`),
+/// clicking the canvas re-requests the lock. This is the standard
+/// WebGL-game pattern.
+fn install_host_action_handler(worker: &Worker, canvas: &HtmlCanvasElement) -> Result<()> {
+    let window = web_sys::window().ok_or_else(|| anyhow!("no global window"))?;
+    let document = window
+        .document()
+        .ok_or_else(|| anyhow!("no document on window"))?;
+
+    // Demo's desired lock state, as last requested by the worker. Lives
+    // here on the main thread (the worker's mirror via
+    // `cursor::current_state` updates from `pointerlockchange` events
+    // we forward back). Drives the canvas-click re-engagement decision:
+    // if want_locked is true but the actual lock dropped (Esc, tab
+    // switch), the next click re-requests. If want_locked is false (the
+    // demo voluntarily released), the click does nothing.
+    let want_locked: Rc<RefCell<bool>> = Rc::new(RefCell::new(false));
+
+    // Worker → main: drain a `host_action` message into DOM calls.
+    {
+        let canvas_for_dispatch = canvas.clone();
+        let document_for_dispatch = document.clone();
+        let want_locked_for_dispatch = want_locked.clone();
+        let cb = Closure::wrap(Box::new(move |event: MessageEvent| {
+            let data: JsValue = event.data();
+            let kind = js_sys::Reflect::get(&data, &JsValue::from_str("kind"))
+                .ok()
+                .and_then(|v| v.as_string());
+            if kind.as_deref() != Some("host_action") {
+                return;
+            }
+            let actions = match js_sys::Reflect::get(&data, &JsValue::from_str("actions")) {
+                Ok(arr) => arr,
+                Err(_) => return,
+            };
+            let arr = match actions.dyn_into::<js_sys::Array>() {
+                Ok(a) => a,
+                Err(_) => return,
+            };
+            for i in 0..arr.length() {
+                let item = arr.get(i);
+                let action_kind = js_sys::Reflect::get(&item, &JsValue::from_str("kind"))
+                    .ok()
+                    .and_then(|v| v.as_string());
+                match action_kind.as_deref() {
+                    Some("pointer_lock_request") => {
+                        *want_locked_for_dispatch.borrow_mut() = true;
+                        // `requestPointerLock` resolves async; the
+                        // `pointerlockchange` listener below relays
+                        // success/failure back to the worker. Failure
+                        // can mean "no transient activation" or "another
+                        // tab already has lock"; in either case the
+                        // demo learns via the relay and can act on it
+                        // (e.g., the user clicks again and we retry).
+                        canvas_for_dispatch.request_pointer_lock();
+                    }
+                    Some("pointer_lock_release") => {
+                        *want_locked_for_dispatch.borrow_mut() = false;
+                        document_for_dispatch.exit_pointer_lock();
+                    }
+                    Some(other) => {
+                        tracing::warn!(
+                            "rye_app::wasm: unknown host_action kind '{other}'; dropping"
+                        );
+                    }
+                    None => {
+                        tracing::warn!("rye_app::wasm: host_action item missing 'kind'");
+                    }
+                }
+            }
+        }) as Box<dyn FnMut(MessageEvent)>);
+        worker
+            .add_event_listener_with_callback("message", cb.as_ref().unchecked_ref())
+            .map_err(|e| anyhow!("worker.addEventListener('message') for host_action: {e:?}"))?;
+        cb.forget();
+    }
+
+    // `pointerlockchange` on document: tells us the truth about the
+    // browser's current lock state, whether we triggered it (requestPointerLock
+    // / exitPointerLock) or the user did (Esc, tab switch). Forward to
+    // the worker so `cursor::mark_applied` reflects reality.
+    {
+        let worker_for_change = worker.clone();
+        let document_for_change = document.clone();
+        let canvas_for_change = canvas.clone();
+        let cb = Closure::wrap(Box::new(move || {
+            let locked = document_for_change
+                .pointer_lock_element()
+                .as_ref()
+                .map(|el| el == canvas_for_change.as_ref())
+                .unwrap_or(false);
+            let msg = build_msg("pointer_lock_changed");
+            set_msg_bool(&msg, "locked", locked);
+            let _ = worker_for_change.post_message(&msg);
+        }) as Box<dyn FnMut()>);
+        document
+            .add_event_listener_with_callback("pointerlockchange", cb.as_ref().unchecked_ref())
+            .map_err(|e| anyhow!("pointerlockchange listener: {e:?}"))?;
+        cb.forget();
+    }
+
+    // Canvas click: re-engage Pointer Lock if the demo last requested
+    // grab but the browser dropped it (Esc). No-op if want_locked is
+    // false (release was voluntary) or if the browser already has lock
+    // (the click landed during normal interaction, no work to do).
+    {
+        let canvas_for_click = canvas.clone();
+        let document_for_click = document.clone();
+        let want_locked_for_click = want_locked.clone();
+        let cb = Closure::wrap(Box::new(move |_ev: web_sys::MouseEvent| {
+            if !*want_locked_for_click.borrow() {
+                return;
+            }
+            let already_locked = document_for_click
+                .pointer_lock_element()
+                .as_ref()
+                .map(|el| el == canvas_for_click.as_ref())
+                .unwrap_or(false);
+            if already_locked {
+                return;
+            }
+            canvas_for_click.request_pointer_lock();
+        }) as Box<dyn FnMut(web_sys::MouseEvent)>);
+        canvas
+            .add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+            .map_err(|e| anyhow!("canvas click listener: {e:?}"))?;
+        cb.forget();
+    }
+
+    Ok(())
 }

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -238,12 +238,10 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
     // only be called from main thread.
     install_host_action_handler(&worker, &canvas).context("install_host_action_handler")?;
 
-    // Listen for the worker's "preview_ready" signal -- sent once after
-    // the worker has rendered the preview frame AND pre-warmed
-    // pipelines. On receipt, promote the overlay from `.initializing`
-    // to `.ready` so the user sees the click-to-launch affordance only
-    // when the demo is genuinely ready. Click then removes the overlay
-    // and starts the RAF loop without any further wait.
+    // Listen for the worker's incremental "preview_progress" updates
+    // (one per warmup frame) to drive the static page-loader bar, and
+    // for the terminal "preview_ready" that removes the bar entirely.
+    install_preview_progress_handler(&worker)?;
     install_preview_ready_handler(&worker, button_id)?;
 
     // Launch-overlay click handler. Spam-click defensive:
@@ -692,6 +690,42 @@ fn set_msg_string(obj: &js_sys::Object, key: &str, v: &str) {
 /// to land at the target rate. Until then the launch overlay's
 /// `.loading` state absorbs spam clicks so they don't compound the
 /// startup hitch.
+/// Listen for `{kind: "preview_progress", pct: f64}` updates from the
+/// worker and drive the static `#rye-page-loader-fill` element's width.
+/// The bar is in `crates/rye-app/static/page_loader.html` (engine-owned,
+/// inlined into the demo's `index.html` via `data-trunk rel="inline"`).
+fn install_preview_progress_handler(worker: &Worker) -> Result<()> {
+    let cb = Closure::wrap(Box::new(move |event: MessageEvent| {
+        let data: JsValue = event.data();
+        let kind = js_sys::Reflect::get(&data, &JsValue::from_str("kind"))
+            .ok()
+            .and_then(|v| v.as_string());
+        if kind.as_deref() != Some("preview_progress") {
+            return;
+        }
+        let pct = js_sys::Reflect::get(&data, &JsValue::from_str("pct"))
+            .ok()
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0);
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Some(fill) = document.get_element_by_id("rye-page-loader-fill") {
+            let _ = fill.dyn_into::<web_sys::HtmlElement>().map(|el| {
+                let _ = el
+                    .style()
+                    .set_property("width", &format!("{}%", pct * 100.0));
+            });
+        }
+    }) as Box<dyn FnMut(MessageEvent)>);
+    worker
+        .add_event_listener_with_callback("message", cb.as_ref().unchecked_ref())
+        .map_err(|e| anyhow!("worker.addEventListener('message') for preview_progress: {e:?}"))?;
+    cb.forget();
+    Ok(())
+}
+
 /// Listen for the worker's once-only `{kind: "preview_ready"}` message
 /// and promote the launch overlay from `.initializing` to `.ready` so
 /// the "Click to launch" affordance becomes visible only after the

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -489,6 +489,14 @@ fn install_dom_input_forwarders(worker: &Worker, canvas: &HtmlCanvasElement) -> 
     for (event_name, pressed) in [("mousedown", true), ("mouseup", false)] {
         let worker = worker.clone();
         let cb = Closure::wrap(Box::new(move |ev: web_sys::MouseEvent| {
+            // Suppress browser default for right (2) + middle (1) button
+            // so right-click context menu and middle-click autoscroll
+            // don't fire ahead of the app receiving the press. Left
+            // button (0) is left alone; demos that pointer-lock will
+            // request the lock on left-click themselves.
+            if ev.button() != 0 {
+                ev.prevent_default();
+            }
             let msg = build_msg("mouse_button");
             set_msg_f32(&msg, "x", ev.offset_x() as f32);
             set_msg_f32(&msg, "y", ev.offset_y() as f32);
@@ -499,6 +507,20 @@ fn install_dom_input_forwarders(worker: &Worker, canvas: &HtmlCanvasElement) -> 
         canvas
             .add_event_listener_with_callback(event_name, cb.as_ref().unchecked_ref())
             .map_err(|e| anyhow!("{event_name} listener: {e:?}"))?;
+        cb.forget();
+    }
+
+    // Block the browser context menu so right-click reaches the app.
+    // Separate from `mousedown`'s suppression because `contextmenu` also
+    // fires for keyboard triggers (Shift+F10, the dedicated context-menu
+    // key) which `mousedown` never sees.
+    {
+        let cb = Closure::wrap(Box::new(move |ev: web_sys::Event| {
+            ev.prevent_default();
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        canvas
+            .add_event_listener_with_callback("contextmenu", cb.as_ref().unchecked_ref())
+            .map_err(|e| anyhow!("contextmenu listener: {e:?}"))?;
         cb.forget();
     }
 
@@ -525,9 +547,34 @@ fn install_dom_input_forwarders(worker: &Worker, canvas: &HtmlCanvasElement) -> 
 
     // Keyboard: listen on document so keys reach us regardless of which
     // element has focus (game convention).
+    //
+    // `preventDefault()` is selective. The browser owns reload (F5,
+    // Ctrl+R), devtools (F12), fullscreen (F11), and Ctrl/Meta/Alt
+    // combinations generally; we leave those alone so the user retains
+    // an escape hatch. The demo owns Tab (otherwise focus walks to
+    // off-canvas DOM elements and subsequent keys never reach us),
+    // Space + arrows (otherwise the browser scrolls or activates a
+    // focused button), and slash + quote (Firefox quick-find). Letter
+    // keys never trigger a browser default action at the page level,
+    // so WASD / T / etc. need no special handling.
     for (event_name, pressed) in [("keydown", true), ("keyup", false)] {
         let worker = worker.clone();
         let cb = Closure::wrap(Box::new(move |ev: web_sys::KeyboardEvent| {
+            let no_modifier = !ev.ctrl_key() && !ev.alt_key() && !ev.meta_key();
+            let owned = matches!(
+                ev.code().as_str(),
+                "Tab"
+                    | "Space"
+                    | "ArrowLeft"
+                    | "ArrowRight"
+                    | "ArrowUp"
+                    | "ArrowDown"
+                    | "Slash"
+                    | "Quote",
+            );
+            if owned && no_modifier {
+                ev.prevent_default();
+            }
             let msg = build_msg("key");
             set_msg_string(&msg, "code", &ev.code());
             set_msg_string(&msg, "key", &ev.key());

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -711,6 +711,11 @@ fn install_preview_ready_handler(worker: &Worker, button_id: &str) -> Result<()>
         let Some(document) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
+        // Remove the static page-load spinner from `index.html`. The
+        // wasm overlay (below) takes over the visual layer from here.
+        if let Some(loader) = document.get_element_by_id("rye-page-loader") {
+            loader.remove();
+        }
         if let Some(overlay) = document.get_element_by_id(&button_id_owned) {
             overlay.set_class_name("rye-demo-launch ready");
         }

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -238,6 +238,14 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
     // only be called from main thread.
     install_host_action_handler(&worker, &canvas).context("install_host_action_handler")?;
 
+    // Listen for the worker's "preview_ready" signal -- sent once after
+    // the worker has rendered the first preview frame. On receipt,
+    // promote the overlay from `.initializing` to `.ready` so the user
+    // sees "Click to launch" only after there's actually a blurred
+    // backdrop behind it. Before this, the overlay shows "Initializing…"
+    // with a spinner and blocks clicks.
+    install_preview_ready_handler(&worker, button_id)?;
+
     // Listen for the worker's "demo_ready" signal -- sent once after the
     // worker has rendered enough frames to be smooth (pipelines compiled,
     // first sim ticks settled). On receipt, remove the launch overlay so
@@ -267,6 +275,18 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
         let on_click = Closure::wrap(Box::new(move || {
             if fired.get() {
                 tracing::debug!("rye_app::wasm::worker: launch click ignored (already fired)");
+                return;
+            }
+            // Gate on the overlay being in `.ready` state. Clicks during
+            // `.initializing` (worker still spawning + preview frame not
+            // rendered) are absorbed silently so the user can spam-click
+            // without queueing a Start that fires before the worker is
+            // actually ready to handle it.
+            if !overlay_for_click.class_name().contains("ready") {
+                tracing::debug!(
+                    "rye_app::wasm::worker: launch click ignored (not yet ready, overlay state = {})",
+                    overlay_for_click.class_name()
+                );
                 return;
             }
             fired.set(true);
@@ -686,6 +706,36 @@ fn set_msg_string(obj: &js_sys::Object, key: &str, v: &str) {
 /// to land at the target rate. Until then the launch overlay's
 /// `.loading` state absorbs spam clicks so they don't compound the
 /// startup hitch.
+/// Listen for the worker's once-only `{kind: "preview_ready"}` message
+/// and promote the launch overlay from `.initializing` to `.ready` so
+/// the "Click to launch" affordance becomes visible only after the
+/// blurred preview frame has actually rendered. Before this, the
+/// overlay shows "Initializing…" with a spinner and the click handler
+/// short-circuits so spam clicks are absorbed.
+fn install_preview_ready_handler(worker: &Worker, button_id: &str) -> Result<()> {
+    let button_id_owned: String = button_id.to_string();
+    let cb = Closure::wrap(Box::new(move |event: MessageEvent| {
+        let data: JsValue = event.data();
+        let kind = js_sys::Reflect::get(&data, &JsValue::from_str("kind"))
+            .ok()
+            .and_then(|v| v.as_string());
+        if kind.as_deref() != Some("preview_ready") {
+            return;
+        }
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Some(overlay) = document.get_element_by_id(&button_id_owned) {
+            overlay.set_class_name("rye-demo-launch ready");
+        }
+    }) as Box<dyn FnMut(MessageEvent)>);
+    worker
+        .add_event_listener_with_callback("message", cb.as_ref().unchecked_ref())
+        .map_err(|e| anyhow!("worker.addEventListener('message') for preview_ready: {e:?}"))?;
+    cb.forget();
+    Ok(())
+}
+
 fn install_demo_ready_handler(worker: &Worker, button_id: &str) -> Result<()> {
     let button_id_owned: String = button_id.to_string();
     let cb = Closure::wrap(Box::new(move |event: MessageEvent| {

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -239,19 +239,12 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
     install_host_action_handler(&worker, &canvas).context("install_host_action_handler")?;
 
     // Listen for the worker's "preview_ready" signal -- sent once after
-    // the worker has rendered the first preview frame. On receipt,
-    // promote the overlay from `.initializing` to `.ready` so the user
-    // sees "Click to launch" only after there's actually a blurred
-    // backdrop behind it. Before this, the overlay shows "Initializing…"
-    // with a spinner and blocks clicks.
+    // the worker has rendered the preview frame AND pre-warmed
+    // pipelines. On receipt, promote the overlay from `.initializing`
+    // to `.ready` so the user sees the click-to-launch affordance only
+    // when the demo is genuinely ready. Click then removes the overlay
+    // and starts the RAF loop without any further wait.
     install_preview_ready_handler(&worker, button_id)?;
-
-    // Listen for the worker's "demo_ready" signal -- sent once after the
-    // worker has rendered enough frames to be smooth (pipelines compiled,
-    // first sim ticks settled). On receipt, remove the launch overlay so
-    // input flows to the canvas; until then the overlay's `.loading`
-    // state absorbs the user's spam clicks.
-    install_demo_ready_handler(&worker, button_id)?;
 
     // Launch-overlay click handler. Spam-click defensive:
     // - FnMut closure (not `Closure::once`) so repeat invocations are
@@ -317,17 +310,10 @@ fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> 
                 }
             }
 
-            // Switch the overlay to its loading state (spinner + "Loading…"
-            // chip text). We DON'T remove the overlay yet -- the worker
-            // is still warming pipelines / cycling first frames and any
-            // clicks landing on the canvas during that window are wasted
-            // work that contributes to the perceived hitching. The
-            // overlay's `pointer-events` stays auto so subsequent clicks
-            // hit it and the `fired` cell short-circuits them; once the
-            // worker reports steady-state via `demo_ready`, the inbound
-            // message listener (`install_demo_ready_handler`) removes the
-            // overlay and the demo becomes interactive.
-            overlay_for_click.set_class_name("rye-demo-launch loading");
+            // Worker pre-warmed pipelines before posting preview_ready,
+            // so the demo is genuinely ready right now. Just remove the
+            // overlay; click → demo is one transition, no second wait.
+            overlay_for_click.remove();
         }) as Box<dyn FnMut()>);
         launch_overlay
             .add_event_listener_with_callback("click", on_click.as_ref().unchecked_ref())
@@ -732,36 +718,6 @@ fn install_preview_ready_handler(worker: &Worker, button_id: &str) -> Result<()>
     worker
         .add_event_listener_with_callback("message", cb.as_ref().unchecked_ref())
         .map_err(|e| anyhow!("worker.addEventListener('message') for preview_ready: {e:?}"))?;
-    cb.forget();
-    Ok(())
-}
-
-fn install_demo_ready_handler(worker: &Worker, button_id: &str) -> Result<()> {
-    let button_id_owned: String = button_id.to_string();
-    let cb = Closure::wrap(Box::new(move |event: MessageEvent| {
-        let data: JsValue = event.data();
-        let kind = js_sys::Reflect::get(&data, &JsValue::from_str("kind"))
-            .ok()
-            .and_then(|v| v.as_string());
-        if kind.as_deref() != Some("demo_ready") {
-            return;
-        }
-        // Find the launch overlay by id and remove it. The overlay was
-        // injected by `inject_launch_overlay` so we look it up via
-        // `document.getElementById` rather than threading the element
-        // through this listener -- the lookup is once-per-page (the
-        // worker only sends `demo_ready` once) and avoids a long-lived
-        // Rc capture.
-        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
-            return;
-        };
-        if let Some(overlay) = document.get_element_by_id(&button_id_owned) {
-            overlay.remove();
-        }
-    }) as Box<dyn FnMut(MessageEvent)>);
-    worker
-        .add_event_listener_with_callback("message", cb.as_ref().unchecked_ref())
-        .map_err(|e| anyhow!("worker.addEventListener('message') for demo_ready: {e:?}"))?;
     cb.forget();
     Ok(())
 }

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -10,9 +10,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::Closure;
 use wasm_bindgen::{JsCast, JsValue};
-use web_sys::{
-    HtmlButtonElement, HtmlCanvasElement, MessageEvent, Worker, WorkerOptions, WorkerType,
-};
+use web_sys::{HtmlCanvasElement, MessageEvent, Worker, WorkerOptions, WorkerType};
 
 /// Main-thread entry point for worker mode. Wires the launch button so a
 /// click transfers the page's canvas to a freshly-spawned worker, which
@@ -74,7 +72,7 @@ fn read_wasm_bundle_url() -> Result<String> {
 /// wire the launch-overlay click handler that posts the `Start`
 /// message + removes the overlay on click. Called once at page load
 /// from `launch_on_click`.
-fn spawn_worker_for_preview(canvas_id: &str, _host_id: &str, button_id: &str) -> Result<()> {
+fn spawn_worker_for_preview(canvas_id: &str, host_id: &str, button_id: &str) -> Result<()> {
     let document = web_sys::window()
         .and_then(|w| w.document())
         .ok_or_else(|| anyhow!("no document on global window"))?;
@@ -83,11 +81,12 @@ fn spawn_worker_for_preview(canvas_id: &str, _host_id: &str, button_id: &str) ->
         .ok_or_else(|| anyhow!("no element with id '{canvas_id}'"))?
         .dyn_into::<HtmlCanvasElement>()
         .map_err(|_| anyhow!("element '{canvas_id}' is not a canvas"))?;
-    let launch_overlay = document
-        .get_element_by_id(button_id)
-        .ok_or_else(|| anyhow!("no element with id '{button_id}'"))?
-        .dyn_into::<HtmlButtonElement>()
-        .map_err(|_| anyhow!("element '{button_id}' is not a button"))?;
+    // Engine owns the overlay markup + CSS. `inject_launch_overlay` is
+    // idempotent: returns an existing button with `button_id` if the
+    // demo's `index.html` shipped one (legacy demos), otherwise creates
+    // it as a child of `host_id` and injects the default CSS into
+    // `<head>` exactly once per page.
+    let launch_overlay = super::launch::inject_launch_overlay(host_id, button_id)?;
 
     // Size the canvas's pixel backing-store to match its DISPLAYED size
     // × device pixel ratio. The HTML's `width`/`height` attributes are a

--- a/crates/rye-app/src/wasm/main_launcher.rs
+++ b/crates/rye-app/src/wasm/main_launcher.rs
@@ -713,7 +713,11 @@ fn install_preview_progress_handler(worker: &Worker) -> Result<()> {
             });
         }
         // Mirror the width into the progressbar's announced value.
-        if let Some(track) = document.query_selector("#rye-page-loader .rye-progress-track").ok().flatten() {
+        if let Some(track) = document
+            .query_selector("#rye-page-loader .rye-progress-track")
+            .ok()
+            .flatten()
+        {
             let _ = track.set_attribute("aria-valuenow", &format!("{}", percent.round() as i32));
         }
     }) as Box<dyn FnMut(MessageEvent)>);

--- a/crates/rye-app/src/wasm/messages.rs
+++ b/crates/rye-app/src/wasm/messages.rs
@@ -37,8 +37,19 @@ pub enum InputMessage {
 
     /// Pointer moved to (x, y) in canvas-local CSS pixels. `buttons` is
     /// the standard `MouseEvent.buttons` bitmask (1=primary, 2=secondary,
-    /// 4=middle).
-    MouseMove { x: f32, y: f32, buttons: u8 },
+    /// 4=middle). `dx`/`dy` are the raw motion delta this event carries
+    /// (`MouseEvent.movementX/Y`), used for FPS mouse-look so the camera
+    /// receives correct deltas both before Pointer Lock engages (against
+    /// arbitrary positions) and while it's engaged (against the locked
+    /// center). When the main thread coalesces moves to one per RAF the
+    /// deltas of the dropped intermediate events are summed in.
+    MouseMove {
+        x: f32,
+        y: f32,
+        buttons: u8,
+        dx: f32,
+        dy: f32,
+    },
 
     /// Pointer button transitioned. `button` is the standard
     /// `MouseEvent.button` (0=primary, 1=middle, 2=secondary).
@@ -82,6 +93,14 @@ pub enum InputMessage {
     /// of a gradient placeholder); the RAF loop only starts once
     /// `Start` lands.
     Start,
+
+    /// Pointer Lock state mirror from the main thread. Fired whenever
+    /// the main thread's `pointerlockchange` event observes the lock
+    /// either engaging or releasing (user pressed Esc, switched tabs,
+    /// etc.). The worker updates [`crate::cursor::mark_applied`] so
+    /// `current_state()` stays in sync with what the browser actually
+    /// has and demos that read the cursor flag see the truth.
+    PointerLockChanged(bool),
 }
 
 thread_local! {
@@ -135,6 +154,8 @@ pub fn parse_non_init(data: &JsValue) -> Result<Option<InputMessage>> {
             x: read_f32_field(data, "x").unwrap_or(0.0),
             y: read_f32_field(data, "y").unwrap_or(0.0),
             buttons: read_u32_field(data, "buttons").unwrap_or(0) as u8,
+            dx: read_f32_field(data, "dx").unwrap_or(0.0),
+            dy: read_f32_field(data, "dy").unwrap_or(0.0),
         },
         "mouse_button" => InputMessage::MouseButton {
             x: read_f32_field(data, "x").unwrap_or(0.0),
@@ -159,6 +180,9 @@ pub fn parse_non_init(data: &JsValue) -> Result<Option<InputMessage>> {
         "focus" => InputMessage::Focus(read_bool_field(data, "focused").unwrap_or(false)),
         "visibility" => InputMessage::Visibility(read_bool_field(data, "visible").unwrap_or(false)),
         "start" => InputMessage::Start,
+        "pointer_lock_changed" => {
+            InputMessage::PointerLockChanged(read_bool_field(data, "locked").unwrap_or(false))
+        }
         _ => return Ok(None), // unknown kind; caller decides to warn or ignore
     };
 

--- a/crates/rye-app/src/wasm/mod.rs
+++ b/crates/rye-app/src/wasm/mod.rs
@@ -12,6 +12,7 @@
 //! `rye-time::frame_trace` registers) live at the module root so the
 //! `rye_app::wasm::*` import path stays flat for the common cases.
 
+pub mod host_action;
 pub mod launch;
 pub mod main_launcher;
 pub mod messages;

--- a/crates/rye-app/src/wasm/mod.rs
+++ b/crates/rye-app/src/wasm/mod.rs
@@ -11,6 +11,17 @@
 //! Detection helpers ([`is_worker_context`], plus the heap sampler that
 //! `rye-time::frame_trace` registers) live at the module root so the
 //! `rye_app::wasm::*` import path stays flat for the common cases.
+//!
+//! ## Browser support
+//!
+//! Verified on Chrome and Firefox (desktop). The hard requirements are
+//! WebGPU (`navigator.gpu`), `OffscreenCanvas` + `transferControlToOffscreen`,
+//! and ES-module workers (`new Worker(url, { type: "module" })`). Safari is
+//! UNVERIFIED: WebGPU shipped in Safari 18 but the OffscreenCanvas-in-worker
+//! + module-worker combination this path depends on has not been tested here,
+//! and older Safari lacks WebGPU entirely. Demos that need a Safari fallback
+//! should feature-detect `navigator.gpu` and surface a "WebGPU required"
+//! message rather than spawning the worker into a hard failure.
 
 pub mod host_action;
 pub mod launch;

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -283,7 +283,7 @@ where
     // wgpu's lazy shader compilation (browser WebGPU defers
     // `create_render_pipeline` work until first use) happens BEFORE
     // the user clicks. Without this the user sees a second hitch right
-    // after clicking; with it the click → demo-running transition is
+    // after clicking; with it the click -> demo-running transition is
     // immediate. Safe because the default `rotate` state is false, so
     // warmup frames don't advance any simulation state (rot_time only
     // ticks when self.rotate is true, which it isn't until the user
@@ -292,8 +292,9 @@ where
     // 11 total frames (1 preview + 10 warmup) is empirically enough to
     // cover the first-frame compilation of the polytope_playground
     // pipelines on Chrome and Firefox WebGPU; more is harmless but
-    // lengthens the perceived initialization wait. Reassess if a
-    // heavier demo (M5+ projections with multiple new pipelines) lands.
+    // lengthens the perceived initialization wait. Reassess if a demo
+    // lands that builds several new render pipelines not exercised by
+    // the default scene.
     //
     // Each frame fires a `preview_progress` message so the main
     // thread's static `#rye-page-loader` bar can advance. During the
@@ -711,10 +712,24 @@ where
         }
     }
 
-    /// One frame: drain input queue, dt, App::update, begin_frame,
-    /// App::record, composite, submit, present. Wraps
-    /// `rye_time::frame_trace::scope` so the same telemetry the windowed
-    /// runner emits is available here.
+    /// One frame of the worker's RAF loop. Phases, in order:
+    ///
+    /// 1. **FPS cap** -- drop this callback if it fired before the next
+    ///    deadline (deadline-anchored, see below).
+    /// 2. **Input drain** -- apply every queued `InputMessage` (resize,
+    ///    mouse, key, focus, pointer-lock-state).
+    /// 3. **Fixed-timestep ticks** -- advance the accumulator, run
+    ///    `App::tick` per tick, count them into `FrameCtx::n_ticks`.
+    /// 4. **App::update + App::ui** -- per-frame update with drained input,
+    ///    then the egui pass.
+    /// 5. **Render** -- `begin_frame`, `App::record`, composite, submit,
+    ///    present.
+    /// 6. **End-of-frame host actions** -- drain `cursor::take_pending`,
+    ///    translate to `host_action`s, post the batched message to the
+    ///    main thread; emit the per-frame `preview_progress` during warmup.
+    ///
+    /// Wraps `rye_time::frame_trace::scope` so the same telemetry the
+    /// windowed runner emits is available here.
     fn frame(&mut self) -> Result<()> {
         // FPS cap: drop RAF callbacks that fire before the next ideal
         // deadline (= previous anchor + target period). Anchoring on

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -404,6 +404,18 @@ where
     pixels_per_point: f32,
     start: web_time::Instant,
     last_update_at: Option<web_time::Instant>,
+    /// Previous mousemove position, used to synthesize `mouse_raw_delta`
+    /// on wasm where `DeviceEvent::MouseMotion` doesn't exist. None
+    /// before the first mousemove, then `Some((x, y))` from the last
+    /// `InputMessage::MouseMove` for delta computation.
+    prev_mouse_pos: Option<(f32, f32)>,
+    /// Anchor for the fps cap. Set to the previous frame's IDEAL deadline
+    /// (not its wake-up time), so RAF jitter doesn't compound into
+    /// alternating-skip behavior at the boundary between the target
+    /// period and the display refresh rate. Mirrors the native runner's
+    /// `last_redraw_at` invariant. `None` when uncapped (so the next
+    /// frame's first-cap-tick anchors against `now`).
+    last_redraw_anchor: Option<web_time::Instant>,
     tick_index: u64,
     /// Fixed-timestep accumulator. Matches the windowed runner so demos
     /// that read `FrameCtx::n_ticks` (e.g. `dt_secs = n_ticks / 60.0`)
@@ -481,6 +493,8 @@ where
             pixels_per_point,
             start: web_time::Instant::now(),
             last_update_at: None,
+            prev_mouse_pos: None,
+            last_redraw_anchor: None,
             tick_index: 0,
             timestep: FixedTimestep::new(60),
             max_ticks_per_frame: 4,
@@ -537,6 +551,19 @@ where
                 }
             }
             InputMessage::MouseMove { x, y, .. } => {
+                // Browser has no `DeviceEvent::MouseMotion` equivalent that
+                // the worker can subscribe to without engaging Pointer Lock
+                // (which needs a user gesture the engine doesn't deliver).
+                // So `mouse_raw_delta` is permanently zero on wasm unless
+                // we synthesize it from successive absolute positions.
+                // The deltas are RAF-coalesced (one per browser frame) and
+                // therefore smoother than a real raw-device stream, but
+                // that's enough for FPS mouse-look on a polychoral demo.
+                if let Some((prev_x, prev_y)) = self.prev_mouse_pos {
+                    self.input
+                        .accumulate_raw_motion((x - prev_x) as f64, (y - prev_y) as f64);
+                }
+                self.prev_mouse_pos = Some((x, y));
                 self.input.cursor_moved(x as f64, y as f64);
             }
             InputMessage::MouseButton {
@@ -587,9 +614,11 @@ where
                 if !focused {
                     // Mirror rye-input's focus-loss convention: drop held
                     // buttons + invalidate cursor delta so re-focus doesn't
-                    // snap.
+                    // snap. `prev_mouse_pos` matches the same lifecycle so
+                    // the synthesized raw delta doesn't jump on re-focus.
                     self.input.release_buttons();
                     self.input.cursor_invalidated();
+                    self.prev_mouse_pos = None;
                 }
             }
             InputMessage::Visibility(_) => {
@@ -611,20 +640,43 @@ where
     /// `rye_time::frame_trace::scope` so the same telemetry the windowed
     /// runner emits is available here.
     fn frame(&mut self) -> Result<()> {
-        // FPS cap: if the user has set a target frame period via the
-        // `fps` console command, drop RAF ticks that fired sooner than
-        // that period. The RAF callback re-schedules unconditionally,
-        // so dropping a tick just means the next callback fires and
-        // re-checks. Note this can only lower the rate below the
-        // browser RAF cadence (typically display refresh); raising fps
-        // above that isn't possible without changing the surface
-        // PresentMode, which browsers don't expose anyway.
-        if let Some(target) = crate::frame_pacing::target_period() {
-            if let Some(prev) = self.last_update_at {
-                let elapsed = web_time::Instant::now().duration_since(prev);
-                if elapsed < target {
-                    return Ok(());
+        // FPS cap: drop RAF callbacks that fire before the next ideal
+        // deadline (= previous anchor + target period). Anchoring on
+        // the IDEAL deadline (not the actual wake-up time) absorbs RAF
+        // jitter -- without this, a target that matches the display
+        // refresh rate suffers alternating-skip (callbacks fire ~0.5ms
+        // early due to jitter, get skipped, the next one fires ~3.7ms
+        // later, half-rate). Mirrors the native runner's pattern at
+        // `lib.rs:1297-1311`. Can only lower the rate below the browser
+        // RAF cadence (typically display refresh); raising above that
+        // isn't possible without changing the surface PresentMode,
+        // which browsers don't expose anyway.
+        let now_raf = web_time::Instant::now();
+        match crate::frame_pacing::target_period() {
+            Some(target) => {
+                if let Some(last) = self.last_redraw_anchor {
+                    let deadline = last + target;
+                    if now_raf < deadline {
+                        return Ok(());
+                    }
+                    // Clamp catch-up: if we drifted multiple periods
+                    // behind (tab backgrounded, etc.), don't queue all
+                    // the missed frames at once -- snap forward to at
+                    // most one period behind `now_raf` so pacing
+                    // resumes cleanly when the tab returns to focus.
+                    let catch_up_floor = now_raf.checked_sub(target).unwrap_or(now_raf);
+                    self.last_redraw_anchor = Some(deadline.max(catch_up_floor));
+                } else {
+                    // First frame under an active cap: start the
+                    // schedule from `now` so the first inter-frame
+                    // interval respects the target period.
+                    self.last_redraw_anchor = Some(now_raf);
                 }
+            }
+            None => {
+                // Uncapped: clear the anchor so a later `fps <N>`
+                // command starts a fresh schedule from that moment.
+                self.last_redraw_anchor = None;
             }
         }
 

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -280,14 +280,32 @@ where
     // displayed via the placeholder canvas instead of through a live
     // RAF loop.
     runner.frame().context("preview frame")?;
+    // Pre-Start warmup: render extra frames so wgpu's lazy shader
+    // compilation (browser WebGPU defers `create_render_pipeline` work
+    // until first use) happens BEFORE the user clicks. Without this
+    // the user sees a second hitch right after clicking; with it the
+    // click → demo-running transition is immediate. Safe because the
+    // default `rotate` state is false, so warmup frames don't advance
+    // any simulation state (rot_time only ticks when self.rotate is
+    // true, which it isn't until the user toggles it).
+    //
+    // 10 frames is empirically enough to cover the first-frame
+    // compilation of the polytope_playground pipelines on Chrome and
+    // Firefox WebGPU; more is harmless but lengthens the perceived
+    // initialization wait. Reassess if a heavier demo (M5+ projections
+    // with multiple new pipelines) lands.
+    const WARMUP_FRAMES: usize = 10;
+    for _ in 0..WARMUP_FRAMES {
+        runner.frame().context("warmup frame")?;
+    }
     tracing::info!(
-        "rye_app::wasm::worker: preview frame rendered; awaiting Start to begin RAF loop"
+        "rye_app::wasm::worker: preview + {WARMUP_FRAMES} warmup frames rendered; \
+         awaiting Start to begin RAF loop"
     );
-    // Tell main thread the preview frame is on the canvas so it can
-    // promote the launch overlay from its "Initializing…" warmup state
-    // to "Click to launch". Posting before the RAF kickoff lets the
-    // main thread reveal the click affordance the instant the blurred
-    // backdrop has something behind it to blur.
+    // Tell main thread the worker is fully ready: preview frame is on
+    // the canvas AND pipelines are warmed. Main thread promotes the
+    // launch overlay to `.ready` so the click affordance becomes
+    // visible; click then triggers an instant Start (no loading state).
     {
         let msg = js_sys::Object::new();
         let _ = js_sys::Reflect::set(
@@ -420,16 +438,6 @@ where
     pixels_per_point: f32,
     start: web_time::Instant,
     last_update_at: Option<web_time::Instant>,
-    /// Number of frames the worker has rendered post-Start. Used to
-    /// trigger the one-shot `demo_ready` notification to the main
-    /// thread after the warm-up cycle completes (pipelines compiled,
-    /// first sim ticks settled). The main thread leaves the launch
-    /// overlay visible-but-loading until this fires so the user's
-    /// initial click-spam doesn't compound the startup hitch.
-    frames_since_start: u32,
-    /// Has `demo_ready` already been posted? One-shot guard so the
-    /// notification doesn't fire repeatedly each frame.
-    demo_ready_sent: bool,
     /// Anchor for the fps cap. Set to the previous frame's IDEAL deadline
     /// (not its wake-up time), so RAF jitter doesn't compound into
     /// alternating-skip behavior at the boundary between the target
@@ -514,8 +522,6 @@ where
             pixels_per_point,
             start: web_time::Instant::now(),
             last_update_at: None,
-            frames_since_start: 0,
-            demo_ready_sent: false,
             last_redraw_anchor: None,
             tick_index: 0,
             timestep: FixedTimestep::new(60),
@@ -871,29 +877,6 @@ where
         if let Ok(scope) = worker_scope() {
             if let Err(e) = super::host_action::post_pending_actions(&scope) {
                 tracing::warn!("rye_app::wasm::worker: post host_action failed: {e:#}");
-            }
-            // After warm-up, signal the main thread once so it can
-            // remove the launch overlay's loading state. 10 frames is
-            // empirically enough to cover the first pass of wgpu
-            // pipeline compilation on Chrome/Firefox WebGPU and the
-            // first sim ticks landing. Posting more than once would be
-            // harmless (the main thread short-circuits on the same
-            // listener) but we guard with `demo_ready_sent` anyway
-            // because each post is a JS object allocation.
-            const DEMO_READY_FRAMES: u32 = 10;
-            self.frames_since_start = self.frames_since_start.saturating_add(1);
-            if !self.demo_ready_sent && self.frames_since_start >= DEMO_READY_FRAMES {
-                let msg = js_sys::Object::new();
-                let _ = js_sys::Reflect::set(
-                    &msg,
-                    &JsValue::from_str("kind"),
-                    &JsValue::from_str("demo_ready"),
-                );
-                if let Err(e) = scope.post_message(&msg) {
-                    tracing::warn!("rye_app::wasm::worker: post demo_ready failed: {e:?}");
-                } else {
-                    self.demo_ready_sent = true;
-                }
             }
         }
 

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -533,15 +533,24 @@ where
         match msg {
             InputMessage::Resize { width, height } => {
                 self.resize(width, height);
-                // Render one frame at the new size so the preview
-                // refreshes (no CSS-stretched display). When the RAF
-                // loop is already running this is just one extra frame
-                // before the next RAF tick; harmless. When we're in
-                // pre-Start preview mode, this is the only frame that
-                // happens, and it's what the launch overlay's
-                // backdrop-filter blurs.
-                if let Err(e) = self.frame() {
-                    tracing::error!("rye_app::wasm::worker: post-resize frame failed: {e:#}");
+                // Render one frame at the new size ONLY when we're in
+                // pre-Start preview mode. After Start kicks the RAF
+                // loop, the next RAF tick naturally renders at the
+                // new size. The recursive frame() call was crashing
+                // the demo on rapid resize because each Resize event
+                // re-enters the frame loop, which drains MORE Resize
+                // events from the queue, each triggering another
+                // frame(); under sustained drag the recursion either
+                // overflows wgpu's command queue or trips a
+                // surface-reconfigure race. Pre-Start there's no RAF
+                // loop yet, so we have to render once to refresh the
+                // backdrop-blur thumbnail.
+                if self.last_update_at.is_none() {
+                    if let Err(e) = self.frame() {
+                        tracing::error!(
+                            "rye_app::wasm::worker: pre-Start resize frame failed: {e:#}"
+                        );
+                    }
                 }
             }
             InputMessage::MouseMove { x, y, dx, dy, .. } => {

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -594,6 +594,23 @@ where
     /// `rye_time::frame_trace::scope` so the same telemetry the windowed
     /// runner emits is available here.
     fn frame(&mut self) -> Result<()> {
+        // FPS cap: if the user has set a target frame period via the
+        // `fps` console command, drop RAF ticks that fired sooner than
+        // that period. The RAF callback re-schedules unconditionally,
+        // so dropping a tick just means the next callback fires and
+        // re-checks. Note this can only lower the rate below the
+        // browser RAF cadence (typically display refresh); raising fps
+        // above that isn't possible without changing the surface
+        // PresentMode, which browsers don't expose anyway.
+        if let Some(target) = crate::frame_pacing::target_period() {
+            if let Some(prev) = self.last_update_at {
+                let elapsed = web_time::Instant::now().duration_since(prev);
+                if elapsed < target {
+                    return Ok(());
+                }
+            }
+        }
+
         rye_time::frame_trace::begin_frame();
         let _frame_scope = rye_time::frame_trace::scope("frame");
 

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -404,11 +404,6 @@ where
     pixels_per_point: f32,
     start: web_time::Instant,
     last_update_at: Option<web_time::Instant>,
-    /// Previous mousemove position, used to synthesize `mouse_raw_delta`
-    /// on wasm where `DeviceEvent::MouseMotion` doesn't exist. None
-    /// before the first mousemove, then `Some((x, y))` from the last
-    /// `InputMessage::MouseMove` for delta computation.
-    prev_mouse_pos: Option<(f32, f32)>,
     /// Anchor for the fps cap. Set to the previous frame's IDEAL deadline
     /// (not its wake-up time), so RAF jitter doesn't compound into
     /// alternating-skip behavior at the boundary between the target
@@ -493,7 +488,6 @@ where
             pixels_per_point,
             start: web_time::Instant::now(),
             last_update_at: None,
-            prev_mouse_pos: None,
             last_redraw_anchor: None,
             tick_index: 0,
             timestep: FixedTimestep::new(60),
@@ -550,20 +544,15 @@ where
                     tracing::error!("rye_app::wasm::worker: post-resize frame failed: {e:#}");
                 }
             }
-            InputMessage::MouseMove { x, y, .. } => {
-                // Browser has no `DeviceEvent::MouseMotion` equivalent that
-                // the worker can subscribe to without engaging Pointer Lock
-                // (which needs a user gesture the engine doesn't deliver).
-                // So `mouse_raw_delta` is permanently zero on wasm unless
-                // we synthesize it from successive absolute positions.
-                // The deltas are RAF-coalesced (one per browser frame) and
-                // therefore smoother than a real raw-device stream, but
-                // that's enough for FPS mouse-look on a polychoral demo.
-                if let Some((prev_x, prev_y)) = self.prev_mouse_pos {
-                    self.input
-                        .accumulate_raw_motion((x - prev_x) as f64, (y - prev_y) as f64);
-                }
-                self.prev_mouse_pos = Some((x, y));
+            InputMessage::MouseMove { x, y, dx, dy, .. } => {
+                // `dx`/`dy` are `MouseEvent.movementX/Y` summed across any
+                // RAF-coalesced intermediate events. This is the correct
+                // raw-motion source whether Pointer Lock is engaged (where
+                // `offsetX/Y` is pinned to the locked center and absolute-
+                // position diffing would always read zero) or not. Browser
+                // movementX/Y has been universal since ~2013, so we don't
+                // bother with a fallback path.
+                self.input.accumulate_raw_motion(dx as f64, dy as f64);
                 self.input.cursor_moved(x as f64, y as f64);
             }
             InputMessage::MouseButton {
@@ -614,11 +603,9 @@ where
                 if !focused {
                     // Mirror rye-input's focus-loss convention: drop held
                     // buttons + invalidate cursor delta so re-focus doesn't
-                    // snap. `prev_mouse_pos` matches the same lifecycle so
-                    // the synthesized raw delta doesn't jump on re-focus.
+                    // snap.
                     self.input.release_buttons();
                     self.input.cursor_invalidated();
-                    self.prev_mouse_pos = None;
                 }
             }
             InputMessage::Visibility(_) => {
@@ -631,6 +618,27 @@ where
                 // the RAF loop starts; the per-frame queue only drains
                 // inside that loop, so routing through it would
                 // deadlock.
+            }
+            InputMessage::PointerLockChanged(locked) => {
+                // The main thread's `pointerlockchange` listener tells us
+                // when the browser actually engaged/released the lock
+                // (user pressed Esc, switched tabs, our request was
+                // denied for lack of activation, etc.). Mirror the truth
+                // into the cursor module so `current_state()` reads what
+                // the browser actually has. Demos can observe a release
+                // they didn't request and switch back to a "click to
+                // re-engage" prompt (the main thread also wires a
+                // canvas-click handler to re-request the lock when our
+                // last-requested state was Locked but the browser dropped
+                // it; this update is the worker-side signal it succeeded).
+                let grab = if locked {
+                    crate::cursor::GrabMode::Locked
+                } else {
+                    crate::cursor::GrabMode::None
+                };
+                // Visibility on wasm is implied by lock state: Pointer
+                // Lock auto-hides; release auto-shows.
+                crate::cursor::mark_applied(grab, !locked);
             }
         }
     }
@@ -798,6 +806,35 @@ where
             let _scope = rye_time::frame_trace::scope("present");
             self.rd.queue.submit(Some(encoder.finish()));
             frame.present();
+        }
+
+        // Drain pending cursor / DOM-action requests produced during this
+        // frame (`freecam.set_active` calls `cursor::request_grab`, etc.)
+        // and post them to the main thread as one batched `host_action`
+        // message. Doing it after `present()` keeps the GPU submission
+        // critical path free of postMessage latency and matches the
+        // native runner's pattern (which applies cursor changes at the
+        // end of redraw, after the surface present).
+        let (pending_grab, _pending_visible) = crate::cursor::take_pending();
+        if let Some(grab) = pending_grab {
+            let action = match grab {
+                crate::cursor::GrabMode::Locked | crate::cursor::GrabMode::Confined => {
+                    super::host_action::HostAction::PointerLockRequest
+                }
+                crate::cursor::GrabMode::None => super::host_action::HostAction::PointerLockRelease,
+            };
+            super::host_action::queue(action);
+        }
+        // `take_pending_warp_center` is drained to clear the flag even
+        // though warp-to-center is a no-op on wasm (browsers don't
+        // expose a cursor-position write). Without the drain the flag
+        // would stick and a later native build (or different wasm
+        // implementation) would observe it.
+        let _ = crate::cursor::take_pending_warp_center();
+        if let Ok(scope) = worker_scope() {
+            if let Err(e) = super::host_action::post_pending_actions(&scope) {
+                tracing::warn!("rye_app::wasm::worker: post host_action failed: {e:#}");
+            }
         }
 
         rye_time::frame_trace::end_frame();

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -279,24 +279,49 @@ where
     // would render on the very first RAF tick if it had started, just
     // displayed via the placeholder canvas instead of through a live
     // RAF loop.
-    runner.frame().context("preview frame")?;
-    // Pre-Start warmup: render extra frames so wgpu's lazy shader
-    // compilation (browser WebGPU defers `create_render_pipeline` work
-    // until first use) happens BEFORE the user clicks. Without this
-    // the user sees a second hitch right after clicking; with it the
-    // click → demo-running transition is immediate. Safe because the
-    // default `rotate` state is false, so warmup frames don't advance
-    // any simulation state (rot_time only ticks when self.rotate is
-    // true, which it isn't until the user toggles it).
+    // Pre-Start warmup: render the preview frame plus extra frames so
+    // wgpu's lazy shader compilation (browser WebGPU defers
+    // `create_render_pipeline` work until first use) happens BEFORE
+    // the user clicks. Without this the user sees a second hitch right
+    // after clicking; with it the click → demo-running transition is
+    // immediate. Safe because the default `rotate` state is false, so
+    // warmup frames don't advance any simulation state (rot_time only
+    // ticks when self.rotate is true, which it isn't until the user
+    // toggles it).
     //
-    // 10 frames is empirically enough to cover the first-frame
-    // compilation of the polytope_playground pipelines on Chrome and
-    // Firefox WebGPU; more is harmless but lengthens the perceived
-    // initialization wait. Reassess if a heavier demo (M5+ projections
-    // with multiple new pipelines) lands.
+    // 11 total frames (1 preview + 10 warmup) is empirically enough to
+    // cover the first-frame compilation of the polytope_playground
+    // pipelines on Chrome and Firefox WebGPU; more is harmless but
+    // lengthens the perceived initialization wait. Reassess if a
+    // heavier demo (M5+ projections with multiple new pipelines) lands.
+    //
+    // Each frame fires a `preview_progress` message so the main
+    // thread's static `#rye-page-loader` bar can advance. During the
+    // first frame (when pipeline compilation actually happens) the GPU
+    // process is blocked and the bar can't visually update -- but the
+    // discrete progress steps before and after the freeze frame the
+    // wait so it doesn't read as a hang.
     const WARMUP_FRAMES: usize = 10;
-    for _ in 0..WARMUP_FRAMES {
+    const TOTAL_FRAMES: usize = 1 + WARMUP_FRAMES;
+    let post_progress = |step: usize| {
+        let msg = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("kind"),
+            &JsValue::from_str("preview_progress"),
+        );
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("pct"),
+            &JsValue::from_f64(step as f64 / TOTAL_FRAMES as f64),
+        );
+        let _ = scope.post_message(&msg);
+    };
+    runner.frame().context("preview frame")?;
+    post_progress(1);
+    for i in 0..WARMUP_FRAMES {
         runner.frame().context("warmup frame")?;
+        post_progress(2 + i);
     }
     tracing::info!(
         "rye_app::wasm::worker: preview + {WARMUP_FRAMES} warmup frames rendered; \

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -563,8 +563,25 @@ where
                         ElementState::Released
                     };
                     self.input.key_input(PhysicalKey::Code(code), state);
+                    // Route to `App::on_key` so hotkeys (spin toggle, R, T,
+                    // digit plane toggles, etc.) work the same on wasm as on
+                    // native. The framework can't dispatch to `App::on_event`
+                    // here because winit's `KeyEvent` has a `pub(crate)`
+                    // field we can't construct from outside the crate.
+                    let ui_has_focus = self.ui.wants_input;
+                    let mut fctx = FrameCtx {
+                        rd: &self.rd,
+                        input: rye_input::FrameInput::default(),
+                        time: self.start.elapsed().as_secs_f32(),
+                        fps: 0.0,
+                        n_ticks: 0,
+                        tick: self.tick_index,
+                        dt: 0.0,
+                        ui_has_focus,
+                        _non_exhaustive: PhantomData,
+                    };
+                    self.app.on_key(code, state, &mut fctx);
                 }
-                // Hotkey routing via App::on_event deferred (see fn doc).
             }
             InputMessage::Focus(focused) => {
                 if !focused {

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -35,11 +35,12 @@ use web_sys::{DedicatedWorkerGlobalScope, MessageEvent, OffscreenCanvas};
 
 use super::messages::{self, InputMessage};
 use super::worker_ui::WorkerUi;
-use crate::{App, FrameCtx, RenderCtx, SetupCtx};
+use crate::{App, FrameCtx, RenderCtx, SetupCtx, TickCtx};
 use rye_asset::AssetWatcher;
 use rye_input::InputState;
 use rye_render::device::RenderDevice;
 use rye_shader::ShaderDb;
+use rye_time::FixedTimestep;
 use winit::event::{ElementState, MouseScrollDelta};
 use winit::keyboard::PhysicalKey;
 
@@ -404,6 +405,18 @@ where
     start: web_time::Instant,
     last_update_at: Option<web_time::Instant>,
     tick_index: u64,
+    /// Fixed-timestep accumulator. Matches the windowed runner so demos
+    /// that read `FrameCtx::n_ticks` (e.g. `dt_secs = n_ticks / 60.0`)
+    /// see ticks fire on the same cadence in browser as on native.
+    /// Hardcoded to 60Hz to match `RunConfig::default()`; if any demo
+    /// ever wants a different rate, RunConfig will need to be wired
+    /// through to the worker (currently set up via postMessage with no
+    /// config payload).
+    timestep: FixedTimestep,
+    /// Mirror of the windowed runner's `max_ticks_per_frame` cap, kept
+    /// at the windowed default (4) so a slow-rendering frame doesn't
+    /// catch up by running 60 ticks in a row and spiraling further.
+    max_ticks_per_frame: usize,
     _marker: PhantomData<A::Space>,
 }
 
@@ -469,6 +482,8 @@ where
             start: web_time::Instant::now(),
             last_update_at: None,
             tick_index: 0,
+            timestep: FixedTimestep::new(60),
+            max_ticks_per_frame: 4,
             _marker: PhantomData,
         })
     }
@@ -597,7 +612,27 @@ where
             None => 1.0 / 60.0,
         };
         self.last_update_at = Some(now);
-        self.tick_index = self.tick_index.wrapping_add(1);
+
+        // Fixed-timestep ticks. Mirrors the windowed runner's structure
+        // so demos that read `FrameCtx::n_ticks` (or compute `dt_secs =
+        // n_ticks / 60.0` to integrate spin / freecam translation /
+        // similar) behave the same in browser as on native.
+        let n_capped;
+        {
+            let _scope = rye_time::frame_trace::scope("sim-ticks");
+            let ticks = self.timestep.advance(now);
+            let n_ticks = ticks.count();
+            n_capped = n_ticks.min(self.max_ticks_per_frame);
+            let tick_dt = 1.0 / 60.0;
+            for _ in 0..n_capped {
+                let mut tctx = TickCtx {
+                    time: self.start.elapsed().as_secs_f32(),
+                    tick: self.tick_index,
+                };
+                self.app.tick(tick_dt, &mut tctx);
+                self.tick_index = self.tick_index.wrapping_add(1);
+            }
+        }
 
         // App::update with the FrameInput accumulated from this frame's
         // InputMessage events. `take_frame` returns the drained snapshot
@@ -611,7 +646,7 @@ where
                 input,
                 time: self.start.elapsed().as_secs_f32(),
                 fps: 0.0, // worker-side FPS bookkeeping not yet wired; reads as 0.0.
-                n_ticks: 0,
+                n_ticks: n_capped,
                 tick: self.tick_index,
                 dt,
                 ui_has_focus,

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -283,6 +283,22 @@ where
     tracing::info!(
         "rye_app::wasm::worker: preview frame rendered; awaiting Start to begin RAF loop"
     );
+    // Tell main thread the preview frame is on the canvas so it can
+    // promote the launch overlay from its "Initializing…" warmup state
+    // to "Click to launch". Posting before the RAF kickoff lets the
+    // main thread reveal the click affordance the instant the blurred
+    // backdrop has something behind it to blur.
+    {
+        let msg = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(
+            &msg,
+            &JsValue::from_str("kind"),
+            &JsValue::from_str("preview_ready"),
+        );
+        if let Err(e) = scope.post_message(&msg) {
+            tracing::warn!("rye_app::wasm::worker: post preview_ready failed: {e:?}");
+        }
+    }
 
     // Self-referential RAF closure. Captures the runner via Rc<RefCell>
     // and re-schedules itself each frame. Standard wasm-bindgen pattern.

--- a/crates/rye-app/src/wasm/worker.rs
+++ b/crates/rye-app/src/wasm/worker.rs
@@ -404,6 +404,16 @@ where
     pixels_per_point: f32,
     start: web_time::Instant,
     last_update_at: Option<web_time::Instant>,
+    /// Number of frames the worker has rendered post-Start. Used to
+    /// trigger the one-shot `demo_ready` notification to the main
+    /// thread after the warm-up cycle completes (pipelines compiled,
+    /// first sim ticks settled). The main thread leaves the launch
+    /// overlay visible-but-loading until this fires so the user's
+    /// initial click-spam doesn't compound the startup hitch.
+    frames_since_start: u32,
+    /// Has `demo_ready` already been posted? One-shot guard so the
+    /// notification doesn't fire repeatedly each frame.
+    demo_ready_sent: bool,
     /// Anchor for the fps cap. Set to the previous frame's IDEAL deadline
     /// (not its wake-up time), so RAF jitter doesn't compound into
     /// alternating-skip behavior at the boundary between the target
@@ -488,6 +498,8 @@ where
             pixels_per_point,
             start: web_time::Instant::now(),
             last_update_at: None,
+            frames_since_start: 0,
+            demo_ready_sent: false,
             last_redraw_anchor: None,
             tick_index: 0,
             timestep: FixedTimestep::new(60),
@@ -843,6 +855,29 @@ where
         if let Ok(scope) = worker_scope() {
             if let Err(e) = super::host_action::post_pending_actions(&scope) {
                 tracing::warn!("rye_app::wasm::worker: post host_action failed: {e:#}");
+            }
+            // After warm-up, signal the main thread once so it can
+            // remove the launch overlay's loading state. 10 frames is
+            // empirically enough to cover the first pass of wgpu
+            // pipeline compilation on Chrome/Firefox WebGPU and the
+            // first sim ticks landing. Posting more than once would be
+            // harmless (the main thread short-circuits on the same
+            // listener) but we guard with `demo_ready_sent` anyway
+            // because each post is a JS object allocation.
+            const DEMO_READY_FRAMES: u32 = 10;
+            self.frames_since_start = self.frames_since_start.saturating_add(1);
+            if !self.demo_ready_sent && self.frames_since_start >= DEMO_READY_FRAMES {
+                let msg = js_sys::Object::new();
+                let _ = js_sys::Reflect::set(
+                    &msg,
+                    &JsValue::from_str("kind"),
+                    &JsValue::from_str("demo_ready"),
+                );
+                if let Err(e) = scope.post_message(&msg) {
+                    tracing::warn!("rye_app::wasm::worker: post demo_ready failed: {e:?}");
+                } else {
+                    self.demo_ready_sent = true;
+                }
             }
         }
 

--- a/crates/rye-app/src/wasm/worker_ui.rs
+++ b/crates/rye-app/src/wasm/worker_ui.rs
@@ -160,8 +160,13 @@ impl WorkerUi {
             }
             // Non-egui-relevant variants: Resize is handled by the
             // runner; Visibility hasn't been wired up; Start fires
-            // outside the frame loop entirely (handled in handle_message).
-            InputMessage::Resize { .. } | InputMessage::Visibility(_) | InputMessage::Start => {}
+            // outside the frame loop entirely (handled in handle_message);
+            // PointerLockChanged is consumed by the worker's cursor state
+            // mirror, not egui.
+            InputMessage::Resize { .. }
+            | InputMessage::Visibility(_)
+            | InputMessage::Start
+            | InputMessage::PointerLockChanged(_) => {}
         }
     }
 

--- a/crates/rye-app/static/page_loader.html
+++ b/crates/rye-app/static/page_loader.html
@@ -15,16 +15,16 @@
      `#rye-launch` overlay takes over the visual layer with the
      click-to-start affordance. -->
 <style>
-    /* Force this element onto its own compositor layer via `translateZ(0)`
-       (the classic "null 3D transform" trick) AND `contain: strict` to
-       isolate it from layout / paint / style invalidations elsewhere in
-       the document. Without this, browsers may compose the spinner on
-       the same layer as `#rye-canvas-host`, which churns whenever the
-       canvas is touched or the launch overlay is injected -- visible as
-       the spinner stuttering or freezing during heavy main-thread work
-       (wasm init, worker spawn, OffscreenCanvas transfer). With the
-       layer pinned, the `transform: rotate` keyframe animation runs on
-       the compositor thread regardless of main-thread load. */
+    /* Layer promotion lives on the PARENT (`translateZ(0)` + `contain:
+       layout paint` to isolate it from layout/paint invalidations
+       elsewhere in the document, without the `size` containment that
+       `contain: strict` includes -- size containment collapses an
+       inset:0 element to 0x0). The spinner `::before` inherits the
+       compositor layer from the parent. Putting layer-promotion
+       transforms on the spinner itself collides with the rotation
+       animation's transform (CSS can't interpolate cleanly across
+       transform function-list mismatches between the static value and
+       the keyframe), which is what froze the animation. */
     #rye-page-loader {
         position: fixed;
         inset: 0;
@@ -34,7 +34,7 @@
         background: #0e0e12;
         z-index: 1;
         transform: translateZ(0);
-        contain: strict;
+        contain: layout paint;
         pointer-events: none;
     }
     #rye-page-loader::before {
@@ -46,11 +46,10 @@
         border-top-color: rgba(230, 230, 245, 0.95);
         border-radius: 50%;
         animation: rye-page-loader-spin 0.9s linear infinite;
-        will-change: transform;
-        transform: translateZ(0);
     }
     @keyframes rye-page-loader-spin {
-        to { transform: rotate(360deg) translateZ(0); }
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
     }
 </style>
 <div id="rye-page-loader"></div>

--- a/crates/rye-app/static/page_loader.html
+++ b/crates/rye-app/static/page_loader.html
@@ -15,14 +15,27 @@
      `#rye-launch` overlay takes over the visual layer with the
      click-to-start affordance. -->
 <style>
+    /* Force this element onto its own compositor layer via `translateZ(0)`
+       (the classic "null 3D transform" trick) AND `contain: strict` to
+       isolate it from layout / paint / style invalidations elsewhere in
+       the document. Without this, browsers may compose the spinner on
+       the same layer as `#rye-canvas-host`, which churns whenever the
+       canvas is touched or the launch overlay is injected -- visible as
+       the spinner stuttering or freezing during heavy main-thread work
+       (wasm init, worker spawn, OffscreenCanvas transfer). With the
+       layer pinned, the `transform: rotate` keyframe animation runs on
+       the compositor thread regardless of main-thread load. */
     #rye-page-loader {
-        position: absolute;
+        position: fixed;
         inset: 0;
         display: flex;
         align-items: center;
         justify-content: center;
         background: #0e0e12;
         z-index: 1;
+        transform: translateZ(0);
+        contain: strict;
+        pointer-events: none;
     }
     #rye-page-loader::before {
         content: '';
@@ -34,9 +47,10 @@
         border-radius: 50%;
         animation: rye-page-loader-spin 0.9s linear infinite;
         will-change: transform;
+        transform: translateZ(0);
     }
     @keyframes rye-page-loader-spin {
-        to { transform: rotate(360deg); }
+        to { transform: rotate(360deg) translateZ(0); }
     }
 </style>
 <div id="rye-page-loader"></div>

--- a/crates/rye-app/static/page_loader.html
+++ b/crates/rye-app/static/page_loader.html
@@ -15,6 +15,17 @@
      `#rye-launch` overlay takes over the visual layer with the
      click-to-start affordance. -->
 <style>
+    /* Why a progress bar instead of a spinner: WebGPU pipeline
+       compilation happens in the browser's GPU process, which is
+       shared with the compositor. While shaders compile, the GPU
+       process is blocked and EVERY animation on the page stalls --
+       CSS, SVG SMIL, even animated GIFs all freeze because they
+       depend on the compositor producing frames. A progress bar
+       sidesteps this: it doesn't pretend to animate smoothly, it
+       jumps to discrete positions as the worker emits
+       `preview_progress` messages. The gaps between jumps tell the
+       viewer "compilation in progress" without the false-confidence
+       of a frozen spinner. */
     #rye-page-loader {
         position: fixed;
         inset: 0;
@@ -25,39 +36,23 @@
         z-index: 1;
         pointer-events: none;
     }
+    #rye-page-loader .rye-progress-track {
+        width: 240px;
+        height: 4px;
+        background: rgba(200, 200, 220, 0.15);
+        border-radius: 2px;
+        overflow: hidden;
+    }
+    #rye-page-loader .rye-progress-fill {
+        height: 100%;
+        background: rgba(230, 230, 245, 0.9);
+        border-radius: 2px;
+        width: 0%;
+        transition: width 200ms ease-out;
+    }
 </style>
-<!-- SVG SMIL animation rather than CSS keyframes: SMIL runs on the
-     browser's SVG timing engine, which keeps ticking even when CSS
-     animations stall on heavy main-thread work (wasm download +
-     compile + worker spawn + OffscreenCanvas transfer all happen in
-     the gap before `preview_ready`, and CSS animations on `transform`
-     are NOT guaranteed to run on the compositor thread in every
-     browser configuration -- `will-change` and `translateZ` are hints
-     the browser may ignore). SMIL is widely supported across modern
-     browsers and is the most reliable "keep spinning regardless"
-     primitive. -->
 <div id="rye-page-loader">
-    <svg width="56" height="56" viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg">
-        <!-- Faint track ring (always visible, no animation). -->
-        <circle cx="28" cy="28" r="22"
-                fill="none"
-                stroke="rgba(200, 200, 220, 0.2)"
-                stroke-width="5" />
-        <!-- Animated arc: a 90deg slice (~half the circumference of the
-             full ring, then most is dashed off so only ~35 units of
-             arc length show). The whole arc spins via animateTransform. -->
-        <circle cx="28" cy="28" r="22"
-                fill="none"
-                stroke="rgba(230, 230, 245, 0.95)"
-                stroke-width="5"
-                stroke-linecap="round"
-                stroke-dasharray="35 200">
-            <animateTransform attributeName="transform"
-                              type="rotate"
-                              from="0 28 28"
-                              to="360 28 28"
-                              dur="0.9s"
-                              repeatCount="indefinite" />
-        </circle>
-    </svg>
+    <div class="rye-progress-track">
+        <div class="rye-progress-fill" id="rye-page-loader-fill"></div>
+    </div>
 </div>

--- a/crates/rye-app/static/page_loader.html
+++ b/crates/rye-app/static/page_loader.html
@@ -15,16 +15,6 @@
      `#rye-launch` overlay takes over the visual layer with the
      click-to-start affordance. -->
 <style>
-    /* Layer promotion lives on the PARENT (`translateZ(0)` + `contain:
-       layout paint` to isolate it from layout/paint invalidations
-       elsewhere in the document, without the `size` containment that
-       `contain: strict` includes -- size containment collapses an
-       inset:0 element to 0x0). The spinner `::before` inherits the
-       compositor layer from the parent. Putting layer-promotion
-       transforms on the spinner itself collides with the rotation
-       animation's transform (CSS can't interpolate cleanly across
-       transform function-list mismatches between the static value and
-       the keyframe), which is what froze the animation. */
     #rye-page-loader {
         position: fixed;
         inset: 0;
@@ -33,23 +23,41 @@
         justify-content: center;
         background: #0e0e12;
         z-index: 1;
-        transform: translateZ(0);
-        contain: layout paint;
         pointer-events: none;
     }
-    #rye-page-loader::before {
-        content: '';
-        display: inline-block;
-        width: 56px;
-        height: 56px;
-        border: 5px solid rgba(200, 200, 220, 0.2);
-        border-top-color: rgba(230, 230, 245, 0.95);
-        border-radius: 50%;
-        animation: rye-page-loader-spin 0.9s linear infinite;
-    }
-    @keyframes rye-page-loader-spin {
-        from { transform: rotate(0deg); }
-        to { transform: rotate(360deg); }
-    }
 </style>
-<div id="rye-page-loader"></div>
+<!-- SVG SMIL animation rather than CSS keyframes: SMIL runs on the
+     browser's SVG timing engine, which keeps ticking even when CSS
+     animations stall on heavy main-thread work (wasm download +
+     compile + worker spawn + OffscreenCanvas transfer all happen in
+     the gap before `preview_ready`, and CSS animations on `transform`
+     are NOT guaranteed to run on the compositor thread in every
+     browser configuration -- `will-change` and `translateZ` are hints
+     the browser may ignore). SMIL is widely supported across modern
+     browsers and is the most reliable "keep spinning regardless"
+     primitive. -->
+<div id="rye-page-loader">
+    <svg width="56" height="56" viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg">
+        <!-- Faint track ring (always visible, no animation). -->
+        <circle cx="28" cy="28" r="22"
+                fill="none"
+                stroke="rgba(200, 200, 220, 0.2)"
+                stroke-width="5" />
+        <!-- Animated arc: a 90deg slice (~half the circumference of the
+             full ring, then most is dashed off so only ~35 units of
+             arc length show). The whole arc spins via animateTransform. -->
+        <circle cx="28" cy="28" r="22"
+                fill="none"
+                stroke="rgba(230, 230, 245, 0.95)"
+                stroke-width="5"
+                stroke-linecap="round"
+                stroke-dasharray="35 200">
+            <animateTransform attributeName="transform"
+                              type="rotate"
+                              from="0 28 28"
+                              to="360 28 28"
+                              dur="0.9s"
+                              repeatCount="indefinite" />
+        </circle>
+    </svg>
+</div>

--- a/crates/rye-app/static/page_loader.html
+++ b/crates/rye-app/static/page_loader.html
@@ -1,0 +1,42 @@
+<!-- Static page-load spinner. Engine-owned, inlined by demos via:
+       <link data-trunk rel="inline" href="../rye-app/static/page_loader.html" />
+     placed inside the `#rye-canvas-host` div.
+
+     Renders on first paint (before the wasm bundle has finished
+     downloading and `inject_launch_overlay` runs), so the user sees
+     "something's happening" immediately on page load instead of a
+     blank canvas. The CSS-only `transform` animation runs on the
+     compositor thread so the rotation stays smooth even while the
+     main thread is busy compiling shaders or running wasm-init work.
+
+     Removed by the wasm runtime (`install_preview_ready_handler` in
+     `rye_app::wasm::main_launcher`) when the worker posts
+     `preview_ready`, at which point the engine-injected
+     `#rye-launch` overlay takes over the visual layer with the
+     click-to-start affordance. -->
+<style>
+    #rye-page-loader {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0e0e12;
+        z-index: 1;
+    }
+    #rye-page-loader::before {
+        content: '';
+        display: inline-block;
+        width: 56px;
+        height: 56px;
+        border: 5px solid rgba(200, 200, 220, 0.2);
+        border-top-color: rgba(230, 230, 245, 0.95);
+        border-radius: 50%;
+        animation: rye-page-loader-spin 0.9s linear infinite;
+        will-change: transform;
+    }
+    @keyframes rye-page-loader-spin {
+        to { transform: rotate(360deg); }
+    }
+</style>
+<div id="rye-page-loader"></div>

--- a/crates/rye-app/static/page_loader.html
+++ b/crates/rye-app/static/page_loader.html
@@ -1,19 +1,25 @@
-<!-- Static page-load spinner. Engine-owned, inlined by demos via:
+<!-- Static page-load progress bar. Engine-owned, inlined by demos via:
        <link data-trunk rel="inline" href="../rye-app/static/page_loader.html" />
      placed inside the `#rye-canvas-host` div.
 
      Renders on first paint (before the wasm bundle has finished
      downloading and `inject_launch_overlay` runs), so the user sees
      "something's happening" immediately on page load instead of a
-     blank canvas. The CSS-only `transform` animation runs on the
-     compositor thread so the rotation stays smooth even while the
-     main thread is busy compiling shaders or running wasm-init work.
+     blank canvas. The bar advances in discrete steps as the worker
+     emits `preview_progress` messages (see the CSS comment below for
+     why a bar, not a spinner).
 
      Removed by the wasm runtime (`install_preview_ready_handler` in
      `rye_app::wasm::main_launcher`) when the worker posts
      `preview_ready`, at which point the engine-injected
      `#rye-launch` overlay takes over the visual layer with the
-     click-to-start affordance. -->
+     click-to-start affordance.
+
+     The progress track carries `role="progressbar"` + aria-value*;
+     `install_preview_progress_handler` updates `aria-valuenow`
+     alongside the fill width so a screen reader announces the
+     loading percentage rather than silence during the multi-second
+     warmup. -->
 <style>
     /* Why a progress bar instead of a spinner: WebGPU pipeline
        compilation happens in the browser's GPU process, which is
@@ -50,9 +56,17 @@
         width: 0%;
         transition: width 200ms ease-out;
     }
+    /* The fill's width tween is the only motion here. Honor a
+       reduced-motion preference by snapping to each step instead. */
+    @media (prefers-reduced-motion: reduce) {
+        #rye-page-loader .rye-progress-fill {
+            transition: none;
+        }
+    }
 </style>
-<div id="rye-page-loader">
-    <div class="rye-progress-track">
+<div id="rye-page-loader" aria-busy="true">
+    <div class="rye-progress-track" role="progressbar" aria-label="Loading demo"
+         aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
         <div class="rye-progress-fill" id="rye-page-loader-fill"></div>
     </div>
 </div>

--- a/crates/rye-render/src/gpu_timer.rs
+++ b/crates/rye-render/src/gpu_timer.rs
@@ -283,7 +283,21 @@ impl GpuTimer {
                     let end_ticks = u64::from_le_bytes(end_bytes);
                     let delta_ticks = end_ticks.saturating_sub(start_ticks);
                     let delta_ns = (delta_ticks as f64 * period_ns as f64) as u64;
-                    let _ = tx.send(Duration::from_nanos(delta_ns));
+                    // Reject implausible deltas. At display refresh rates above
+                    // ~120 Hz the triple-buffer cycle can race on some drivers
+                    // (Vulkan validation reports the writes are correctly
+                    // ordered but the resolved values appear to pair a start
+                    // tick from one cycle with an end tick several cycles
+                    // later, yielding deltas that grow linearly with elapsed
+                    // wall time). A real frame's GPU work is sub-100ms even on
+                    // the heaviest scenes; anything beyond that is a desynced
+                    // slot, not a stall. Dropping the sample keeps `gpu-total`
+                    // in `trace summary` honest and avoids spamming the
+                    // frame-trace spike WARN at high refresh rates.
+                    const MAX_PLAUSIBLE_FRAME_NS: u64 = 1_000_000_000 / 10;
+                    if delta_ns <= MAX_PLAUSIBLE_FRAME_NS {
+                        let _ = tx.send(Duration::from_nanos(delta_ns));
+                    }
                 }
                 drop(view);
                 buffer_for_callback.unmap();

--- a/crates/rye-render/src/gpu_timer.rs
+++ b/crates/rye-render/src/gpu_timer.rs
@@ -73,6 +73,25 @@ use wgpu::{
 /// contention.
 const FRAMES_IN_FLIGHT: usize = 3;
 
+/// Upper bound on a believable single-frame GPU time. A real frame's GPU work is
+/// sub-100ms even on the heaviest scenes; anything beyond that is a desynced
+/// triple-buffer slot, not a stall.
+const MAX_PLAUSIBLE_FRAME_NS: u64 = 1_000_000_000 / 10;
+
+/// Whether a resolved GPU-timer delta is small enough to be a real frame time.
+///
+/// At display refresh rates above ~120 Hz the triple-buffer cycle can race on
+/// some drivers: Vulkan validation reports the `write_timestamp` /
+/// `resolve_query_set` calls are correctly ordered, but the resolved values
+/// appear to pair a start tick from one cycle with an end tick several cycles
+/// later, yielding deltas that grow linearly with elapsed wall time. Dropping
+/// the over-budget sample keeps `gpu-total` in `trace summary` honest and stops
+/// the frame-trace spike WARN from spamming at high refresh rates. Pulled out as
+/// a free function so the threshold logic is unit-testable without a GPU.
+fn is_plausible_frame_delta_ns(delta_ns: u64) -> bool {
+    delta_ns <= MAX_PLAUSIBLE_FRAME_NS
+}
+
 /// Bytes per resolved slot pair (two `u64` ticks).
 const BYTES_PER_SLOT: u64 = 16;
 
@@ -283,19 +302,7 @@ impl GpuTimer {
                     let end_ticks = u64::from_le_bytes(end_bytes);
                     let delta_ticks = end_ticks.saturating_sub(start_ticks);
                     let delta_ns = (delta_ticks as f64 * period_ns as f64) as u64;
-                    // Reject implausible deltas. At display refresh rates above
-                    // ~120 Hz the triple-buffer cycle can race on some drivers
-                    // (Vulkan validation reports the writes are correctly
-                    // ordered but the resolved values appear to pair a start
-                    // tick from one cycle with an end tick several cycles
-                    // later, yielding deltas that grow linearly with elapsed
-                    // wall time). A real frame's GPU work is sub-100ms even on
-                    // the heaviest scenes; anything beyond that is a desynced
-                    // slot, not a stall. Dropping the sample keeps `gpu-total`
-                    // in `trace summary` honest and avoids spamming the
-                    // frame-trace spike WARN at high refresh rates.
-                    const MAX_PLAUSIBLE_FRAME_NS: u64 = 1_000_000_000 / 10;
-                    if delta_ns <= MAX_PLAUSIBLE_FRAME_NS {
+                    if is_plausible_frame_delta_ns(delta_ns) {
                         let _ = tx.send(Duration::from_nanos(delta_ns));
                     }
                 }
@@ -440,6 +447,22 @@ mod tests {
         // comment "Clear the flag whether the read succeeded or not").
         flag.store(false, Ordering::Release);
         assert!(!flag.load(Ordering::Acquire), "callback re-arms the slot");
+    }
+
+    #[test]
+    fn plausible_frame_delta_rejects_over_budget() {
+        // A 4ms frame (240 Hz) is plausible.
+        assert!(is_plausible_frame_delta_ns(4_000_000));
+        // 16.7ms (60 Hz) is plausible.
+        assert!(is_plausible_frame_delta_ns(16_666_667));
+        // Exactly the 100ms cap is the inclusive boundary.
+        assert!(is_plausible_frame_delta_ns(MAX_PLAUSIBLE_FRAME_NS));
+        // 250ms+ is the desynced-slot garbage the filter exists to drop
+        // (these were the 250-950ms spike-WARN values at 240 Hz).
+        assert!(!is_plausible_frame_delta_ns(250_000_000));
+        assert!(!is_plausible_frame_delta_ns(950_000_000));
+        // Zero (a slot that resolved start == end) is plausible, not a stall.
+        assert!(is_plausible_frame_delta_ns(0));
     }
 
     #[test]

--- a/crates/tesseract_demo/index.html
+++ b/crates/tesseract_demo/index.html
@@ -67,51 +67,9 @@
             display: block;
             background: #0e0e12;
         }
-        /* Launch overlay: covers the entire host so clicking anywhere
-           triggers the worker's Start signal. The worker has already
-           rendered ONE preview frame into the canvas underneath;
-           `backdrop-filter: blur(...)` blurs that frame so the viewer
-           sees a softened preview of the demo's first frame (not a
-           gradient placeholder). On click the overlay is removed,
-           revealing the live canvas, and the worker's RAF loop starts. */
-        .rye-demo-launch {
-            position: absolute;
-            top: 0; left: 0; right: 0; bottom: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font: inherit;
-            font-size: 14px;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            color: #d8d8df;
-            background: rgba(14, 14, 18, 0.35);
-            backdrop-filter: blur(14px);
-            -webkit-backdrop-filter: blur(14px);
-            border: none;
-            cursor: pointer;
-            transition: background 200ms ease, opacity 200ms ease;
-        }
-        .rye-demo-launch::after {
-            /* Outlined chip around the text so it reads as interactive
-               without dominating the preview. */
-            content: 'Click anywhere to launch';
-            display: inline-block;
-            padding: 14px 28px;
-            border: 1px solid rgba(200, 200, 220, 0.5);
-            border-radius: 6px;
-            background: rgba(20, 20, 28, 0.55);
-        }
-        .rye-demo-launch:hover {
-            background: rgba(14, 14, 18, 0.25);
-        }
-        .rye-demo-launch:hover::after {
-            background: rgba(28, 28, 38, 0.65);
-            border-color: rgba(220, 220, 240, 0.7);
-        }
-        .rye-demo-launch:active {
-            background: rgba(14, 14, 18, 0.4);
-        }
+        /* `.rye-demo-launch` (the click-to-start overlay) is injected by
+           `rye_app::wasm::launch::inject_launch_overlay` along with its
+           CSS. Override by shipping a stylesheet later in the cascade. */
     </style>
 </head>
 <body>
@@ -120,16 +78,9 @@
              can `transferControlToOffscreen()` it on click. Width/height
              attributes are a fallback; the launcher recomputes the
              physical-pixel size at click time from CSS dimensions × DPR
-             before transferring. -->
+             before transferring. The overlay button is appended at
+             runtime by the engine. -->
         <canvas id="rye-canvas" width="1280" height="800"></canvas>
-        <!-- Full-overlay launch button. Click anywhere in the host
-             triggers the spawn (the button covers the canvas). On click
-             the button removes itself; the canvas underneath becomes
-             visible and the worker takes over rendering. The button's
-             label is supplied by CSS (`::after`) so the markup stays
-             demo-agnostic. -->
-        <button id="rye-launch" class="rye-demo-launch" type="button"
-                aria-label="Launch demo"></button>
     </div>
 </body>
 </html>

--- a/crates/tesseract_demo/index.html
+++ b/crates/tesseract_demo/index.html
@@ -69,7 +69,10 @@
         }
         /* `.rye-demo-launch` (the click-to-start overlay) is injected by
            `rye_app::wasm::launch::inject_launch_overlay` along with its
-           CSS. Override by shipping a stylesheet later in the cascade. */
+           CSS. Override by shipping a stylesheet later in the cascade.
+           The static `#rye-page-loader` spinner that covers the
+           wasm-init window is inlined into `#rye-canvas-host` below
+           via `data-trunk rel="inline"`. */
     </style>
 </head>
 <body>
@@ -81,6 +84,9 @@
              before transferring. The overlay button is appended at
              runtime by the engine. -->
         <canvas id="rye-canvas" width="1280" height="800"></canvas>
+        <!-- Engine-owned static spinner; see polytope_playground for the
+             rationale. Removed by the wasm runtime on preview_ready. -->
+        <link data-trunk rel="inline" href="../rye-app/static/page_loader.html" />
     </div>
 </body>
 </html>

--- a/crates/tesseract_demo/src/main.rs
+++ b/crates/tesseract_demo/src/main.rs
@@ -355,9 +355,14 @@ impl App for TesseractApp {
         }
     }
 
-    fn on_event(&mut self, ev: &winit::event::WindowEvent, ctx: &mut FrameCtx<'_>) {
-        use winit::event::{ElementState, KeyEvent, WindowEvent};
-        use winit::keyboard::{KeyCode, PhysicalKey};
+    fn on_key(
+        &mut self,
+        code: winit::keyboard::KeyCode,
+        state: winit::event::ElementState,
+        ctx: &mut FrameCtx<'_>,
+    ) {
+        use winit::event::ElementState;
+        use winit::keyboard::KeyCode;
         // Gate app-level hotkeys on egui NOT having keyboard focus. Without this,
         // typing `trace` in the console fires our `KeyT` handler and toggles
         // pause; silently freezing the animation while the user just wanted to
@@ -366,63 +371,52 @@ impl App for TesseractApp {
         if ctx.ui_has_focus {
             return;
         }
-        if let WindowEvent::KeyboardInput {
-            event:
-                KeyEvent {
-                    state,
-                    physical_key: PhysicalKey::Code(code),
-                    ..
-                },
-            ..
-        } = ev
+        // Alt is the only key that needs BOTH edges: the freecam preset's
+        // `on_alt(pressed)` interprets press + release according to its
+        // `cursor_mode` (Hold by default, MMO-style: cursor released while
+        // held, re-grabbed on release). Toggle mode ignores release
+        // internally.
+        if matches!(code, KeyCode::AltLeft | KeyCode::AltRight)
+            && matches!(self.mode, CameraMode::FreeRoam)
         {
-            // Alt is the only key that needs BOTH edges: the freecam
-            // preset's `on_alt(pressed)` interprets press + release
-            // according to its `cursor_mode` (Hold by default, MMO-style:
-            // cursor released while held, re-grabbed on release). Toggle
-            // mode ignores release internally.
-            if matches!(code, KeyCode::AltLeft | KeyCode::AltRight)
-                && matches!(self.mode, CameraMode::FreeRoam)
-            {
-                self.freecam.on_alt(matches!(state, ElementState::Pressed));
-                return;
+            self.freecam.on_alt(matches!(state, ElementState::Pressed));
+            return;
+        }
+        if !matches!(state, ElementState::Pressed) {
+            return;
+        }
+        match code {
+            KeyCode::KeyF => {
+                // Toggle camera mode. Freecam preset grabs the cursor +
+                // seeds its position from the current camera pose on
+                // activation, releases on deactivation; the toggle
+                // feels continuous rather than teleporting.
+                self.mode = match self.mode {
+                    CameraMode::Orbit => {
+                        self.freecam.set_active(true, self.camera.position);
+                        CameraMode::FreeRoam
+                    }
+                    CameraMode::FreeRoam => {
+                        self.freecam.set_active(false, self.camera.position);
+                        CameraMode::Orbit
+                    }
+                };
             }
-            if !matches!(state, ElementState::Pressed) {
-                return;
+            // T always toggles pause; Space ALSO toggles pause, but only
+            // outside FreeRoam (where Space is the jump-up axis and would
+            // be a double-bind).
+            KeyCode::KeyT => {
+                self.paused = !self.paused;
             }
-            match code {
-                KeyCode::KeyF => {
-                    // Toggle camera mode. Freecam preset grabs the cursor +
-                    // seeds its position from the current camera pose on
-                    // activation, releases on deactivation; the toggle
-                    // feels continuous rather than teleporting.
-                    self.mode = match self.mode {
-                        CameraMode::Orbit => {
-                            self.freecam.set_active(true, self.camera.position);
-                            CameraMode::FreeRoam
-                        }
-                        CameraMode::FreeRoam => {
-                            self.freecam.set_active(false, self.camera.position);
-                            CameraMode::Orbit
-                        }
-                    };
-                }
-                // T always toggles pause; Space ALSO toggles pause, but only
-                // outside FreeRoam (where Space is the jump-up axis and would
-                // be a double-bind).
-                KeyCode::KeyT => {
-                    self.paused = !self.paused;
-                }
-                KeyCode::Space if !matches!(self.mode, CameraMode::FreeRoam) => {
-                    self.paused = !self.paused;
-                }
-                KeyCode::KeyR => {
-                    // Reset orientation to identity. omega is preserved so
-                    // unpausing keeps the chosen spin direction.
-                    self.rotor = Rotor4::IDENTITY;
-                }
-                _ => {}
+            KeyCode::Space if !matches!(self.mode, CameraMode::FreeRoam) => {
+                self.paused = !self.paused;
             }
+            KeyCode::KeyR => {
+                // Reset orientation to identity. omega is preserved so
+                // unpausing keeps the chosen spin direction.
+                self.rotor = Rotor4::IDENTITY;
+            }
+            _ => {}
         }
     }
 


### PR DESCRIPTION
wasm worker-mode hardening + polytope_playground polish

**Why:** Browser demos lacked Pointer Lock, leaked Tab/right-click/hotkeys to the page, stuttered on fps changes, and crashed on rapid resize; the rotation sliders also fought each other (a 4D rotor has no faithful 6-plane decomposition). Adds a worker-to-main DOM-action channel, `App::on_key`, an engine-owned loading bar, and independent sliders.

**Verify:** 668 tests; `trunk serve --release crates/polytope_playground/index.html`, then enter freecam, scrub sliders, drag-resize.