### PR TITLE
alternative 4D projections + SphericalS3 rasterization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 Cargo.lock
 
 # IDE / editor / tooling
+CLAUDE.md
 .claude/
 .idea/
 .vscode/
@@ -26,7 +27,7 @@ desktop.ini
 *.orig
 *.rej
 
-# Personal devlog — backed up separately (Obsidian)
+# Personal devlog
 docs/devlog/
 
 # Personal audit / dev scripts (not shipped; rerun locally)

--- a/crates/polytope_playground/src/active.rs
+++ b/crates/polytope_playground/src/active.rs
@@ -152,6 +152,11 @@ impl Demo {
         value_w: f32,
     ) {
         let plane = Plane4::ALL[plane_idx];
+        // Displayed angle BEFORE any widget in this cell mutates state this
+        // frame. The checkbox below flips `active[plane_idx]`, which changes
+        // whether the spin contribution counts toward the displayed angle, so
+        // we capture the pre-toggle displayed angle here to absorb that step.
+        let displayed_before = self.active_displayed_angle(plane_idx);
         // Slider value is the *displayed* angle (base + spin contribution),
         // wrapped into (-720°, 720°]. The wrap is purely for the slider
         // handle: during continuous spin the raw displayed angle grows
@@ -162,12 +167,30 @@ impl Demo {
         // regardless of how this value is normalized for display --
         // `exp(plane * (x + 2π·k))` is the same rotor for any integer k
         // when the plane is a simple unit bivector.
-        let raw_deg = self.active_displayed_angle(plane_idx).to_degrees();
-        let mut deg = wrap_slider_deg(raw_deg);
-        ui.add_sized(
+        let mut deg = wrap_slider_deg(displayed_before.to_degrees());
+        let checkbox_resp = ui.add_sized(
             [checkbox_w, 18.0],
             egui::Checkbox::new(&mut self.active[plane_idx], ""),
         );
+        if checkbox_resp.changed() {
+            // Toggling a plane must not teleport the body: the displayed angle
+            // is `base + spin_contribution(active)`, and flipping `active`
+            // adds or removes the `rot_time * RATE` spin term in one step.
+            // Re-solve `base` so the displayed angle is continuous across the
+            // toggle (freeze the accumulated spin into `base` when switching
+            // off, subtract it back out when switching on):
+            //     base = displayed_before - spin_contribution(active_after)
+            // This keeps the checkbox decoupled from the live orientation, the
+            // same invariant the slider write-back below preserves for drags.
+            let spin_contribution = if self.active[plane_idx] {
+                self.rot_time * crate::consts::BASE_ROTATION_RATE
+            } else {
+                0.0
+            };
+            self.base_angles[plane_idx] = displayed_before - spin_contribution;
+            self.rot_state = self.active_rotor();
+            self.write_all(self.rot_state);
+        }
         ui.add_sized(
             [label_w, 18.0],
             egui::Label::new(egui::RichText::new(plane.label()).monospace()),

--- a/crates/polytope_playground/src/catalog.rs
+++ b/crates/polytope_playground/src/catalog.rs
@@ -20,7 +20,7 @@ use rye_render::raymarch::RaymarchShape;
 /// `hexadecachoron` family; the `*-plex` aliases (pentaplex, dodecaplex, ...) are
 /// deliberately avoided since "plex" is dimension-generalized rather than being the
 /// actual 4D name.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub(crate) struct ShapeEntry {
     pub(crate) shape: RaymarchShape,
     pub(crate) body_color: [f32; 3],

--- a/crates/polytope_playground/src/consts.rs
+++ b/crates/polytope_playground/src/consts.rs
@@ -56,6 +56,26 @@ pub(crate) const CARD_ITEM_SPACING_X: f32 = 4.0;
 pub(crate) const W_SCRUB_RATE: f32 = 0.5;
 pub(crate) const W_RANGE: f32 = 1.5;
 
+/// Lower bound on the wireframe Hyperslice slab full-width. A user-set
+/// thickness of 0 is clamped up to this so the slab stays a real (if razor-
+/// thin) band: a w-range that *crosses* `w_slice` survives, one entirely to
+/// one side is culled. (The cull tests each cell's w-range, not a single
+/// edge's, so "survives" means the cell's edges are kept.) Without the floor,
+/// thickness 0 would demand an exact f32 equality (`w_min == w_slice == w_max`)
+/// that never fires for a generic rotor, hiding the whole wireframe. The value
+/// is one ulp-scale band around a unit-circumradius polytope's w-range; small
+/// enough to read as "the slice plane" yet wide enough to admit a straddling
+/// w-range.
+pub(crate) const HYPERSLICE_MIN_THICKNESS: f32 = 1e-4;
+
+/// Default wireframe Hyperslice slab full-width when the affordance is first
+/// enabled. A polytope cross-section at a given `w_slice` is one infinitely-
+/// thin 3-flat; a slab of this width keeps edges within `+/- 0.1` of the
+/// slice so the surviving wireframe reads as "the edges near the current
+/// cut" rather than the full graph or a single razor plane. Tuned against the
+/// demo's `BODY_SIZE`-scaled polytopes (w-extent ~0.7).
+pub(crate) const HYPERSLICE_DEFAULT_THICKNESS: f32 = 0.2;
+
 /// Animation-time scrub rate for the left / right arrow keys, in
 /// seconds-of-rot_time per real second held. 1.0 means a one-second
 /// real-time hold advances `rot_time` by one second of animation.
@@ -88,3 +108,12 @@ pub(crate) const BODY_SIZE: f32 = 0.7;
 
 /// Center-y for all bodies; floor is at y=0.
 pub(crate) const BODY_Y: f32 = 0.9;
+
+/// Subdivisions per wireframe edge when the `space` blend is active (anything
+/// other than pure flat). Each edge becomes this many sub-segments so the
+/// great-circle arc reads as a smooth curve rather than a chord of chords.
+/// Adjacent polytope vertices subtend a small great-circle angle, so 16 is
+/// already visually smooth; higher values multiply the per-frame wireframe
+/// rebuild cost (the dominant cost for the 600-cell) for no visible gain.
+/// Pure-flat mode bypasses tessellation entirely and emits one segment per edge.
+pub(crate) const SPACE_TESSELLATION_SAMPLES: usize = 16;

--- a/crates/polytope_playground/src/filmstrip.rs
+++ b/crates/polytope_playground/src/filmstrip.rs
@@ -132,6 +132,46 @@ impl Demo {
         }
     }
 
+    /// Single-view body: just the subject picker. Single mode renders exactly
+    /// one shape (`strip_subject`, shared with the filmstrip) with the full
+    /// surface / wireframe / projection / points stack, so this body needs no
+    /// w/t-axis fan controls. The subject is chosen from the same catalog menu
+    /// the filmstrip and shape-row `+` button use, so a user who picks a
+    /// 120/600-cell here gets the same heavy-SDF hint they would in those views.
+    ///
+    /// The Schlegel boundary-cell stepper (in the Render modal) reads this
+    /// subject's `cell_count()` for its upper bound, which is the whole reason
+    /// Single mode exists: the cell index is well-defined only against one
+    /// unambiguous polytope.
+    pub(crate) fn render_single_body(&mut self, ui: &mut egui::Ui) {
+        ui.separator();
+        let heavy = matches!(
+            self.strip_subject.shape,
+            RaymarchShape::Polytope(Polytope4::Cell120 | Polytope4::Cell600)
+        );
+        if heavy && self.surface_mode.uses_sdf_for_polychora() {
+            ui.colored_label(
+                egui::Color32::from_rgb(242, 130, 70),
+                "120/600-cell SDFs are heavy; expect <60 fps. Try `surface raster`.",
+            );
+        }
+        ui.horizontal(|ui| {
+            // Same catalog menu as the filmstrip subject picker + the shape-row
+            // `+` button, so the visuals (nested category submenus, hover names)
+            // stay identical across every shape-selection surface.
+            let subject_button = ui
+                .button(format!("subject: {}", self.strip_subject.label))
+                .on_hover_text("Pick the single polytope to inspect");
+            egui::Popup::menu(&subject_button).show(|ui| {
+                ui.set_min_width(140.0);
+                render_shape_catalog_menu(ui, |entry| {
+                    self.strip_subject = entry;
+                });
+            });
+            ui.label("Projection + boundary cell live in the Render settings (gear).");
+        });
+    }
+
     /// Filmstrip body: subject combo (over the catalog, so the
     /// user can pick any of the shipped polytopes independent of
     /// `self.row`) plus per-axis count DragValues. Heavy-shape

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -118,6 +118,17 @@ const PERSPECTIVE_SCALE_DENOM_EPSILON: f32 = 1e-4;
 /// value of `0.25 * sqrt(2 / eps)`, recorded because `f32::sqrt` is not `const`).
 const STEREOGRAPHIC_VIEW_RADIUS: f32 = 35.355_34;
 
+/// Cap on the reconstructed near-pole image magnitude (see `near_pole_view_point`).
+/// A point within the pole-denominator clamp band is a point-at-infinity; the
+/// conformal map's denominator clamp deflates its rendered magnitude toward the
+/// origin, so the wireframe builder substitutes the true magnitude
+/// `sqrt((1 + dot) / (1 - dot))` in the same projected direction. That true
+/// magnitude diverges at the pole, so it is capped here purely for f32 safety:
+/// `1e4` is far above `STEREOGRAPHIC_VIEW_RADIUS` (so the sample reliably clips
+/// out) and far below any value that would lose precision in the segment/sphere
+/// boundary solve (`1e4^2 = 1e8`, comfortably inside f32's exact-integer range).
+const STEREOGRAPHIC_POLE_FAR_CAP: f32 = 1.0e4;
+
 /// Body-local projected-radius clip for a `projection`, or `None` when the
 /// projection needs no clip. Only [`rye_math::Projection::Stereographic`] has a
 /// genuine point-at-infinity in its image (a vertex on the pole), so it is the
@@ -165,32 +176,34 @@ fn perspective_scale_at_w(w_slice: f32, projection: &rye_math::Projection<4>) ->
     }
 }
 
-/// Whether `projection` maps a straight R⁴ chord to a straight R³ segment, so a
+/// Whether `projection` maps a straight R4 chord to a straight R3 segment, so a
 /// polytope edge can be rendered as a single line between its projected endpoints.
 ///
 /// `Identity` / `Orthographic` are linear and `Perspective4D` is a central
 /// projection (the bodies sit at `w = 0`, so the perspective divide is a
-/// line-preserving map onto R³): all three send a 4D segment to an R³ segment,
-/// the affine fast path. `Schlegel` and `Stereographic` are non-affine -- their
-/// R³ image of a point depends nonlinearly on all four coordinates, so the image
-/// of an edge is a *curve*, not the chord through its projected endpoints. An edge
-/// drawn as a single straight chord under those projections drifts off its own
-/// projected midpoint (measured ~0.17 R³ units for a unit-circumradius tesseract
-/// edge under the `+w`-pole stereographic map), and the per-vertex-projected
-/// cross-section cap, which lands on the true projected edge, then floats off the
-/// wireframe. The wireframe builder subdivides the edge under these projections so
-/// the rendered polyline follows the projected curve and the cap rejoins it.
-///
-/// This is the same affine/non-affine split [`perspective_scale_at_w`] reports as
-/// `Some`/`None`; kept as a distinct boolean so the wireframe edge path reads as a
-/// shape question ("is the projected edge straight?") rather than borrowing the
-/// section cap's scalar-shim return.
-fn projection_is_affine(projection: &rye_math::Projection<4>) -> bool {
+/// line-preserving map onto R3). Schlegel is central projection onto the chosen
+/// cell's hyperplane, so it is line-preserving too even though it is not affine
+/// and cannot use the section-cap scalar shim. Stereographic is the odd one out:
+/// sampling a chord through its S3-normalizing projection generally curves in
+/// R3. The flat stereographic wireframe path is a separate endpoint-chord
+/// overlay, not this projected chord interior.
+fn projection_maps_chords_to_lines(projection: &rye_math::Projection<4>) -> bool {
     match *projection {
         rye_math::Projection::Identity
         | rye_math::Projection::Orthographic { .. }
-        | rye_math::Projection::Perspective4D { .. } => true,
-        rye_math::Projection::Schlegel { .. } | rye_math::Projection::Stereographic { .. } => false,
+        | rye_math::Projection::Perspective4D { .. }
+        | rye_math::Projection::Schlegel { .. } => true,
+        rye_math::Projection::Stereographic { .. } => false,
+    }
+}
+
+/// Whether a flat wireframe edge (`blend == 0`) should render as the R3 chord
+/// between projected endpoints. Stereographic edges are always drawn as S3 arcs
+/// (`blend == 1`), so this chord path is the affine projections' geometry.
+fn flat_edge_uses_endpoint_chord(projection: &rye_math::Projection<4>) -> bool {
+    match *projection {
+        rye_math::Projection::Stereographic { .. } => true,
+        _ => projection_maps_chords_to_lines(projection),
     }
 }
 
@@ -333,11 +346,10 @@ fn cell_w_range(cell: &[u32], local_vertices: &[Vec4]) -> (f32, f32) {
 /// blow-up is culled. No clip is applied for other projections
 /// ([`stereographic_clip_radius`] returns `None`).
 ///
-/// Used by [`push_blended_edge`] for the flat-space (`blend == 0`) case under a
-/// non-affine projection (Stereographic / Schlegel), where a single straight
-/// segment would drift off the projected edge and the per-vertex-projected
-/// cross-section cap would float off the wireframe. Affine projections never reach
-/// here; they keep the single-segment fast path.
+/// Kept as the future escape hatch for a projection that genuinely maps flat R4
+/// chords to curved R3 images. Current built-in modes do not use it for
+/// `blend == 0`: line-preserving projections and the stereographic comparison
+/// overlay both use endpoint chords.
 #[allow(clippy::too_many_arguments)]
 fn push_projected_chord(
     mesh: &mut LineMesh<3>,
@@ -401,6 +413,156 @@ fn sample_in_radius(projected: Vec3, radius: Option<f32>) -> bool {
     }
 }
 
+/// Parameter `t in [0, 1]` at which the straight segment `inside -> outside`
+/// (`p_in` within the clip sphere, `p_out` beyond it) crosses the clip sphere of
+/// radius `r`, both points in the body-local projected frame. Solving
+/// `|p_in + t*(p_out - p_in)|^2 = r^2` for `t` is the standard segment/sphere
+/// intersection (do Carmo, *Differential Geometry of Curves and Surfaces*, §1.5,
+/// the line/quadric form): with `d = p_out - p_in`,
+///   `|d|^2 t^2 + 2(p_in·d) t + (|p_in|^2 - r^2) = 0`.
+/// Because `|p_in| <= r < |p_out|` the constant term is non-positive and the
+/// leading term positive, so the two roots straddle zero and the unique crossing
+/// in `[0, 1]` is the larger root `(-b + sqrt(b^2 - a*c)) / a`. The discriminant
+/// is non-negative for a genuine straddle; it is floored at 0 against f32
+/// roundoff on a sample sitting essentially on the boundary, and the result is
+/// clamped to `[0, 1]` so a hair-past-unit root from the same roundoff cannot
+/// push the clip point off the segment.
+///
+/// This is the smooth-clip primitive: a near-pole arc sub-segment that leaves
+/// the view radius is cut AT the boundary rather than dropped whole, so the
+/// visible arc end rides the clip sphere continuously as a vertex sweeps the
+/// pole under rotation, instead of popping between discrete tessellation samples
+/// (the 16-cell "bounce"). The cut point lies on the real polyline chord, so it
+/// preserves the arc's path and the genuine pole-crossing inversion; it is NOT a
+/// radial rescale of an off-arc sample.
+fn radius_crossing_t(p_in: Vec3, p_out: Vec3, r: f32) -> f32 {
+    let d = p_out - p_in;
+    let a = d.length_squared();
+    // Coincident projected samples have no crossing direction; clip at the far
+    // end (degenerate, effectively never hit for a real straddle).
+    if a <= f32::MIN_POSITIVE {
+        return 1.0;
+    }
+    let b = p_in.dot(d);
+    let c = p_in.length_squared() - r * r;
+    let disc = (b * b - a * c).max(0.0);
+    ((-b + disc.sqrt()) / a).clamp(0.0, 1.0)
+}
+
+/// The clip-sphere boundary point at parameter `t` along the projected segment
+/// `p_in -> p_out`, returned as `(world_point, color)`: the body-local projected
+/// crossing `lerp(p_in, p_out, t)` translated by `body_pos`, paired with the
+/// endpoint colors linearly interpolated by the same `t` so the cut inherits the
+/// edge's gradient. `t` comes from [`radius_crossing_t`].
+fn clip_point(
+    p_in: Vec3,
+    p_out: Vec3,
+    c_in: [f32; 4],
+    c_out: [f32; 4],
+    t: f32,
+    body_pos: Vec3,
+) -> ([f32; 3], [f32; 4]) {
+    let boundary = (p_in.lerp(p_out, t) + body_pos).to_array();
+    let color = [
+        c_in[0] + (c_out[0] - c_in[0]) * t,
+        c_in[1] + (c_out[1] - c_in[1]) * t,
+        c_in[2] + (c_out[2] - c_in[2]) * t,
+        c_in[3] + (c_out[3] - c_in[3]) * t,
+    ];
+    (boundary, color)
+}
+
+/// Emit one tessellation sub-segment into `mesh` under the stereographic radius
+/// clip. Each end is `(projected, world, color, in_radius)`: the body-local
+/// projected point (what the clip tests), its world point (what the mesh draws),
+/// the endpoint color, and whether the projected point is within the clip radius.
+///
+/// With no clip (`clip_radius == None`) both ends are always in-radius and the
+/// whole sub-segment is emitted, bit-identical to the unclipped path. Under the
+/// clip a fully-inside sub-segment is emitted whole; a sub-segment that STRADDLES
+/// the boundary is cut AT the clip sphere via [`radius_crossing_t`] /
+/// [`clip_point`], so the visible arc end rides the boundary smoothly as a vertex
+/// sweeps the pole (this is what removes the near-pole "bounce": the tip tracks
+/// the boundary continuously instead of popping between discrete tessellation
+/// samples); a fully-outside sub-segment is dropped, breaking the polyline so the
+/// next in-bounds pair starts fresh rather than bridging the gap through the pole
+/// region.
+fn push_clipped_subsegment(
+    mesh: &mut LineMesh<3>,
+    clip_radius: Option<f32>,
+    width: f32,
+    body_pos_r3: Vec3,
+    prev: (Vec3, [f32; 3], [f32; 4], bool),
+    cur: (Vec3, [f32; 3], [f32; 4], bool),
+) {
+    let (prev_proj, prev_world, prev_c, prev_in) = prev;
+    let (cur_proj, cur_world, cur_c, cur_in) = cur;
+    let mut push = |a_world, b_world, a_c, b_c| {
+        mesh.segments.push((a_world, b_world));
+        mesh.colors.push((a_c, b_c));
+        mesh.widths.push(width);
+    };
+    match (clip_radius, prev_in, cur_in) {
+        // No clip, or both samples inside: emit the whole sub-segment.
+        (None, _, _) | (Some(_), true, true) => push(prev_world, cur_world, prev_c, cur_c),
+        // Both outside: drop, so the polyline breaks across the pole region.
+        (Some(_), false, false) => {}
+        // Inside -> outside: cut the far end to the clip sphere.
+        (Some(r), true, false) => {
+            let t = radius_crossing_t(prev_proj, cur_proj, r);
+            let (bw, bc) = clip_point(prev_proj, cur_proj, prev_c, cur_c, t, body_pos_r3);
+            push(prev_world, bw, prev_c, bc);
+        }
+        // Outside -> inside: cut the near end (measured from the inside sample).
+        (Some(r), false, true) => {
+            let t = radius_crossing_t(cur_proj, prev_proj, r);
+            let (bw, bc) = clip_point(cur_proj, prev_proj, cur_c, prev_c, t, body_pos_r3);
+            push(bw, cur_world, bc, cur_c);
+        }
+    }
+}
+
+/// Body-local projected point of a wireframe sample `p` for the stereographic
+/// CLIP, correcting the conformal map's near-pole denominator clamp.
+///
+/// The map floors the denominator `1 - dot(p, pole)` at `STEREOGRAPHIC_POLE_EPSILON`
+/// so a vertex at the pole stays finite, but the numerator `p - dot*pole` vanishes
+/// at the pole too. So WITHIN the clamp band the rendered magnitude
+/// `|perp| / eps` DEFLATES toward the origin as the sample nears the pole, instead
+/// of diverging. A vertex sweeping the pole under rotation would then drag its
+/// incident edges in through the screen center and back out (the gradient visibly
+/// sliding along a line that should read as a static axis), rather than the edges
+/// running off to the clip boundary and the figure inverting cleanly.
+///
+/// For a sample genuinely inside the clamp band this returns the TRUE conformal
+/// magnitude `sqrt((1 + dot) / (1 - dot))` (capped by [`STEREOGRAPHIC_POLE_FAR_CAP`]
+/// for f32 safety) in the SAME projected direction, so the magnitude clip treats
+/// it as the point-at-infinity it is and the boundary cut runs the edge out toward
+/// it. The projected direction is taken from the deflated point, which is correct:
+/// the clamp scales `perp` uniformly, so only the magnitude is wrong, not the
+/// direction. Outside the band, and for every non-stereographic projection, this
+/// is exactly `project_point` (no perturbation, bit-identical to the unclamped
+/// path). The exact pole (`perp ~ 0`, projected point at the origin) has no
+/// direction to send outward, so it is left at the origin (the map's documented
+/// pole-to-origin value); a rotating vertex effectively never lands on it exactly.
+fn stereographic_view_point(p: Vec4, projection: &rye_math::Projection<4>) -> Vec3 {
+    let proj =
+        <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(p, projection);
+    let rye_math::Projection::Stereographic { pole } = projection else {
+        return proj;
+    };
+    let dot = p.normalize().dot(*pole).clamp(-1.0, 1.0);
+    let raw = 1.0 - dot;
+    if raw < rye_math::STEREOGRAPHIC_POLE_EPSILON && proj.length() > MIN_EDGE_RADIUS {
+        let true_mag = ((1.0 + dot) / raw.max(f32::MIN_POSITIVE))
+            .sqrt()
+            .min(STEREOGRAPHIC_POLE_FAR_CAP);
+        proj.normalize() * true_mag
+    } else {
+        proj
+    }
+}
+
 /// In-place near-pole clip for the section-cap FILL, at TRIANGLE granularity: a
 /// just-appended triangle in `indices[start_i..]` survives only when all three of
 /// its vertices' body-local projected points are within `radius`, mirroring the
@@ -443,19 +605,19 @@ fn retain_in_radius_triangles(
 }
 
 /// Append one polytope edge to `mesh`, morphed between a flat R⁴ chord and an
-/// S³ great-circle arc by `blend` (0 = chord, 1 = arc; see [`Demo::space_blend`]).
+/// S³ great-circle arc by `blend` (0 = chord, 1 = arc). The caller derives
+/// `blend` from the projection ([`state::default_edge_blend`]): Stereographic
+/// passes 1, the affine projections pass 0.
 ///
 /// `a` / `b` are the body-local 4D endpoints (rotor-rotated and `body_size`-scaled).
 /// Both interpolation curves share these endpoints because the polytope's
 /// vertices sit on the body's circumsphere, so the morph only bows the edge
-/// interior outward onto the sphere. The edge is emitted as a single straight R³
-/// chord only when it is flat (`blend == 0`) AND the projection maps a chord to a
-/// chord ([`projection_is_affine`]); a non-affine projection subdivides even the
-/// flat chord (via [`push_projected_chord`]) so the screen polyline follows the
-/// projected curve and the section cap lands on it. The blended (`blend > 0`) path
-/// always subdivides into [`SPACE_TESSELLATION_SAMPLES`] sub-segments with a
-/// per-sample chord/arc blend and a linear color gradient between the endpoint
-/// colors.
+/// interior outward onto the sphere. Flat edges (`blend == 0`) render as the R3
+/// chord between projected endpoints. Under stereographic that flat chord is a
+/// comparison overlay; the faithful S3 great-circle edge is the `blend == 1`
+/// path. The blended (`blend > 0`) path subdivides into
+/// [`SPACE_TESSELLATION_SAMPLES`] sub-segments with a per-sample chord/arc blend
+/// and a linear color gradient between the endpoint colors.
 ///
 /// `slerp_scratch` is a caller-owned buffer reused across edges to keep the
 /// great-circle sampling off the per-edge allocation path; it is cleared on
@@ -475,7 +637,7 @@ fn retain_in_radius_triangles(
 /// runs over every edge of the 600-cell wireframe each frame (the documented
 /// dominant per-frame cost). The endpoints are shared by both curves, so no
 /// metric fidelity is lost where it would be visible; only the interior path
-/// differs, and the arc sample already carries the S³ curvature the morph is
+/// differs, and the arc sample already carries the S3 bow the morph is
 /// meant to show.
 #[allow(clippy::too_many_arguments)]
 fn push_blended_edge(
@@ -490,30 +652,28 @@ fn push_blended_edge(
     body_pos_r3: Vec3,
     slerp_scratch: &mut Vec<Vec4>,
 ) {
-    // Single-segment fast path: one straight R³ chord per edge, bit-identical to
-    // the pre-blend behavior. Valid only when the edge is a flat chord (`blend <=
-    // 0`) AND the projection sends a straight R⁴ chord to a straight R³ segment
-    // (`projection_is_affine`). Under a non-affine projection (Stereographic /
-    // Schlegel) the projected edge is a CURVE, so a single chord drifts off its own
-    // projected midpoint and the per-vertex-projected section cap floats off the
-    // wireframe; those fall through to the subdivided path below, which samples the
-    // flat chord and projects each sample so the polyline follows the projected
-    // curve. Kept ahead of any extra work so steady-state perf in the default mode
-    // (flat space, affine projection) is unaffected.
+    // Flat edge: one straight R3 chord per polytope edge. For stereographic this
+    // is a comparison overlay, not the S3 great-circle image.
     if blend <= 0.0 {
-        if projection_is_affine(projection) {
-            let a3 = project_to_world(a, projection, body_pos_r3);
-            let b3 = project_to_world(b, projection, body_pos_r3);
-            mesh.segments.push((a3.to_array(), b3.to_array()));
-            mesh.colors.push((color_a, color_b));
-            mesh.widths.push(width);
+        if flat_edge_uses_endpoint_chord(projection) {
+            let clip_radius = stereographic_clip_radius(projection);
+            let a3_local = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+                a, projection,
+            );
+            let b3_local = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+                b, projection,
+            );
+            if sample_in_radius(a3_local, clip_radius) && sample_in_radius(b3_local, clip_radius) {
+                mesh.segments.push((
+                    (a3_local + body_pos_r3).to_array(),
+                    (b3_local + body_pos_r3).to_array(),
+                ));
+                mesh.colors.push((color_a, color_b));
+                mesh.widths.push(width);
+            }
             return;
         }
-        // Flat chord, non-affine projection: the edge is still geometrically the
-        // straight R⁴ chord (no sphere bow), but its R³ image is a curve, so
-        // subdivide the chord and project each sample. This is what lets the
-        // per-vertex-projected section cap rejoin the wireframe. No slerp buffer
-        // needed; the chord has no radial arc.
+        // Future non-line-preserving flat projection: sample the R⁴ chord.
         push_projected_chord(mesh, a, b, color_a, color_b, width, projection, body_pos_r3);
         return;
     }
@@ -523,15 +683,25 @@ fn push_blended_edge(
     if radius_a < MIN_EDGE_RADIUS || radius_b < MIN_EDGE_RADIUS {
         // Vertex effectively at the body center: no radial direction for slerp, so
         // the sphere arc is undefined and the edge degrades to the flat chord.
-        // Affine projections render it as a single straight segment; non-affine
-        // ones subdivide so the projected chord still curves. Never reached in
-        // practice (regular polytope vertices are at circumradius `body_size`).
-        if projection_is_affine(projection) {
-            let a3 = project_to_world(a, projection, body_pos_r3);
-            let b3 = project_to_world(b, projection, body_pos_r3);
-            mesh.segments.push((a3.to_array(), b3.to_array()));
-            mesh.colors.push((color_a, color_b));
-            mesh.widths.push(width);
+        // Never reached in practice (regular polytope vertices are at
+        // circumradius `body_size`), but route through the same flat-edge chord
+        // policy so degenerate inputs don't invent spherical samples.
+        if flat_edge_uses_endpoint_chord(projection) {
+            let clip_radius = stereographic_clip_radius(projection);
+            let a3_local = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+                a, projection,
+            );
+            let b3_local = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+                b, projection,
+            );
+            if sample_in_radius(a3_local, clip_radius) && sample_in_radius(b3_local, clip_radius) {
+                mesh.segments.push((
+                    (a3_local + body_pos_r3).to_array(),
+                    (b3_local + body_pos_r3).to_array(),
+                ));
+                mesh.colors.push((color_a, color_b));
+                mesh.widths.push(width);
+            }
             return;
         }
         push_projected_chord(mesh, a, b, color_a, color_b, width, projection, body_pos_r3);
@@ -555,11 +725,18 @@ fn push_blended_edge(
     // Sample 0 is `a` exactly (flat == sphere == a), so seed `prev` from it and
     // emit consecutive sub-segments from sample 1. `slerp_scratch` holds exactly
     // `samples + 1` points, so skipping the first walks indices 1..=samples.
-    // Same stereographic clip as `push_projected_chord`: drop a sub-segment whose
-    // endpoint leaves the clip radius (a near-pole blended sample), resuming the
-    // polyline when it re-enters; `clip_radius == None` keeps every sample.
-    let proj0 =
-        <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(a, projection);
+    // Stereographic clip: a sub-segment straddling the view radius is cut AT the
+    // boundary (`push_clipped_subsegment`), so a near-pole arc end rides the
+    // clip sphere smoothly under rotation instead of popping between samples; a
+    // fully-outside sub-segment is dropped, breaking the polyline across the pole
+    // region. `clip_radius == None` keeps every sample whole.
+    // `stereographic_view_point` corrects the near-pole denominator-clamp
+    // deflation so a sample inside the pole band reads as the point-at-infinity it
+    // is (large magnitude, correct direction) rather than collapsing toward the
+    // origin; outside the band, and for every other projection, it is exactly
+    // `project_point`.
+    let proj0 = stereographic_view_point(a, projection);
+    let mut prev_proj = proj0;
     let mut prev_world = (proj0 + body_pos_r3).to_array();
     let mut prev_c = color_a;
     let mut prev_in = sample_in_radius(proj0, clip_radius);
@@ -568,10 +745,7 @@ fn push_blended_edge(
         let flat = a.lerp(b, s);
         let radius = radius_a + (radius_b - radius_a) * s;
         let sphere = radius * arc_pt;
-        let proj = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
-            flat.lerp(sphere, blend),
-            projection,
-        );
+        let proj = stereographic_view_point(flat.lerp(sphere, blend), projection);
         let world = (proj + body_pos_r3).to_array();
         let c = [
             color_a[0] + (color_b[0] - color_a[0]) * s,
@@ -580,11 +754,15 @@ fn push_blended_edge(
             color_a[3] + (color_b[3] - color_a[3]) * s,
         ];
         let cur_in = sample_in_radius(proj, clip_radius);
-        if prev_in && cur_in {
-            mesh.segments.push((prev_world, world));
-            mesh.colors.push((prev_c, c));
-            mesh.widths.push(width);
-        }
+        push_clipped_subsegment(
+            mesh,
+            clip_radius,
+            width,
+            body_pos_r3,
+            (prev_proj, prev_world, prev_c, prev_in),
+            (proj, world, c, cur_in),
+        );
+        prev_proj = proj;
         prev_world = world;
         prev_c = c;
         prev_in = cur_in;
@@ -955,7 +1133,6 @@ impl Demo {
             stereographic_pole: state::STEREOGRAPHIC_DEFAULT_POLE,
             wireframe_hyperslice: false,
             wireframe_hyperslice_thickness: consts::HYPERSLICE_DEFAULT_THICKNESS,
-            space_blend: 0.0,
             wireframe_width_px: 1.8,
             wireframe_alpha: 1.0,
             unique_edge_palette_cache: std::collections::HashMap::new(),
@@ -1002,12 +1179,12 @@ impl Demo {
                 window_pos: egui::Pos2::new(220.0, 120.0),
                 open: false,
             },
-            // On by default: the moment a user picks a non-default projection or
-            // turns up Curvature, the annotation explains the mode without their
-            // having to read the source. `render_mode_annotation` no-ops while the
-            // scene is in its plain drop-w + flat-space default, so an open flag
-            // costs nothing until a non-default mode is selected. Default position
-            // sits below the example callout's default slot so the two don't stack.
+            // On by default: the moment a user picks a non-default projection the
+            // annotation explains the mode without their having to read the
+            // source. `render_mode_annotation` no-ops while the scene is in its
+            // plain drop-w default, so an open flag costs nothing until a
+            // non-default projection is selected. Default position sits below the
+            // example callout's default slot so the two don't stack.
             mode_annotation_open: rye_egui::CalloutState {
                 window_pos: egui::Pos2::new(220.0, 300.0),
                 open: true,
@@ -1289,46 +1466,27 @@ impl Demo {
         self.render_example_callout(ctx, frame);
         // Per-mode educational annotation (on by default; toggle via View > Mode
         // annotation). No-ops in the default drop-w + flat-space scene; otherwise
-        // explains the active projection / curvature combination.
+        // explains the active projection / edge-geometry combination.
         self.render_mode_annotation(ctx, frame);
     }
 
     /// Surface the per-projection / per-space-mode educational annotation via the
     /// `rye_egui::callout` primitive, anchored to the leading polychoron's body
     /// center. The text is the pure [`state::mode_annotation`] mapping of the
-    /// active `(wireframe_projection, effective_blend, raster-cap)` state,
-    /// reprojected per frame so the leader line tracks the shape as the camera
-    /// orbits. `effective_blend` is `space_blend` only while the wireframe overlay
-    /// is enabled (the bowed edges live there and nowhere else), so a curvature
-    /// value set while the overlay is off does not produce a spherical annotation
-    /// for geometry that is not on screen. No-op when the toggle is off, the row
-    /// has no polychoron, or the scene is in its plain default state (drop-w
-    /// projection AND no visible curvature), where the mapping returns `None` and
-    /// there is nothing non-obvious to explain.
+    /// active `wireframe_projection`, reprojected per frame so the leader line
+    /// tracks the shape as the camera orbits. No-op when the toggle is off, the
+    /// row has no polychoron, or the projection is the plain default (drop-w),
+    /// where the mapping returns `None` and there is nothing to explain.
     ///
     /// Anchoring to the body center (not a single vertex like
     /// [`Self::render_example_callout`]) is deliberate: the annotation is about the
-    /// whole shape's projection / curvature, not one vertex, so the body center is
-    /// the honest anchor.
+    /// whole shape's projection, not one vertex, so the body center is the honest
+    /// anchor.
     fn render_mode_annotation(&mut self, ctx: &egui::Context, frame: &mut FrameCtx<'_>) {
         if !self.mode_annotation_open.open {
             return;
         }
-        // The flat cross-section cap is drawn only in Raster surface mode; this
-        // gates the three-way-overlap note inside `mode_annotation`.
-        let flat_cap_drawn = matches!(self.surface_mode, SurfaceMode::Raster);
-        // The spherical-curvature morph is wireframe-only: `space_blend` bows the
-        // edges in `push_blended_edge`, reached only from `render_wireframe_overlay`,
-        // and that path is skipped while the overlay is off. The caps and the
-        // projection stay visible without the wireframe, but the bowed edges do
-        // not, so report the blend as flat when the overlay is off (see
-        // `annotation_effective_blend`) and the annotation never claims curvature
-        // the user cannot see.
-        let effective_blend =
-            state::annotation_effective_blend(self.space_blend, self.wireframe_enabled);
-        let Some(annotation) =
-            state::mode_annotation(self.wireframe_projection, effective_blend, flat_cap_drawn)
-        else {
+        let Some(annotation) = state::mode_annotation(self.wireframe_projection) else {
             return;
         };
 
@@ -2210,7 +2368,10 @@ impl Demo {
         let cross_section_projection = state::section_layer_projection(true, wireframe_projection);
         // Flat-chord vs S³-arc morph for every edge (0 = chord). Captured once so
         // the per-edge helper stays free of `&self`.
-        let space_blend = self.space_blend;
+        // Edge geometry is derived from the projection, not a control:
+        // Stereographic draws S3 great-circle arcs, every affine projection draws
+        // flat R4 chords (see `state::default_edge_blend`).
+        let space_blend = state::default_edge_blend(self.wireframe_projection);
         // Wireframe Hyperslice cull: when on, only edges whose body-local
         // w-interval intersects the slab around `w_slice` survive. Captured
         // once per frame. This is a third, independent slicing affordance
@@ -2471,11 +2632,11 @@ impl Demo {
                 };
                 color_a[3] = alpha;
                 color_b[3] = alpha;
-                // Emit the edge in body-local 4D, projected to world R³. At
-                // `space_blend == 0` this is one chord per edge (the historical
-                // behavior); above 0 the edge bows toward its S³ great-circle arc.
-                // Projection is shared with the flat path: DropW is identity-on-
-                // (x, y, z), Perspective4D scales each component by focal/(focal-w).
+                // Emit the edge in body-local 4D, projected to world R³. `blend`
+                // is projection-derived (Stereographic -> 1 = S³ arc, affine -> 0
+                // = one chord per edge). Projection is shared with the flat path:
+                // Shadow is identity-on-(x, y, z), Perspective4D scales each
+                // component by focal/(focal-w).
                 push_blended_edge(
                     &mut parent_lines,
                     a,
@@ -2584,85 +2745,6 @@ struct RotatePolytopesApp {
     perf: rye_app::trace::PerfOverlay,
 }
 
-/// Shared handler for the `wireframe space` subcommand and the top-level
-/// `space` alias. Both write the same `space_blend` field (the flat<->spherical
-/// edge morph; see [`Demo::space_blend`]): `flat` -> 0.0 (R⁴ chords),
-/// `spherical` -> 1.0 (S³ great-circle arcs), `blend <t>` -> a `t` accepted only
-/// inside `[0, 1]`. A bare invocation reports the current value. Factored out so
-/// the canonical control (`wireframe space`, since the morph IS a
-/// wireframe-geometry property) and the one-keypress thesis alias (`space
-/// spherical`) cannot drift apart.
-///
-/// `space_blend` is read ONLY by [`Demo::render_wireframe_overlay`], which the
-/// frame loop skips entirely while `wireframe_enabled` is `false` (the default).
-/// So a verb that turns the morph ON has to enable the wireframe too, or the
-/// headline `space spherical` keypress mutates a field nothing draws and the
-/// user sees no change. This handler therefore takes `wireframe_enabled` and
-/// flips it on whenever it sets a NON-ZERO blend (`spherical`, or `blend <t>`
-/// with `t > 0`): the great-circle arcs only exist in the wireframe layer, so
-/// asking to see them is implicitly asking for that layer. `flat` and `blend 0`
-/// leave `wireframe_enabled` untouched, never force it off: zero blend is the
-/// default flat geometry and a user may have the wireframe up for unrelated
-/// reasons (color mode, projection, hyperslice). Bare query and rejected input
-/// touch neither field.
-///
-/// Both fields are `&mut` primitives rather than `&mut Demo` so the two
-/// registrations still share one body (they cannot diverge) AND the handler
-/// stays unit-testable without a GPU-backed `Demo`.
-fn run_space_command(
-    space_blend: &mut f32,
-    wireframe_enabled: &mut bool,
-    args: &[&str],
-    out: &mut rye_egui::console::ConsoleWriter,
-) -> anyhow::Result<()> {
-    // Turning the morph on without the wireframe layer drawn is a silent no-op;
-    // surface that the layer was auto-enabled so the user knows where the arcs
-    // came from and can toggle it off again if they only wanted the SDF view.
-    let mut enable_wireframe = |out: &mut rye_egui::console::ConsoleWriter| {
-        if !*wireframe_enabled {
-            *wireframe_enabled = true;
-            out.line("wireframe overlay auto-enabled (the morph draws there)");
-        }
-    };
-    match args.first().copied() {
-        None => {
-            out.line(format!(
-                "wireframe space blend: {space_blend:.3} (0 = flat, 1 = spherical)"
-            ));
-        }
-        Some("flat") => {
-            *space_blend = 0.0;
-            out.line("wireframe space: flat (R⁴ chords)");
-        }
-        Some("spherical") => {
-            *space_blend = 1.0;
-            out.line("wireframe space: spherical (S³ great-circle arcs)");
-            enable_wireframe(out);
-        }
-        Some("blend") => match args.get(1) {
-            None => out.line(format!("wireframe space blend: {space_blend:.3}")),
-            Some(s) => match s.parse::<f32>() {
-                Ok(t) if (0.0..=1.0).contains(&t) => {
-                    *space_blend = t;
-                    out.line(format!("wireframe space blend: set to {t:.3}"));
-                    // Only a positive blend bows the edges; `blend 0` is flat
-                    // geometry and must not silently flip the overlay on.
-                    if t > 0.0 {
-                        enable_wireframe(out);
-                    }
-                }
-                _ => out.line(format!(
-                    "wireframe space blend: invalid `{s}` (need a float in [0, 1])"
-                )),
-            },
-        },
-        Some(other) => out.line(format!(
-            "wireframe space: unknown `{other}` (try flat|spherical|blend)"
-        )),
-    }
-    Ok(())
-}
-
 /// Lower bound on a VISIBLE section-layer fill alpha. Mirrors the old `surface
 /// alpha` floor: below this the cap is so faint it reads as off, so the grammar
 /// rejects it and steers the user to `0` (the explicit off state) instead, the
@@ -2756,27 +2838,6 @@ impl RotatePolytopesApp {
                 Ok(())
             },
         ));
-        // Top-level alias for `wireframe space`. The canonical control lives under
-        // `wireframe space` because the morph IS a wireframe-geometry property,
-        // but the spec's thesis demo is the one-keypress `space spherical`, so we
-        // also surface a thin top-level verb dispatching the SAME
-        // [`run_space_command`] handler. `cmd` passes `(args, ctx, out)` whereas
-        // the subcommand passes `(ctx, args, out)`; the closure just reorders.
-        c.register(
-            rye_egui::cmd(
-                "space",
-                "edge geometry: flat (R⁴ chords) | spherical (S³ arcs) | blend <t in [0,1]>",
-                |args: &[&str], demo: &mut Demo, out| {
-                    run_space_command(
-                        &mut demo.space_blend,
-                        &mut demo.wireframe_enabled,
-                        args,
-                        out,
-                    )
-                },
-            )
-            .with_args(&[&["flat", "spherical", "blend"]]),
-        );
         // Cross-section + parent-wireframe overlay. Tab-completion is context-aware
         // via [`SubcommandSet`]: each subcommand's value slot lists only that
         // subcommand's choices. Bare invocations flip:
@@ -2889,8 +2950,8 @@ impl RotatePolytopesApp {
                 )
                 .custom(
                     "perspective",
-                    "wireframe 4D->R³ projection (bare cycles): drop-w | w-depth | schlegel <cell> | stereographic | hyperslice",
-                    &[&["drop-w", "w-depth", "schlegel", "stereographic", "hyperslice"]],
+                    "wireframe 4D->R³ projection (bare cycles): shadow | w-pinhole | schlegel <cell> | stereographic | hyperslice",
+                    &[&["shadow", "w-pinhole", "schlegel", "stereographic", "hyperslice"]],
                     &[],
                     |d, args, out| {
                         let next = match args.first().copied() {
@@ -2944,11 +3005,15 @@ impl RotatePolytopesApp {
                             }
                             Some(token) => WireframeProjection::from_token(token).ok_or_else(|| {
                                 anyhow!(
-                                    "unknown projection `{token}` (try drop-w|w-depth|schlegel|stereographic|hyperslice)"
+                                    "unknown projection `{token}` (try shadow|w-pinhole|schlegel|stereographic|hyperslice)"
                                 )
                             })?,
                         };
                         d.wireframe_projection = next;
+                        state::apply_projection_selection_defaults(
+                            d.wireframe_projection,
+                            &mut d.wireframe_enabled,
+                        );
                         // Resolve + cache the Schlegel face-plane params now (at
                         // select time) so the per-frame upload never re-runs the
                         // LazyLock cell-table fit. No-op (clears the cache) for the
@@ -3025,20 +3090,6 @@ impl RotatePolytopesApp {
                             }
                         }
                         Ok(())
-                    },
-                )
-                .custom(
-                    "space",
-                    "edge geometry: flat (R⁴ chords) | spherical (S³ arcs) | blend <t in [0,1]>",
-                    &[&["flat", "spherical", "blend"]],
-                    &[],
-                    |d, args, out| {
-                        run_space_command(
-                            &mut d.space_blend,
-                            &mut d.wireframe_enabled,
-                            args,
-                            out,
-                        )
                     },
                 )
                 .custom(
@@ -4010,15 +4061,14 @@ mod blended_edge_tests {
     /// edge interior; the endpoints are shared by the flat chord and the S³ arc
     /// (the vertices already lie on the body's circumsphere), so the glue must be
     /// bit-exact at every t or the section cap would detach from the wireframe.
-    /// Walks a non-affine projection (Stereographic) so the subdivided path is
-    /// taken even at blend == 0, plus the blended path at several interior t.
+    /// Walks a stereographic projection: `blend == 0` takes the flat endpoint
+    /// chord path, while `blend > 0` takes the sampled spherical path.
     #[test]
     fn blend_endpoints_exact_at_all_t() {
         let a = Vec4::new(0.5, 0.5, 0.5, 0.5);
         let b = Vec4::new(-0.5, 0.5, 0.5, -0.5);
-        // Stereographic from the +w pole: non-affine, so even blend == 0 takes
-        // the subdivided `push_projected_chord` branch, and blend > 0 takes the
-        // slerp branch. Both must still glue the endpoints exactly.
+        // Stereographic from the +w pole: zero blend is one endpoint chord, and
+        // blend > 0 takes the sampled path. Both must still glue the endpoints.
         let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
         let body_pos = Vec3::new(-0.25, 1.5, 0.0);
         let expected_a = project_to_world(a, &proj, body_pos).to_array();
@@ -4052,154 +4102,11 @@ mod blended_edge_tests {
 }
 
 #[cfg(test)]
-mod space_command_tests {
-    //! Tests for the flat<->spherical morph control surfaced two ways: the
-    //! Render-modal Curvature slider and the `wireframe space` / top-level
-    //! `space` console verbs. Both write the same `space_blend` field; these
-    //! pin that the field is written and clamped identically across surfaces.
+mod section_command_tests {
+    //! Tests for shared console handlers unit-testable without a GPU-backed
+    //! `Demo` by exercising the handler body directly.
     use super::*;
-    use rye_app::egui;
     use rye_egui::console::ConsoleWriter;
-    use std::cell::Cell;
-
-    /// Render the modal's Curvature slider headless against `seed` and return the
-    /// value it leaves behind. `__run_test_ui` hands the closure a `Fn` context
-    /// (no `&mut` captures), so the bound value lives in a `Cell` driven through
-    /// `Slider::from_get_set`; this is behaviorally the same widget the modal
-    /// builds via `Slider::new(&mut space_blend, 0.0..=1.0)` (which itself
-    /// desugars to `from_get_set` over the field) with the same range and the
-    /// default `SliderClamping::Always`.
-    fn slider_clamped(seed: f32) -> f32 {
-        let cell = Cell::new(seed as f64);
-        egui::__run_test_ui(|ui| {
-            ui.add(egui::Slider::from_get_set(0.0..=1.0, |v: Option<f64>| {
-                if let Some(v) = v {
-                    cell.set(v);
-                }
-                cell.get()
-            }));
-        });
-        cell.get() as f32
-    }
-
-    /// The modal Curvature slider writes `space_blend` and clamps it to [0, 1].
-    /// The default `SliderClamping::Always` re-clamps the bound value to the
-    /// range on every render (egui 0.33, `Slider::add_contents` calls
-    /// `set_value(old_value)` when clamping is `Always`), so rendering the widget
-    /// once against an out-of-range seed must pull the field back into [0, 1].
-    #[test]
-    fn space_blend_slider_writes_field() {
-        assert_eq!(slider_clamped(5.0), 1.0, "above-range value clamps to 1.0");
-        assert_eq!(slider_clamped(-3.0), 0.0, "below-range value clamps to 0.0");
-        assert_eq!(
-            slider_clamped(0.375),
-            0.375,
-            "in-range value is preserved exactly"
-        );
-    }
-
-    /// `space spherical` (top-level alias) and `wireframe space spherical`
-    /// (canonical subcommand) move `space_blend` to the same value, because both
-    /// registrations dispatch the single shared `run_space_command` handler.
-    /// Driving the registered console for each path needs a GPU-backed `Demo`
-    /// ctx, which a unit test cannot build; instead this exercises the shared
-    /// handler directly (the exact `&mut space_blend` both call sites pass),
-    /// which IS the aliasing guarantee: the two verbs cannot diverge while they
-    /// share this function. Covers every verb plus the clamp rejection.
-    #[test]
-    fn space_toplevel_aliases_wireframe_space() {
-        // Seed the wireframe ON so this test isolates the blend mutation from the
-        // auto-enable behavior (covered separately by
-        // `space_command_enables_wireframe_for_visible_morph`).
-        let run = |start: f32, args: &[&str]| -> f32 {
-            let mut blend = start;
-            let mut wireframe = true;
-            let mut out = ConsoleWriter::new();
-            run_space_command(&mut blend, &mut wireframe, args, &mut out)
-                .expect("handler is infallible");
-            blend
-        };
-
-        assert_eq!(run(0.4, &["spherical"]), 1.0, "spherical -> 1.0");
-        assert_eq!(run(0.4, &["flat"]), 0.0, "flat -> 0.0");
-        assert_eq!(run(0.4, &["blend", "0.625"]), 0.625, "blend t -> t");
-
-        // Bare query and unknown/invalid args must NOT mutate the field.
-        assert_eq!(run(0.4, &[]), 0.4, "bare query leaves blend untouched");
-        assert_eq!(run(0.4, &["nonsense"]), 0.4, "unknown verb is inert");
-        assert_eq!(
-            run(0.4, &["blend", "9.0"]),
-            0.4,
-            "out-of-range blend is rejected, not clamped silently"
-        );
-        assert_eq!(
-            run(0.4, &["blend", "notafloat"]),
-            0.4,
-            "unparseable blend is rejected"
-        );
-    }
-
-    /// The morph is read ONLY by the wireframe overlay, which the frame loop
-    /// skips while `wireframe_enabled` is false (the default). So a verb that
-    /// sets a NON-ZERO blend must also turn the wireframe on, or the headline
-    /// `space spherical` keypress mutates a field nothing draws. This pins that
-    /// invariant per verb, and the inverse: verbs that leave the geometry flat
-    /// (`flat`, `blend 0`, bare query, rejected input) never flip the overlay,
-    /// since zero blend is the default geometry and the user may have the
-    /// wireframe up (or deliberately down) for unrelated reasons.
-    #[test]
-    fn space_command_enables_wireframe_for_visible_morph() {
-        // Returns the wireframe-enabled flag after running `args` against a
-        // wireframe that started OFF (the demo default).
-        let wireframe_after = |args: &[&str]| -> bool {
-            let mut blend = 0.0_f32;
-            let mut wireframe = false;
-            let mut out = ConsoleWriter::new();
-            run_space_command(&mut blend, &mut wireframe, args, &mut out)
-                .expect("handler is infallible");
-            wireframe
-        };
-
-        // Non-zero blend is invisible without the overlay: auto-enable it.
-        assert!(
-            wireframe_after(&["spherical"]),
-            "`space spherical` must enable the wireframe so the arcs show"
-        );
-        assert!(
-            wireframe_after(&["blend", "0.5"]),
-            "`space blend 0.5` (positive) must enable the wireframe"
-        );
-
-        // Flat geometry must not silently flip the overlay on.
-        assert!(
-            !wireframe_after(&["flat"]),
-            "`space flat` is the default geometry; it must not enable the wireframe"
-        );
-        assert!(
-            !wireframe_after(&["blend", "0"]),
-            "`space blend 0` is flat; it must not enable the wireframe"
-        );
-        assert!(
-            !wireframe_after(&[]),
-            "bare query must not touch the overlay"
-        );
-        assert!(
-            !wireframe_after(&["blend", "9.0"]),
-            "rejected (out-of-range) blend must not touch the overlay"
-        );
-
-        // A wireframe the user already turned ON stays on through `flat`: the
-        // morph control must never force the overlay OFF.
-        let mut blend = 1.0_f32;
-        let mut wireframe = true;
-        let mut out = ConsoleWriter::new();
-        run_space_command(&mut blend, &mut wireframe, &["flat"], &mut out)
-            .expect("handler is infallible");
-        assert!(
-            wireframe,
-            "`space flat` must not force an enabled wireframe off"
-        );
-    }
 
     /// `run_section_alpha` is the shared handler behind both `section cross-alpha`
     /// and `section cap-alpha`. It must: set a visible alpha in range, accept `0`
@@ -5110,14 +5017,7 @@ mod section_cap_projection_tests {
             None
         );
         assert_eq!(
-            perspective_scale_at_w(
-                0.0,
-                &rye_math::Projection::Schlegel {
-                    cell_normal: Vec4::W,
-                    cell_offset: 0.5,
-                    viewpoint_distance: 0.75,
-                }
-            ),
+            perspective_scale_at_w(0.0, &rye_math::Projection::schlegel(Vec4::W, 0.5, 0.75)),
             None
         );
     }
@@ -5196,82 +5096,54 @@ mod section_cap_projection_tests {
         }
     }
 
-    /// `projection_is_affine` is true exactly for the chord-to-chord projections
-    /// (Identity / Orthographic / Perspective4D) and false for the curving ones
-    /// (Schlegel / Stereographic). This is the predicate the wireframe edge builder
-    /// branches on to decide between a single straight segment and a subdivided
-    /// polyline; it must agree with `perspective_scale_at_w`'s `Some`/`None` split,
-    /// since both encode the same affine/non-affine distinction.
+    /// Edge-line preservation, flat endpoint chords, and section-cap scalar
+    /// shortcuts are separate questions. Schlegel preserves straight edges but
+    /// still needs per-vertex cap projection. Stereographic does not preserve a
+    /// sampled chord interior, but its flat wireframe mode is an endpoint-chord
+    /// comparison overlay.
     #[test]
-    fn projection_affine_classification_matches_scale_shim() {
-        let cases = [
-            rye_math::Projection::Identity,
-            rye_math::Projection::Orthographic { drop_axis: 3 },
-            rye_math::Projection::Perspective4D {
-                focal_distance: 2.0,
-            },
-            rye_math::Projection::Schlegel {
-                cell_normal: Vec4::W,
-                cell_offset: 0.5,
-                viewpoint_distance: 0.75,
-            },
-            rye_math::Projection::Stereographic { pole: Vec4::W },
-        ];
-        for proj in cases {
-            assert_eq!(
-                projection_is_affine(&proj),
-                perspective_scale_at_w(0.0, &proj).is_some(),
-                "affine flag must match the scale-shim Some/None split for {proj:?}"
-            );
-        }
-        assert!(projection_is_affine(&rye_math::Projection::Identity));
-        assert!(!projection_is_affine(
-            &rye_math::Projection::Stereographic { pole: Vec4::W }
-        ));
+    fn flat_edge_chord_policy_splits_from_cap_scale_policy() {
+        let schlegel = rye_math::Projection::schlegel(Vec4::W, 0.5, 0.75);
+        assert_eq!(
+            perspective_scale_at_w(0.0, &schlegel),
+            None,
+            "Schlegel cap vertices need per-vertex projection"
+        );
+        assert!(
+            projection_maps_chords_to_lines(&schlegel),
+            "Schlegel central projection preserves straight edges"
+        );
+        assert!(
+            flat_edge_uses_endpoint_chord(&schlegel),
+            "flat Schlegel wireframe edges render as one chord"
+        );
+
+        let stereo = rye_math::Projection::Stereographic { pole: Vec4::W };
+        assert_eq!(
+            perspective_scale_at_w(0.0, &stereo),
+            None,
+            "stereographic cap vertices need per-vertex projection"
+        );
+        assert!(
+            !projection_maps_chords_to_lines(&stereo),
+            "stereographic does not preserve a sampled chord interior"
+        );
+        assert!(
+            flat_edge_uses_endpoint_chord(&stereo),
+            "flat stereographic wireframe edges render as comparison chords"
+        );
     }
 
-    /// The repair invariant: under a non-affine projection (Stereographic), the
-    /// parent wireframe edge built by `push_blended_edge` is subdivided so the
-    /// screen polyline follows the projected curve, and a section-cap vertex (the
-    /// edge's slice intersection, projected per-vertex through
-    /// `cap_vertex_projected_and_world`)
-    /// lands ON that polyline. The pre-repair single straight chord between the two
-    /// projected endpoints missed the cap by a measurable margin (~0.17 R³ units for
-    /// a unit-circumradius tesseract w-edge under the `+w`-pole map); the test
-    /// asserts the subdivided polyline closes that gap to well under the chord error.
-    ///
-    /// Uses a generic polytope edge whose endpoints differ in the spatial axes too
-    /// (not a pure radial w-edge, whose projected endpoints stay collinear with the
-    /// cap and would hide the defect), so the stereographic image genuinely bows off
-    /// the chord. `body_pos = ZERO` so the comparison is in the projection's own
-    /// frame.
+    /// Zero-blend stereographic is the comparison overlay: project endpoints,
+    /// then draw the R3 chord between them. The faithful S3 edge is sampled at
+    /// blend one.
     #[test]
-    fn stereographic_wireframe_polyline_tracks_section_cap() {
+    fn stereographic_zero_blend_is_endpoint_chord_overlay() {
         let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
         let body_pos = Vec3::ZERO;
-        let w_slice = 0.0;
-        // Endpoints straddling `w = 0` with distinct spatial coords; the slice cuts
-        // the edge at a non-midpoint, away from any radial special case.
         let a = Vec4::new(0.30, 0.60, 0.20, 0.50);
         let b = Vec4::new(0.70, 0.10, 0.40, -0.30);
-        // Section cap vertex: the edge's true intersection with `w = w_slice`.
-        // `edge_section` returns its drop-w R³; `cap_vertex_projected_and_world`
-        // reconstructs it at `w_slice` and projects per-vertex (the non-affine path).
-        let t_cut = (w_slice - a.w) / (b.w - a.w);
-        let cut = a.lerp(b, t_cut);
-        let cap_r3 = [cut.x, cut.y, cut.z];
-        let scale = perspective_scale_at_w(w_slice, &proj);
-        assert_eq!(
-            scale, None,
-            "Stereographic must take the per-vertex cap path"
-        );
-        let cap = Vec3::from_array(
-            cap_vertex_projected_and_world(cap_r3, w_slice, scale, &proj, body_pos).1,
-        );
 
-        // Build the parent wireframe edge through the real code path (flat space:
-        // blend = 0). Under Stereographic this routes to `push_projected_chord`, so
-        // `mesh` holds SPACE_TESSELLATION_SAMPLES sub-segments, not one chord.
         let mut mesh = LineMesh::<3>::default();
         let mut scratch = Vec::new();
         let white = [1.0, 1.0, 1.0, 1.0];
@@ -5287,36 +5159,54 @@ mod section_cap_projection_tests {
             body_pos,
             &mut scratch,
         );
-        assert!(
-            mesh.segments.len() > 1,
-            "non-affine flat edge must subdivide, got {} segment(s)",
-            mesh.segments.len()
+        assert_eq!(
+            mesh.segments.len(),
+            1,
+            "zero-blend stereographic should be one endpoint chord"
         );
-
-        // Min distance from the cap vertex to the polyline (any sub-segment).
-        let poly_gap = mesh
-            .segments
-            .iter()
-            .map(|(s, e)| {
-                point_to_segment_distance(cap, Vec3::from_array(*s), Vec3::from_array(*e))
-            })
-            .fold(f32::INFINITY, f32::min);
-
-        // The pre-repair single chord between the two projected endpoints.
-        let pa = project_to_world(a, &proj, body_pos);
-        let pb = project_to_world(b, &proj, body_pos);
-        let chord_gap = point_to_segment_distance(cap, pa, pb);
-
-        // The defect (single chord) misses the cap by a real margin; the repaired
-        // polyline tracks it. The chord error for this edge is ~0.16; require the
-        // polyline to beat it by more than 10x and sit near the sampling floor.
-        assert!(
-            chord_gap > 0.05,
-            "expected the single-chord defect to miss the cap, gap {chord_gap}"
+        assert_eq!(
+            scratch.len(),
+            0,
+            "zero-blend stereographic should not use the slerp scratch"
         );
-        assert!(
-            poly_gap < chord_gap * 0.1,
-            "subdivided polyline must track the cap: poly_gap {poly_gap} vs chord_gap {chord_gap}"
+        let expected_a = project_to_world(a, &proj, body_pos).to_array();
+        let expected_b = project_to_world(b, &proj, body_pos).to_array();
+        assert_eq!(mesh.segments[0].0, expected_a);
+        assert_eq!(mesh.segments[0].1, expected_b);
+    }
+
+    /// Schlegel is not affine for cap scaling, but it is a central projection:
+    /// flat R⁴ edges map to straight R³ chords. This catches the old
+    /// "non-affine == must subdivide" mistake.
+    #[test]
+    fn schlegel_flat_wireframe_edge_is_endpoint_chord() {
+        let proj = rye_math::Projection::schlegel(Vec4::W, 0.5, 1.0);
+        assert_eq!(perspective_scale_at_w(0.0, &proj), None);
+        let a = Vec4::new(0.25, 0.50, -0.25, 0.50);
+        let b = Vec4::new(-0.25, 0.50, -0.25, -0.50);
+        let mut mesh = LineMesh::<3>::default();
+        let mut scratch = Vec::new();
+        let white = [1.0, 1.0, 1.0, 1.0];
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            white,
+            white,
+            1.0,
+            0.0,
+            &proj,
+            Vec3::ZERO,
+            &mut scratch,
+        );
+        assert_eq!(mesh.segments.len(), 1, "Schlegel edge is one chord");
+        assert_eq!(
+            mesh.segments[0].0,
+            project_to_world(a, &proj, Vec3::ZERO).to_array()
+        );
+        assert_eq!(
+            mesh.segments[0].1,
+            project_to_world(b, &proj, Vec3::ZERO).to_array()
         );
     }
 
@@ -5389,11 +5279,7 @@ mod section_cap_projection_tests {
                 focal_distance: 2.0,
             },
             rye_math::Projection::Stereographic { pole: Vec4::W },
-            rye_math::Projection::Schlegel {
-                cell_normal: Vec4::W,
-                cell_offset: 0.5,
-                viewpoint_distance: 0.9,
-            },
+            rye_math::Projection::schlegel(Vec4::W, 0.5, 0.9),
         ];
 
         // Honest layer (drop-w): the world cap is the body-local cap scaled by 1
@@ -5541,11 +5427,7 @@ mod section_cap_projection_tests {
             rye_math::Projection::Perspective4D {
                 focal_distance: 2.0,
             },
-            rye_math::Projection::Schlegel {
-                cell_normal: Vec4::W,
-                cell_offset: 0.5,
-                viewpoint_distance: 0.75,
-            },
+            rye_math::Projection::schlegel(Vec4::W, 0.5, 0.75),
         ] {
             assert_eq!(
                 stereographic_clip_radius(&proj),
@@ -5558,7 +5440,11 @@ mod section_cap_projection_tests {
     /// Build the parent wireframe edge `a -> b` under the `+w`-pole stereographic
     /// projection with `body_pos = ZERO`, so each emitted endpoint's world coord
     /// equals its body-local projected point. Returns the segment endpoints.
-    fn build_stereographic_edge(a: Vec4, b: Vec4) -> Vec<([f32; 3], [f32; 3])> {
+    fn build_stereographic_edge_with_blend(
+        a: Vec4,
+        b: Vec4,
+        blend: f32,
+    ) -> Vec<([f32; 3], [f32; 3])> {
         let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
         let mut mesh = LineMesh::<3>::default();
         let mut scratch = Vec::new();
@@ -5570,12 +5456,20 @@ mod section_cap_projection_tests {
             white,
             white,
             1.0,
-            0.0,
+            blend,
             &proj,
             Vec3::ZERO,
             &mut scratch,
         );
         mesh.segments
+    }
+
+    fn build_stereographic_edge(a: Vec4, b: Vec4) -> Vec<([f32; 3], [f32; 3])> {
+        build_stereographic_edge_with_blend(a, b, 0.0)
+    }
+
+    fn build_spherical_stereographic_edge(a: Vec4, b: Vec4) -> Vec<([f32; 3], [f32; 3])> {
+        build_stereographic_edge_with_blend(a, b, 1.0)
     }
 
     /// A unit point at angular distance `theta_deg` from the `+w` pole, in the
@@ -5585,6 +5479,24 @@ mod section_cap_projection_tests {
         Vec4::new(t.sin(), 0.0, 0.0, t.cos())
     }
 
+    /// Zero-blend stereographic is an endpoint chord overlay. If either endpoint
+    /// clips out near the pole, the flat chord drops; the sampled S3 path can
+    /// still resume after its clipped samples.
+    #[test]
+    fn stereographic_zero_blend_near_pole_uses_endpoint_clip() {
+        let zero = build_stereographic_edge(near_pole(1.0), Vec4::new(1.0, 0.0, 0.0, 0.0));
+        let spherical =
+            build_spherical_stereographic_edge(near_pole(1.0), Vec4::new(1.0, 0.0, 0.0, 0.0));
+        assert!(
+            zero.is_empty(),
+            "flat near-pole chord should drop when an endpoint clips out"
+        );
+        assert!(
+            !spherical.is_empty(),
+            "sampled S3 edge should resume after clipped near-pole samples"
+        );
+    }
+
     /// Boundedness: every emitted endpoint of a stereographic wireframe edge has
     /// body-local projected magnitude <= `STEREOGRAPHIC_VIEW_RADIUS`, even for an
     /// edge that grazes the pole. The edge runs from 1 degree off the pole (well
@@ -5592,7 +5504,8 @@ mod section_cap_projection_tests {
     /// drops the near-pole samples, so no emitted endpoint carries the blow-up.
     #[test]
     fn stereographic_clip_output_bounded_by_radius() {
-        let segs = build_stereographic_edge(near_pole(1.0), Vec4::new(1.0, 0.0, 0.0, 0.0));
+        let segs =
+            build_spherical_stereographic_edge(near_pole(1.0), Vec4::new(1.0, 0.0, 0.0, 0.0));
         assert!(
             !segs.is_empty(),
             "edge must emit at least one in-bounds segment"
@@ -5609,36 +5522,111 @@ mod section_cap_projection_tests {
         }
     }
 
-    /// The discriminating test the radius-clamp alternative fails: the clip is a
-    /// DROP, not a magnitude rescale. A pole-grazing edge tessellated into
-    /// `SPACE_TESSELLATION_SAMPLES` sub-segments must emit FEWER than that many
-    /// segments (the near-pole ones are dropped). A radius clamp would rescale the
-    /// offending samples back onto a sphere of radius `R` and keep every segment,
-    /// preserving the 180-degree direction flip across a pole crossing; this
-    /// asserts segments genuinely vanish, so the implementation cannot quietly be
-    /// a clamp. Also asserts no retained endpoint sits at the clamp ring (no
-    /// emitted endpoint within a hair of `R`), which a clamp would manufacture.
+    /// The clip cuts a straddling sub-segment AT the view boundary and DROPS a
+    /// sub-segment whose interior runs deep through the pole; it is neither a
+    /// whole-segment drop nor a magnitude rescale. The fixture is an edge whose
+    /// great-circle interior passes straight through the `+w` pole (endpoints 5
+    /// degrees off the pole on opposite sides), so the deep-pole samples blow up
+    /// while both endpoints stay well inside `R`. Three guarantees:
+    ///
+    /// 1. **Boundary cut, not stop-short.** Some emitted endpoint sits within a
+    ///    hair of `R`: the straddling sub-segment is cut to the clip sphere, so
+    ///    the arc reaches the boundary instead of stopping at the last in-radius
+    ///    tessellation sample (the old whole-segment drop left the tip at a random
+    ///    interior sample, the source of the near-pole "bounce").
+    /// 2. **Deep-pole drop, not rescale.** The polyline still has a GAP (fewer
+    ///    than `SPACE_TESSELLATION_SAMPLES` segments): the both-outside samples
+    ///    straddling the pole are dropped, never bridged. A radius rescale-clamp
+    ///    would instead keep every sub-segment (pinned onto the sphere of radius
+    ///    `R`), preserving the 180-degree direction flip across the pole as a
+    ///    spurious segment sweeping the view; the gap proves we drop them.
+    /// 3. **Bounded.** Every emitted endpoint stays within `R`.
     #[test]
-    fn stereographic_clip_drops_segments_not_rescales() {
-        // Edge from 1 degree off the pole to the equator: the first samples sit
-        // inside the ~3.24-degree clip band (image magnitude > R) and are dropped.
-        let segs = build_stereographic_edge(near_pole(1.0), Vec4::new(1.0, 0.0, 0.0, 0.0));
+    fn stereographic_clip_cuts_to_boundary_and_drops_deep_pole() {
+        let r = STEREOGRAPHIC_VIEW_RADIUS;
+        // Endpoints 5 degrees off the pole on opposite sides of the w-x plane;
+        // their connecting great circle passes through the +w pole at its
+        // midpoint. The endpoints' image magnitude is cot(2.5 deg) ~ 22.9 < R, so
+        // they are kept, while the midpoint samples blow up past R.
+        let off = 5.0_f32.to_radians();
+        let a = Vec4::new(off.sin(), 0.0, 0.0, off.cos());
+        let b = Vec4::new(-off.sin(), 0.0, 0.0, off.cos());
+        let segs = build_spherical_stereographic_edge(a, b);
+        assert!(!segs.is_empty(), "kept endpoints must emit segments");
+
+        // (1) Boundary cut: an endpoint sits within a hair of R.
+        let max_extent = segs
+            .iter()
+            .flat_map(|(s, e)| [Vec3::from_array(*s).length(), Vec3::from_array(*e).length()])
+            .fold(0.0_f32, f32::max);
+        assert!(
+            (max_extent - r).abs() < 1e-2,
+            "straddling sub-segment must be cut to the boundary (max extent {max_extent}, R {r})"
+        );
+
+        // (2) Deep-pole drop: the through-pole samples vanish, leaving a gap.
         assert!(
             segs.len() < SPACE_TESSELLATION_SAMPLES,
-            "near-pole edge must drop sub-segments (got {} of {})",
+            "deep-pole samples must drop (got {} of {}); a rescale-clamp would keep them all",
             segs.len(),
             SPACE_TESSELLATION_SAMPLES
         );
-        // No retained endpoint sits on the clamp ring at radius ~R: a rescale
-        // clamp would pin the dropped samples there, a drop never does.
-        let r = STEREOGRAPHIC_VIEW_RADIUS;
+
+        // (3) Bounded.
         for (s, e) in &segs {
             for end in [Vec3::from_array(*s), Vec3::from_array(*e)] {
                 assert!(
-                    (end.length() - r).abs() > 0.5,
-                    "endpoint {end:?} sits on the clamp ring at radius {r}; clip must drop, not rescale"
+                    end.length() <= r + 1e-3,
+                    "endpoint {end:?} (|.| = {}) exceeds the bound {r}",
+                    end.length()
                 );
             }
+        }
+    }
+
+    /// The regression test for the 16-cell near-pole artifacts under `xw`
+    /// rotation: once a vertex is near the `+w` pole, the visible arc tip must sit
+    /// at the clip boundary and STAY there as the vertex sweeps closer, with no
+    /// popping (sample-granularity drop) and no diving toward the center (the
+    /// conformal map's denominator-clamp deflation). The fixture is the genuine
+    /// 16-cell edge `+e_w -> +e_y`: `+e_y` is FIXED by an `xw` rotation while
+    /// `+e_w` rotates toward the pole, so the arc tip is purely the near-pole end.
+    ///
+    /// The sweep walks `phi` from 3 deg (just past the view-radius crossing,
+    /// `cot(phi/2) = R` at `phi ~ 3.24 deg`, so `+e_w` is already beyond `R`) down
+    /// to 0.05 deg, deep inside the pole-denominator clamp band (`phi < ~0.8 deg`).
+    /// Across this whole regime the tip must hold the boundary `R` to within a
+    /// unit. Two prior defects each break this: the whole-segment drop left the tip
+    /// at the last in-radius sample (well below `R`), and the clamp-band deflation
+    /// dove the tip from `R` toward the origin below `phi ~ 0.2 deg` (a >30-unit
+    /// collapse). Both manifest as a tip far below `R` somewhere in the sweep.
+    #[test]
+    fn stereographic_clip_arc_tip_holds_boundary_near_pole() {
+        let r = STEREOGRAPHIC_VIEW_RADIUS;
+        // `xw` rotation of the +e_w -- +e_y edge by `phi`: e_w -> (-sin phi, 0, 0,
+        // cos phi) sweeps toward the pole; e_y = (0, 1, 0, 0) is fixed.
+        let tip_extent = |phi_deg: f32| -> f32 {
+            let phi = phi_deg.to_radians();
+            let a = Vec4::new(-phi.sin(), 0.0, 0.0, phi.cos());
+            let b = Vec4::new(0.0, 1.0, 0.0, 0.0);
+            build_spherical_stereographic_edge(a, b)
+                .iter()
+                .flat_map(|(s, e)| [Vec3::from_array(*s).length(), Vec3::from_array(*e).length()])
+                .fold(0.0_f32, f32::max)
+        };
+        // Geometric sweep so steps cluster near the pole, where the deflation dive
+        // strikes; every sample is in the beyond-R regime.
+        let samples = 60;
+        let hi = 3.0_f32.ln();
+        let lo = 0.05_f32.ln();
+        for step in 0..=samples {
+            let frac = step as f32 / samples as f32;
+            let phi = (hi + (lo - hi) * frac).exp();
+            let tip = tip_extent(phi);
+            assert!(
+                tip > r - 1.0 && tip <= r + 1e-2,
+                "near-pole arc tip must hold the boundary R={r} at phi={phi} deg, got {tip}"
+            );
         }
     }
 
@@ -5650,7 +5638,7 @@ mod section_cap_projection_tests {
     /// stereographic case.
     #[test]
     fn stereographic_pole_endpoint_edge_is_finite_and_bounded() {
-        let segs = build_stereographic_edge(Vec4::W, Vec4::new(1.0, 0.0, 0.0, 0.0));
+        let segs = build_spherical_stereographic_edge(Vec4::W, Vec4::new(1.0, 0.0, 0.0, 0.0));
         let r = STEREOGRAPHIC_VIEW_RADIUS;
         for (s, e) in &segs {
             for end in [Vec3::from_array(*s), Vec3::from_array(*e)] {
@@ -5666,19 +5654,19 @@ mod section_cap_projection_tests {
         }
     }
 
-    /// Non-perturbation off the pole: an edge well clear of the pole keeps every
-    /// sub-segment (nothing dropped) and each emitted endpoint equals the raw
-    /// `project_to_world` of the corresponding chord sample bit-for-bit. The clip
-    /// is a pure post-filter on already-projected samples; it must not move a
-    /// retained sample. This guards the conformal interior: the clip changes
-    /// nothing where the projection is well-behaved.
+    /// Non-perturbation off the pole: a spherical edge well clear of the pole
+    /// keeps every sub-segment (nothing dropped) and each emitted endpoint equals
+    /// the raw `project_to_world` of the corresponding great-circle sample
+    /// bit-for-bit. The clip is a pure post-filter on already-projected samples;
+    /// it must not move a retained sample. This guards the conformal interior:
+    /// the clip changes nothing where the projection is well-behaved.
     #[test]
     fn stereographic_clip_does_not_perturb_off_pole_edge() {
         let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
-        // An edge straddling w = 0, far from the +w pole on both ends.
-        let a = Vec4::new(0.30, 0.60, 0.20, 0.10);
-        let b = Vec4::new(0.70, 0.10, 0.40, -0.30);
-        let segs = build_stereographic_edge(a, b);
+        // A unit edge straddling w = 0, far from the +w pole on both ends.
+        let a = Vec4::new(0.30, 0.60, 0.20, 0.10).normalize();
+        let b = Vec4::new(0.70, 0.10, 0.40, -0.30).normalize();
+        let segs = build_spherical_stereographic_edge(a, b);
         assert_eq!(
             segs.len(),
             SPACE_TESSELLATION_SAMPLES,
@@ -5686,10 +5674,13 @@ mod section_cap_projection_tests {
         );
         // Reconstruct the un-clipped projected polyline directly and compare.
         let samples = SPACE_TESSELLATION_SAMPLES;
+        let mut arc = Vec::new();
+        <rye_math::SphericalS3Embedded as rye_math::RasterizableSpace<4>>::tessellate_segment(
+            a, b, samples, &mut arc,
+        );
         let mut prev = project_to_world(a, &proj, Vec3::ZERO).to_array();
-        for (k, seg) in segs.iter().enumerate() {
-            let s = (k + 1) as f32 / samples as f32;
-            let cur = project_to_world(a.lerp(b, s), &proj, Vec3::ZERO).to_array();
+        for (k, (seg, &sample)) in segs.iter().zip(arc.iter().skip(1)).enumerate() {
+            let cur = project_to_world(sample, &proj, Vec3::ZERO).to_array();
             assert_eq!(seg.0, prev, "segment {k} start must match raw projection");
             assert_eq!(seg.1, cur, "segment {k} end must match raw projection");
             prev = cur;
@@ -5779,8 +5770,9 @@ mod section_cap_projection_tests {
     /// The cap FILL drops a triangle touching a near-pole vertex and keeps a
     /// triangle whose vertices are all far from the pole, at TRIANGLE granularity:
     /// a fan triangle with one near-pole vertex vanishes entirely (its index
-    /// triple is removed), while a far fan keeps every triangle. Mirrors
-    /// `stereographic_clip_drops_segments_not_rescales` for the fill path.
+    /// triple is removed), while a far fan keeps every triangle. The fill clip is
+    /// a whole-triangle drop (no boundary cut), mirroring the deep-pole drop in
+    /// `stereographic_clip_cuts_to_boundary_and_drops_deep_pole` for the fill path.
     #[test]
     fn cap_fill_triangle_dropped_near_pole() {
         let r = STEREOGRAPHIC_VIEW_RADIUS;
@@ -5899,30 +5891,27 @@ mod section_cap_projection_tests {
         );
     }
 
-    /// The default-pole render path actually projects through the cell-center pole
-    /// (not `+w`), and the cap clip applies to it: a cap vertex near the cell
-    /// center is dropped, one far from it kept. Pins that
-    /// `resolved_wireframe_projection`'s pole substitution flows into the cap fill
-    /// without re-deriving the projection. Also a demo-level guard that the
-    /// conformal map is the pure rye-math primitive (an equatorial-ish cap vertex
-    /// far from any pole projects to a bounded, finite, kept point).
+    /// The default-pole render path projects through the `+w` pole, and the cap
+    /// clip applies to it: a cap vertex near `+w` is dropped, one far from it
+    /// kept. Pins that `resolved_wireframe_projection`'s pole substitution flows
+    /// into the cap fill without re-deriving the projection. Also a demo-level
+    /// guard that the conformal map is the pure rye-math primitive (a cap vertex
+    /// far from the pole projects to a bounded, finite, kept point).
     #[test]
-    fn cap_fill_uses_default_cell_center_pole() {
+    fn cap_fill_uses_default_plus_w_pole() {
         let proj = default_stereographic();
         let clip = stereographic_clip_radius(&proj);
-        // A 4D point in the cell-center pole's near neighborhood (NOT exactly on
-        // it: the pole itself maps to a small point because the perpendicular
-        // numerator vanishes there; the blow-up is in the punctured neighborhood).
-        // `(0.5, 0.5, 0.5, 0.49)` normalizes to dot ~ 0.99996 with the pole, image
-        // magnitude ~87, well past the ~35 radius, so it drops.
-        let near = cap_projected([0.5, 0.5, 0.5], 0.49, &proj);
+        // A 4D point in the +w pole's near neighborhood: `(0.05, 0, 0, 1.0)`
+        // normalizes to dot ~ 0.99875 with +w, image magnitude ~40, past the
+        // ~35 radius, so it drops.
+        let near = cap_projected([0.05, 0.0, 0.0], 1.0, &proj);
         assert!(
             !sample_in_radius(near, clip),
-            "cap vertex near the cell-center pole (|.| = {}) must drop",
+            "cap vertex near the +w pole (|.| = {}) must drop",
             near.length()
         );
-        // A point far from the cell-center direction (negative lanes) stays
-        // bounded and finite, the pure conformal image, and is kept.
+        // A point far from +w (w = 0) stays bounded and finite, the pure
+        // conformal image, and is kept.
         let far = cap_projected([-0.4, -0.3, 0.2], 0.0, &proj);
         assert!(
             far.is_finite() && sample_in_radius(far, clip),

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -86,36 +86,72 @@ const SECTION_FACES_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Dep
 /// large-but-finite rather than dividing by zero.
 const PERSPECTIVE_SCALE_DENOM_EPSILON: f32 = 1e-4;
 
-/// Body-local projected radius past which a stereographic sample is treated as
-/// the conformal point at infinity and cut from the rendered polyline (the arc
-/// runs out to this radius; samples beyond it are the near-pole blow-up).
+/// Fraction of the live camera-to-body distance used as the stereographic arc
+/// clip radius (see [`stereographic_view_radius`]).
 ///
-/// **The cap must sit below the camera distance.** A stereographic near-pole edge
-/// images to an arc that runs off toward infinity; the cap bounds it at this
-/// world radius. The wireframe is centered near the orbit target, and the camera
-/// orbits it at [`OrbitController`]'s distance (the demo's default is `9.5`, the
-/// minimum `1.5`). If the cap exceeds the camera distance, an arc endpoint at
-/// radius `R` in the camera's direction lands AT or BEHIND the eye, and the
+/// **The clip must sit below the camera distance.** A stereographic near-pole
+/// edge images to an arc that runs off toward infinity; the clip bounds it at a
+/// world radius. If that radius exceeds the camera's distance to the figure, an
+/// arc endpoint in the camera's direction lands AT or BEHIND the eye, and the
 /// perspective projection of a point grazing the eye plane is hyper-sensitive: a
 /// small rotation step swings its screen image from the far edge (a "long" arc)
 /// to a finite on-screen point (a "short" arc), the long/short rubberband. The
 /// engine's near-plane line clip (`line_raster.wgsl`) removes the sign-flip
-/// *width* artifact of a behind-eye endpoint, but it cannot remove this
-/// *length* discontinuity, which is inherent to an extended arc reaching past a
-/// close camera. Keeping `R` comfortably below the orbit distance keeps every arc
-/// endpoint well in front of the eye, so the projection stays smooth and bounded
-/// and the arc has no way to graze the camera plane.
+/// *width* artifact of a behind-eye endpoint, but it cannot remove this *length*
+/// discontinuity, which is inherent to an extended arc reaching past a close
+/// camera. Tying the radius to a fraction `< 1` of the live camera distance keeps
+/// every arc endpoint in front of the eye at ANY zoom (the zoom-robust property)
+/// when zooming in (the zoom-robust property). On zoom-OUT the radius is held at
+/// [`STEREOGRAPHIC_VIEW_RADIUS_MAX`] rather than growing without bound, which also
+/// brings the arcs on-screen (their NDC shrinks) so a pulled-back camera frames a
+/// larger shape's full arc halo.
 ///
-/// `6.0` sits below the default `9.5` orbit (nearest approach to the eye `~3.5`,
-/// a gentle off-axis sweep) and far above the legitimate image extent of a
-/// unit-circumradius polytope (a `w = 0.5` vertex maps to radius `~1.7`), so real
-/// geometry is never clipped while the near-pole arcs read as an extended halo
-/// rather than offscreen-bouncing infinities. It is also well under the
-/// pole-clamp ceiling `sqrt(2 / eps)` (~141), so the near-pole blow-up still
-/// reliably exceeds it. NOTE: not yet adaptive to zoom; a zoom-in past `R` would
-/// reintroduce the grazing sweep (the near-plane clip still prevents the width
-/// artifact). Pinned by `stereographic_view_radius_below_camera_distance`.
-const STEREOGRAPHIC_VIEW_RADIUS: f32 = 6.0;
+/// `0.75` leaves a nearest-approach margin of `0.25 ×` the camera distance (a
+/// gentle off-axis sweep, never a graze); at an 8-unit camera distance it yields
+/// ~6.0, the eyes-on-confirmed extent (the test reference `STEREOGRAPHIC_VIEW_RADIUS`).
+const STEREOGRAPHIC_VIEW_RADIUS_FRACTION: f32 = 0.75;
+
+/// Floor on the stereographic clip radius, so a close zoom never clips the figure
+/// itself: a unit-circumradius polytope's legitimate image reaches radius `~1.7`
+/// (a `w = 0.5` vertex), so the clip is held at least this far out. When the
+/// camera is nearer than `~3.3` units the floor can exceed the camera distance
+/// (the user is essentially inside the figure); the near-plane line clip is the
+/// backstop there.
+const STEREOGRAPHIC_VIEW_RADIUS_FLOOR: f32 = 2.5;
+
+/// Ceiling on the stereographic clip radius. Beyond this the arc would be drawn
+/// deep into the steep near-pole region, where the fixed-count
+/// [`SPACE_TESSELLATION_SAMPLES`] arc sampling (uniform in 4D arc-angle) is far
+/// too coarse for the nonlinear projection: consecutive samples jump several-fold
+/// in image magnitude, so the rendered arc facets into long straight chords
+/// (jagged) and those chords twitch as rotation shifts which sample brackets the
+/// boundary (the bounce). Capping at `6.0` keeps the arc in the gentle region
+/// where the 16 samples read as a smooth curve, and matches the eyes-on-confirmed
+/// extent. To let arcs extend further AND stay smooth, raise this together with
+/// the arc sample count (or subdivide adaptively by projected segment length).
+const STEREOGRAPHIC_VIEW_RADIUS_MAX: f32 = 6.0;
+
+/// Reference clip radius for tests (which have no live camera): the value
+/// [`stereographic_view_radius`] yields at an 8-unit camera distance and beyond
+/// (where it saturates at [`STEREOGRAPHIC_VIEW_RADIUS_MAX`]). Eyes-on-confirmed to
+/// kill the rubberband while keeping the near-pole arcs a smooth extended halo.
+/// The live render path uses the camera-adaptive [`stereographic_view_radius`]
+/// instead, so this is compiled only for tests.
+#[cfg(test)]
+const STEREOGRAPHIC_VIEW_RADIUS: f32 = STEREOGRAPHIC_VIEW_RADIUS_MAX;
+
+/// Camera-adaptive stereographic clip radius: a fraction of the live distance
+/// from the eye to the figure, clamped to `[FLOOR, MAX]`. The fraction keeps it
+/// below the camera distance so zoom-in never rubberbands; the MAX ceiling keeps
+/// it out of the under-tessellated steep near-pole region so zoom-out never
+/// jaggeds or bounces (see [`STEREOGRAPHIC_VIEW_RADIUS_MAX`]); the floor keeps the
+/// figure itself from being clipped at close range.
+fn stereographic_view_radius(camera_distance: f32) -> f32 {
+    (camera_distance * STEREOGRAPHIC_VIEW_RADIUS_FRACTION).clamp(
+        STEREOGRAPHIC_VIEW_RADIUS_FLOOR,
+        STEREOGRAPHIC_VIEW_RADIUS_MAX,
+    )
+}
 
 /// Cap on the reconstructed near-pole image magnitude (see `near_pole_view_point`).
 /// A point within the pole-denominator clamp band is a point-at-infinity; the
@@ -123,23 +159,26 @@ const STEREOGRAPHIC_VIEW_RADIUS: f32 = 6.0;
 /// origin, so the wireframe builder substitutes the true magnitude
 /// `sqrt((1 + dot) / (1 - dot))` in the same projected direction. That true
 /// magnitude diverges at the pole, so it is capped here purely for f32 safety:
-/// `1e4` is far above `STEREOGRAPHIC_VIEW_RADIUS` (so the sample reliably clips
-/// out) and far below any value that would lose precision in the segment/sphere
-/// boundary solve (`1e4^2 = 1e8`, comfortably inside f32's exact-integer range).
+/// `1e4` is far above any camera-adaptive view radius (so the sample reliably
+/// clips out) and far below any value that would lose precision in the
+/// segment/sphere boundary solve (`1e4^2 = 1e8`, inside f32's exact-integer range).
 const STEREOGRAPHIC_POLE_FAR_CAP: f32 = 1.0e4;
 
-/// Body-local projected-radius clip for a `projection`, or `None` when the
-/// projection needs no clip. Only [`rye_math::Projection::Stereographic`] has a
-/// genuine point-at-infinity in its image (a vertex on the pole), so it is the
-/// only projection whose near-singularity samples are dropped; the affine
-/// projections and Schlegel's bounded-finite clamp keep every sample. The test
-/// compares the magnitude of the *pre-translate* projected point (the conformal
-/// image about the body's own center), which is invariant to the body's R³
-/// position and the camera, so the same 4D edge clips identically at every row
-/// slot and zoom.
-fn stereographic_clip_radius(projection: &rye_math::Projection<4>) -> Option<f32> {
+/// Body-local projected-radius clip for a `projection` at the given per-frame
+/// `view_radius`, or `None` when the projection needs no clip. Only
+/// [`rye_math::Projection::Stereographic`] has a genuine point-at-infinity in its
+/// image (a vertex on the pole), so it is the only projection whose
+/// near-singularity samples are clipped; the affine projections and Schlegel's
+/// bounded-finite clamp keep every sample. `view_radius` is the camera-adaptive
+/// [`stereographic_view_radius`] in the live render path (tests pass the fixed
+/// [`STEREOGRAPHIC_VIEW_RADIUS`]); it is a body-local radius, so the same 4D edge
+/// clips identically at every row slot regardless of the body's R³ position.
+fn stereographic_clip_radius(
+    projection: &rye_math::Projection<4>,
+    view_radius: f32,
+) -> Option<f32> {
     match *projection {
-        rye_math::Projection::Stereographic { .. } => Some(STEREOGRAPHIC_VIEW_RADIUS),
+        rye_math::Projection::Stereographic { .. } => Some(view_radius),
         rye_math::Projection::Identity
         | rye_math::Projection::Orthographic { .. }
         | rye_math::Projection::Perspective4D { .. }
@@ -359,9 +398,10 @@ fn push_projected_chord(
     width: f32,
     projection: &rye_math::Projection<4>,
     body_pos_r3: Vec3,
+    view_radius: f32,
 ) {
     let samples = SPACE_TESSELLATION_SAMPLES;
-    let clip_radius = stereographic_clip_radius(projection);
+    let clip_radius = stereographic_clip_radius(projection, view_radius);
     // Seed from sample 0 (`a` exactly). `sample_at` returns the pre-translate
     // projected point (for the clip test) and the world point (for the mesh).
     let sample_at = |p4: Vec4| {
@@ -650,12 +690,13 @@ fn push_blended_edge(
     projection: &rye_math::Projection<4>,
     body_pos_r3: Vec3,
     slerp_scratch: &mut Vec<Vec4>,
+    view_radius: f32,
 ) {
     // Flat edge: one straight R3 chord per polytope edge. For stereographic this
     // is a comparison overlay, not the S3 great-circle image.
     if blend <= 0.0 {
         if flat_edge_uses_endpoint_chord(projection) {
-            let clip_radius = stereographic_clip_radius(projection);
+            let clip_radius = stereographic_clip_radius(projection, view_radius);
             let a3_local = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
                 a, projection,
             );
@@ -673,7 +714,17 @@ fn push_blended_edge(
             return;
         }
         // Future non-line-preserving flat projection: sample the R⁴ chord.
-        push_projected_chord(mesh, a, b, color_a, color_b, width, projection, body_pos_r3);
+        push_projected_chord(
+            mesh,
+            a,
+            b,
+            color_a,
+            color_b,
+            width,
+            projection,
+            body_pos_r3,
+            view_radius,
+        );
         return;
     }
 
@@ -686,7 +737,7 @@ fn push_blended_edge(
         // circumradius `body_size`), but route through the same flat-edge chord
         // policy so degenerate inputs don't invent spherical samples.
         if flat_edge_uses_endpoint_chord(projection) {
-            let clip_radius = stereographic_clip_radius(projection);
+            let clip_radius = stereographic_clip_radius(projection, view_radius);
             let a3_local = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
                 a, projection,
             );
@@ -703,12 +754,22 @@ fn push_blended_edge(
             }
             return;
         }
-        push_projected_chord(mesh, a, b, color_a, color_b, width, projection, body_pos_r3);
+        push_projected_chord(
+            mesh,
+            a,
+            b,
+            color_a,
+            color_b,
+            width,
+            projection,
+            body_pos_r3,
+            view_radius,
+        );
         return;
     }
 
     let samples = SPACE_TESSELLATION_SAMPLES;
-    let clip_radius = stereographic_clip_radius(projection);
+    let clip_radius = stereographic_clip_radius(projection, view_radius);
     // Unit endpoints on S³ for the great-circle arc; the per-sample radius lerp
     // below restores the body's scale and keeps the endpoints exactly on `a`/`b`.
     let p0u = a / radius_a;
@@ -1093,11 +1154,12 @@ impl Demo {
         );
 
         let mut camera = Camera::<EuclideanR3>::at_origin();
-        camera.position = Vec3::new(0.0, 3.0, 9.0);
+        camera.position = Vec3::new(0.0, 4.0, 13.0);
         let mut orbit: OrbitController<EuclideanR3> = OrbitController::default();
-        // Wider orbit so all four bodies in the row are visible at
-        // default zoom; user can scroll-zoom in.
-        orbit.set_orbit(9.5, -0.25);
+        // Wider orbit so all four bodies in the row are visible at default zoom,
+        // with extra room for larger shapes' stereographic arcs; the user can
+        // scroll-zoom in toward MIN_DISTANCE or out toward the raised MAX_DISTANCE.
+        orbit.set_orbit(13.0, -0.25);
 
         // Freecam preset; inactive at startup. The `camera freecam` console
         // command calls `freecam.set_active(true, camera.position)` which
@@ -1894,7 +1956,10 @@ impl Demo {
         // the touching edges are dropped. Gating the point push on the same
         // predicate keeps the points overlay consistent with the wireframe.
         // `None` for every other projection, so nothing is dropped there.
-        let points_clip_radius = stereographic_clip_radius(&wireframe_projection);
+        let points_clip_radius = stereographic_clip_radius(
+            &wireframe_projection,
+            stereographic_view_radius(self.camera_distance_to_focus()),
+        );
         // Active-mode palette: bright green for vertices that belong to a
         // currently-intersected cell, dim gray otherwise. Same hues the
         // wireframe overlay uses so the visual identity stays consistent.
@@ -2152,8 +2217,9 @@ impl Demo {
         // cap outline. The cross layer is drop-w (Identity), so its radius is
         // `None` and every triangle is kept, bit-identical to before this clip.
         // The cap layer is `None` unless the active projection is Stereographic.
-        let cross_clip = stereographic_clip_radius(&cross_projection);
-        let cap_clip = stereographic_clip_radius(&cap_projection);
+        let view_radius = stereographic_view_radius(self.camera_distance_to_focus());
+        let cross_clip = stereographic_clip_radius(&cross_projection, view_radius);
+        let cap_clip = stereographic_clip_radius(&cap_projection, view_radius);
 
         // Reused per-vertex projected-point buffer for the triangle-granularity
         // fill clip, taken out so the `append_layer` closure can hold it `&mut`
@@ -2313,6 +2379,14 @@ impl Demo {
     /// wireframe) from the current row + rotor + w_slice, upload them, clear the overlay
     /// depth buffer, and execute the three raster passes on top of the existing SDF render.
     ///
+    /// Distance from the camera eye to the scene focus (the orbit target), used to
+    /// scale the stereographic clip radius (see [`stereographic_view_radius`]).
+    /// Reads the live eye position rather than `orbit.distance` so it is correct in
+    /// FreeRoam too, where the orbit controller is not driving the camera.
+    fn camera_distance_to_focus(&self) -> f32 {
+        (self.camera.position - self.orbit.target).length()
+    }
+
     /// Per-body transform: each canonical Polytope4 vertex `v` becomes the world Vec4
     /// `body.position + effective_body_size() * rot_state.apply(v)`. The section algorithm
     /// then runs on these world vertices against the demo's `w_slice`, producing geometry
@@ -2359,6 +2433,11 @@ impl Demo {
         // Resolve once per frame; same projection applied to every body's wireframe so all
         // bodies share a consistent R³ embedding.
         let wireframe_projection = self.resolved_wireframe_projection();
+        // Camera-adaptive stereographic clip radius for this frame, captured once
+        // (Copy f32) so the perimeter closure and the per-edge `push_blended_edge`
+        // calls below share it without re-borrowing `self`. See
+        // `stereographic_view_radius` for why it tracks the camera distance.
+        let view_radius = stereographic_view_radius(self.camera_distance_to_focus());
         // Per-layer perimeter toggles + the honest layer's always-drop-w
         // projection (the active projection is forced to `Identity` for the
         // cross-section so its outline can never follow a distorting projection).
@@ -2439,7 +2518,7 @@ impl Demo {
                 let w_slice = self.w_slice;
                 let mut push_perimeter = |projection: &rye_math::Projection<4>| {
                     let section_scale = perspective_scale_at_w(w_slice, projection);
-                    let clip_radius = stereographic_clip_radius(projection);
+                    let clip_radius = stereographic_clip_radius(projection, view_radius);
                     for ((a, b), (color, width)) in perim
                         .segments
                         .iter()
@@ -2647,6 +2726,7 @@ impl Demo {
                     &wireframe_projection,
                     body_pos_r3,
                     &mut slerp_scratch,
+                    view_radius,
                 );
             }
         }
@@ -3903,6 +3983,7 @@ mod blended_edge_tests {
             &flat_drop_w(),
             Vec3::ZERO,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         assert_eq!(mesh.segments.len(), 1);
         let chord = (Vec3::new(0.0, 0.7, 0.0) - Vec3::new(0.7, 0.0, 0.0)).length();
@@ -3928,6 +4009,7 @@ mod blended_edge_tests {
             &flat_drop_w(),
             Vec3::ZERO,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         assert_eq!(mesh.segments.len(), SPACE_TESSELLATION_SAMPLES);
     }
@@ -3955,6 +4037,7 @@ mod blended_edge_tests {
             &flat_drop_w(),
             Vec3::ZERO,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         let arc_len = polyline_length(&arc);
         // Quarter circle of radius 0.7 has arc length 0.7·π/2 ≈ 1.0996 vs chord
@@ -3989,6 +4072,7 @@ mod blended_edge_tests {
                 &flat_drop_w(),
                 Vec3::ZERO,
                 &mut scratch,
+                STEREOGRAPHIC_VIEW_RADIUS,
             );
             polyline_length(&mesh)
         };
@@ -4045,6 +4129,7 @@ mod blended_edge_tests {
             &proj,
             body_pos,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
 
         assert_eq!(mesh.segments.len(), 1, "affine flat chord is one segment");
@@ -4087,6 +4172,7 @@ mod blended_edge_tests {
                 &proj,
                 body_pos,
                 &mut scratch,
+                STEREOGRAPHIC_VIEW_RADIUS,
             );
             assert!(!mesh.segments.is_empty(), "blend {blend}: emitted nothing");
             let first = mesh.segments.first().unwrap().0;
@@ -5157,6 +5243,7 @@ mod section_cap_projection_tests {
             &proj,
             body_pos,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         assert_eq!(
             mesh.segments.len(),
@@ -5197,6 +5284,7 @@ mod section_cap_projection_tests {
             &proj,
             Vec3::ZERO,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         assert_eq!(mesh.segments.len(), 1, "Schlegel edge is one chord");
         assert_eq!(
@@ -5236,6 +5324,7 @@ mod section_cap_projection_tests {
             &proj,
             body_pos,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         assert_eq!(
             mesh.segments.len(),
@@ -5366,47 +5455,68 @@ mod section_cap_projection_tests {
     // temporal behavior is a visual property and needs human eyes-on (see the
     // wireframe overlay note); a test named "flicker_free" would be a doc lie.
 
-    /// `STEREOGRAPHIC_VIEW_RADIUS` sits below the camera orbit distance (so a
-    /// near-pole arc can never reach the camera plane and rubberband), above the
-    /// legitimate stereographic image of a unit-circumradius polytope (so real
-    /// geometry is never clipped), and below the pole-clamp magnitude ceiling
-    /// `sqrt(2 / eps)` (so the near-pole blow-up still reliably exceeds it). The
-    /// camera-distance bound is the load-bearing one: it is what removes the
-    /// long/short length jump the near-plane line clip alone cannot.
+    /// The camera-adaptive clip radius stays below the camera distance at every
+    /// reasonable zoom (so a near-pole arc can never reach the camera plane and
+    /// rubberband, the zoom-robust property), clears the legitimate image of a
+    /// unit-circumradius polytope (so real geometry is never clipped), stays below
+    /// the pole-clamp magnitude ceiling (so the near-pole blow-up still reliably
+    /// exceeds it), and saturates at [`STEREOGRAPHIC_VIEW_RADIUS_MAX`] on zoom-out
+    /// (so the arc never reaches the under-tessellated steep region, which would
+    /// jag and bounce). The below-camera-distance and saturation properties are
+    /// the load-bearing ones.
     #[test]
-    fn stereographic_view_radius_below_camera_distance() {
-        // The demo's default orbit distance (see `Demo::new`, `set_orbit(9.5, ..)`).
-        // The wireframe sits near the orbit target, so this is the eye's distance
-        // from the stereographic image; an arc capped below it stays in front of
-        // the eye at every orientation.
-        const DEFAULT_ORBIT_DISTANCE: f32 = 9.5;
-        assert!(
-            STEREOGRAPHIC_VIEW_RADIUS < DEFAULT_ORBIT_DISTANCE,
-            "radius {STEREOGRAPHIC_VIEW_RADIUS} must stay below the camera distance \
-             {DEFAULT_ORBIT_DISTANCE} so arcs never reach the camera plane"
-        );
-
-        // Below the pole-clamp ceiling, so a clamp-band sample reliably exceeds R.
-        let clamp_ceiling = (2.0 / rye_math::STEREOGRAPHIC_POLE_EPSILON).sqrt();
-        assert!(
-            STEREOGRAPHIC_VIEW_RADIUS < clamp_ceiling,
-            "radius {STEREOGRAPHIC_VIEW_RADIUS} must sit below the clamp ceiling {clamp_ceiling}"
-        );
-
-        // Above the legit image: project an actual unit tesseract vertex (the
-        // `+w`-cell corner, the worst non-pole case at w = 0.5, image magnitude
-        // sqrt(3) ~ 1.73) and require the cap to clear it with margin, so real
-        // geometry is never clipped. Pins the radius against a genuine sample
-        // rather than a const-vs-const tautology.
+    fn stereographic_view_radius_tracks_camera_distance() {
+        // The legit image of the worst non-pole vertex (the `+w`-cell corner at
+        // w = 0.5, image magnitude sqrt(3) ~ 1.73): the radius must always clear
+        // it so real geometry is never clipped. Pinned against a genuine sample.
         let legit = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
             Vec4::new(0.5, 0.5, 0.5, 0.5),
             &rye_math::Projection::Stereographic { pole: Vec4::W },
+        )
+        .length();
+        let clamp_ceiling = (2.0 / rye_math::STEREOGRAPHIC_POLE_EPSILON).sqrt();
+
+        // Across the orbit's zoom range and beyond, the radius stays a fixed
+        // fraction below the camera distance, clears the figure, and sits under
+        // the clamp ceiling. At very close range the figure floor can exceed the
+        // distance (the eye is inside the figure); above the floor's reach the
+        // strict-below-distance property holds, which is the rubberband fix.
+        for distance in [2.0_f32, 4.0, 8.0, 16.0, 40.0] {
+            let r = stereographic_view_radius(distance);
+            assert!(
+                r > legit,
+                "radius {r} at distance {distance} must clear the figure {legit}"
+            );
+            assert!(
+                r < clamp_ceiling,
+                "radius {r} must stay below the clamp ceiling"
+            );
+            // Above where the floor dominates, the radius is strictly below the
+            // camera distance (arcs stay in front of the eye).
+            if distance * STEREOGRAPHIC_VIEW_RADIUS_FRACTION >= STEREOGRAPHIC_VIEW_RADIUS_FLOOR {
+                assert!(
+                    r < distance,
+                    "radius {r} must stay below camera distance {distance} (no plane crossing)"
+                );
+            }
+            // Never past the gentle-region ceiling, at any distance.
+            assert!(
+                r <= STEREOGRAPHIC_VIEW_RADIUS_MAX,
+                "radius {r} must never exceed the cap {STEREOGRAPHIC_VIEW_RADIUS_MAX}"
+            );
+        }
+
+        // On zoom-out the radius saturates at the cap (does not grow into the
+        // under-tessellated steep region), which is what keeps far-zoom arcs
+        // smooth and bounce-free.
+        assert_eq!(
+            stereographic_view_radius(40.0),
+            STEREOGRAPHIC_VIEW_RADIUS_MAX
         );
-        assert!(
-            STEREOGRAPHIC_VIEW_RADIUS > 2.0 * legit.length(),
-            "radius {STEREOGRAPHIC_VIEW_RADIUS} must clear the legit image ({})",
-            legit.length()
-        );
+        // The test reference equals the live value at an 8-unit camera distance
+        // (and beyond), so fixtures using the constant exercise a representative
+        // radius.
+        assert!((stereographic_view_radius(8.0) - STEREOGRAPHIC_VIEW_RADIUS).abs() < 1e-5);
     }
 
     /// `stereographic_clip_radius` returns `Some(R)` exactly for Stereographic and
@@ -5418,7 +5528,10 @@ mod section_cap_projection_tests {
     #[test]
     fn stereographic_clip_radius_only_for_stereographic() {
         assert_eq!(
-            stereographic_clip_radius(&rye_math::Projection::Stereographic { pole: Vec4::W }),
+            stereographic_clip_radius(
+                &rye_math::Projection::Stereographic { pole: Vec4::W },
+                STEREOGRAPHIC_VIEW_RADIUS
+            ),
             Some(STEREOGRAPHIC_VIEW_RADIUS)
         );
         for proj in [
@@ -5430,7 +5543,7 @@ mod section_cap_projection_tests {
             rye_math::Projection::schlegel(Vec4::W, 0.5, 0.75),
         ] {
             assert_eq!(
-                stereographic_clip_radius(&proj),
+                stereographic_clip_radius(&proj, STEREOGRAPHIC_VIEW_RADIUS),
                 None,
                 "non-stereographic projection {proj:?} must carry no clip"
             );
@@ -5460,6 +5573,7 @@ mod section_cap_projection_tests {
             &proj,
             Vec3::ZERO,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         mesh.segments
     }
@@ -5714,6 +5828,7 @@ mod section_cap_projection_tests {
             &proj,
             Vec3::ZERO,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         let cap_after_first = scratch.capacity();
         // The slerp buffer holds `samples + 1` points, so its capacity must be
@@ -5732,6 +5847,7 @@ mod section_cap_projection_tests {
             &proj,
             Vec3::ZERO,
             &mut scratch,
+            STEREOGRAPHIC_VIEW_RADIUS,
         );
         assert_eq!(
             scratch.capacity(),
@@ -5825,7 +5941,7 @@ mod section_cap_projection_tests {
     #[test]
     fn cap_fill_matches_perimeter_clip() {
         let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
-        let clip = stereographic_clip_radius(&proj);
+        let clip = stereographic_clip_radius(&proj, STEREOGRAPHIC_VIEW_RADIUS);
         // A near-pole cap vertex (w-slice close to +w, off-axis so it projects to
         // a large finite point) and a far one on the equatorial slice.
         let near = cap_projected([0.05, 0.02, 0.01], 0.999, &proj);
@@ -5861,7 +5977,7 @@ mod section_cap_projection_tests {
     #[test]
     fn points_overlay_drops_near_pole_vertex() {
         let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
-        let clip = stereographic_clip_radius(&proj);
+        let clip = stereographic_clip_radius(&proj, STEREOGRAPHIC_VIEW_RADIUS);
         // Body-local vertex within the angular epsilon of +w: project it the same
         // way render_points does, then apply the gate.
         let v_near = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
@@ -5884,7 +6000,8 @@ mod section_cap_projection_tests {
         );
         // Affine projection carries no clip: even the near-pole image is kept
         // (Identity has no point-at-infinity, so the magnitude is bounded anyway).
-        let affine_clip = stereographic_clip_radius(&rye_math::Projection::Identity);
+        let affine_clip =
+            stereographic_clip_radius(&rye_math::Projection::Identity, STEREOGRAPHIC_VIEW_RADIUS);
         assert!(
             sample_in_radius(v_near, affine_clip),
             "affine projection must keep every point (no clip)"
@@ -5900,7 +6017,7 @@ mod section_cap_projection_tests {
     #[test]
     fn cap_fill_uses_default_plus_w_pole() {
         let proj = default_stereographic();
-        let clip = stereographic_clip_radius(&proj);
+        let clip = stereographic_clip_radius(&proj, STEREOGRAPHIC_VIEW_RADIUS);
         // A 4D point in the +w pole's near neighborhood: `(0.05, 0, 0, 1.0)`
         // normalizes to dot ~ 0.99875 with +w, image magnitude ~40, past the
         // ~35 radius, so it drops.

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -64,7 +64,8 @@ use rye_egui::Console;
 use rye_math::WPlane;
 use rye_math::{Bivector, EuclideanR3, Rotor, Rotor4};
 use rye_physics::polytope::{
-    polytope_section_faces_append, polytope_section_overlay_with_vertices, vertex_color_by_position,
+    polytope_section_faces_append, polytope_section_overlay_with_vertices,
+    vertex_color_by_position, Polytope4,
 };
 use rye_render::{
     device::RenderDevice,
@@ -100,11 +101,12 @@ const PERSPECTIVE_SCALE_DENOM_EPSILON: f32 = 1e-4;
 /// *width* artifact of a behind-eye endpoint, but it cannot remove this *length*
 /// discontinuity, which is inherent to an extended arc reaching past a close
 /// camera. Tying the radius to a fraction `< 1` of the live camera distance keeps
-/// every arc endpoint in front of the eye at ANY zoom (the zoom-robust property)
-/// when zooming in (the zoom-robust property). On zoom-OUT the radius is held at
-/// [`STEREOGRAPHIC_VIEW_RADIUS_MAX`] rather than growing without bound, which also
-/// brings the arcs on-screen (their NDC shrinks) so a pulled-back camera frames a
-/// larger shape's full arc halo.
+/// every arc endpoint in front of the eye when zooming in (the zoom-robust
+/// property). On zoom-OUT the radius is held at
+/// [`STEREOGRAPHIC_CELL16_RADIUS_MAX`] rather than growing without bound, which
+/// also brings the arcs on-screen (their NDC shrinks) so a pulled-back camera
+/// frames the figure. This fraction applies to the 16-cell (the only shape the
+/// clip bounds; see [`stereographic_view_radius`]).
 ///
 /// `0.75` leaves a nearest-approach margin of `0.25 ×` the camera distance (a
 /// gentle off-axis sweep, never a graze); at an 8-unit camera distance it yields
@@ -119,38 +121,50 @@ const STEREOGRAPHIC_VIEW_RADIUS_FRACTION: f32 = 0.75;
 /// backstop there.
 const STEREOGRAPHIC_VIEW_RADIUS_FLOOR: f32 = 2.5;
 
-/// Ceiling on the stereographic clip radius. Beyond this the arc would be drawn
-/// deep into the steep near-pole region, where the fixed-count
+/// Ceiling on the stereographic clip radius FOR THE 16-CELL. Beyond this the arc
+/// would be drawn deep into the steep near-pole region, where the fixed-count
 /// [`SPACE_TESSELLATION_SAMPLES`] arc sampling (uniform in 4D arc-angle) is far
 /// too coarse for the nonlinear projection: consecutive samples jump several-fold
 /// in image magnitude, so the rendered arc facets into long straight chords
 /// (jagged) and those chords twitch as rotation shifts which sample brackets the
-/// boundary (the bounce). Capping at `6.0` keeps the arc in the gentle region
-/// where the 16 samples read as a smooth curve, and matches the eyes-on-confirmed
-/// extent. To let arcs extend further AND stay smooth, raise this together with
-/// the arc sample count (or subdivide adaptively by projected segment length).
-const STEREOGRAPHIC_VIEW_RADIUS_MAX: f32 = 6.0;
+/// boundary (the bounce). `10.0` keeps the 16-cell's arcs extended but bounded
+/// within the (mostly) well-sampled region. To extend further AND stay smooth,
+/// raise this together with the arc sample count (or subdivide adaptively by
+/// projected segment length) — a future arc-extent slider would drive both.
+const STEREOGRAPHIC_CELL16_RADIUS_MAX: f32 = 10.0;
 
 /// Reference clip radius for tests (which have no live camera): the value
-/// [`stereographic_view_radius`] yields at an 8-unit camera distance and beyond
-/// (where it saturates at [`STEREOGRAPHIC_VIEW_RADIUS_MAX`]). Eyes-on-confirmed to
-/// kill the rubberband while keeping the near-pole arcs a smooth extended halo.
-/// The live render path uses the camera-adaptive [`stereographic_view_radius`]
-/// instead, so this is compiled only for tests.
+/// [`stereographic_view_radius`] yields for the 16-cell at an 8-unit camera
+/// distance (`0.75 × 8`). A representative mid-range radius the clip-mechanics
+/// tests exercise; the live render path uses the camera- and shape-adaptive
+/// [`stereographic_view_radius`], so this is compiled only for tests.
 #[cfg(test)]
-const STEREOGRAPHIC_VIEW_RADIUS: f32 = STEREOGRAPHIC_VIEW_RADIUS_MAX;
+const STEREOGRAPHIC_VIEW_RADIUS: f32 = 6.0;
 
-/// Camera-adaptive stereographic clip radius: a fraction of the live distance
-/// from the eye to the figure, clamped to `[FLOOR, MAX]`. The fraction keeps it
-/// below the camera distance so zoom-in never rubberbands; the MAX ceiling keeps
-/// it out of the under-tessellated steep near-pole region so zoom-out never
-/// jaggeds or bounces (see [`STEREOGRAPHIC_VIEW_RADIUS_MAX`]); the floor keeps the
-/// figure itself from being clipped at close range.
-fn stereographic_view_radius(camera_distance: f32) -> f32 {
-    (camera_distance * STEREOGRAPHIC_VIEW_RADIUS_FRACTION).clamp(
-        STEREOGRAPHIC_VIEW_RADIUS_FLOOR,
-        STEREOGRAPHIC_VIEW_RADIUS_MAX,
-    )
+/// Per-shape, camera-adaptive stereographic clip radius.
+///
+/// **The 16-cell is special.** The default `+w` pole sits exactly on a 16-cell
+/// vertex (`±e_w`), so its near-pole edges genuinely blow up to infinity and must
+/// be bounded. Its radius is a fraction of the live camera distance (zoom-robust:
+/// shrinks on zoom-in so an endpoint never reaches the camera plane, no
+/// rubberband), floored so a close zoom never clips the figure, and capped at
+/// [`STEREOGRAPHIC_CELL16_RADIUS_MAX`] so a far zoom never drives the arc into the
+/// under-tessellated steep region (no jaggedness/bounce).
+///
+/// **Every other polytope has its vertices OFF the `+w` pole** (the tesseract's
+/// reach `dot = ½`, the 24-cell's `1/√2`, etc.), so its stereographic image is
+/// naturally bounded and is drawn with NO clip (`f32::INFINITY` — the clip never
+/// engages), giving the full undistorted conformal extent. A vertex only reaches
+/// the pole if rotated exactly onto it, a transient the near-plane line clip
+/// already keeps finite.
+fn stereographic_view_radius(polytope: Polytope4, camera_distance: f32) -> f32 {
+    match polytope {
+        Polytope4::Cell16 => (camera_distance * STEREOGRAPHIC_VIEW_RADIUS_FRACTION).clamp(
+            STEREOGRAPHIC_VIEW_RADIUS_FLOOR,
+            STEREOGRAPHIC_CELL16_RADIUS_MAX,
+        ),
+        _ => f32::INFINITY,
+    }
 }
 
 /// Cap on the reconstructed near-pole image magnitude (see `near_pole_view_point`).
@@ -1159,12 +1173,13 @@ impl Demo {
         );
 
         let mut camera = Camera::<EuclideanR3>::at_origin();
-        camera.position = Vec3::new(0.0, 4.0, 13.0);
+        camera.position = Vec3::new(0.0, 3.0, 9.0);
         let mut orbit: OrbitController<EuclideanR3> = OrbitController::default();
-        // Wider orbit so all four bodies in the row are visible at default zoom,
-        // with extra room for larger shapes' stereographic arcs; the user can
-        // scroll-zoom in toward MIN_DISTANCE or out toward the raised MAX_DISTANCE.
-        orbit.set_orbit(13.0, -0.25);
+        // Default framing: all four bodies in the row visible at startup. `8.0`
+        // is the original startup distance (the old code asked for 9.5 but the
+        // pre-bump MAX_DISTANCE = 8 clamped it); the raised MAX_DISTANCE only
+        // widens the scroll-out range, it does not push the startup view back.
+        orbit.set_orbit(8.0, -0.25);
 
         // Freecam preset; inactive at startup. The `camera freecam` console
         // command calls `freecam.set_active(true, camera.position)` which
@@ -1960,11 +1975,9 @@ impl Demo {
         // large-but-finite clamp point, which would draw as a giant disc while
         // the touching edges are dropped. Gating the point push on the same
         // predicate keeps the points overlay consistent with the wireframe.
-        // `None` for every other projection, so nothing is dropped there.
-        let points_clip_radius = stereographic_clip_radius(
-            &wireframe_projection,
-            stereographic_view_radius(self.camera_distance_to_focus()),
-        );
+        // `None` for every other projection, so nothing is dropped there. The
+        // radius is resolved per shape in the loop (only the 16-cell is clipped).
+        let cam_dist = self.camera_distance_to_focus();
         // Active-mode palette: bright green for vertices that belong to a
         // currently-intersected cell, dim gray otherwise. Same hues the
         // wireframe overlay uses so the visual identity stays consistent.
@@ -1983,6 +1996,11 @@ impl Demo {
             let Some(polytope) = entry.shape.polytope4() else {
                 continue;
             };
+            // Per-shape clip: finite for the 16-cell, none for the rest.
+            let points_clip_radius = stereographic_clip_radius(
+                &wireframe_projection,
+                stereographic_view_radius(polytope, cam_dist),
+            );
             let topo = polytope.topology();
             let body_pos = body_position(slot, n);
             let body_pos_r3 = Vec3::new(body_pos[0], body_pos[1], body_pos[2]);
@@ -2220,11 +2238,10 @@ impl Demo {
         let cap_scale = perspective_scale_at_w(w_slice, &cap_projection);
         // Near-pole drop radius per layer, shared with the wireframe edges and the
         // cap outline. The cross layer is drop-w (Identity), so its radius is
-        // `None` and every triangle is kept, bit-identical to before this clip.
-        // The cap layer is `None` unless the active projection is Stereographic.
-        let view_radius = stereographic_view_radius(self.camera_distance_to_focus());
-        let cross_clip = stereographic_clip_radius(&cross_projection, view_radius);
-        let cap_clip = stereographic_clip_radius(&cap_projection, view_radius);
+        // `None` and every triangle is kept; the cap layer is `None` unless the
+        // active projection is Stereographic. The radius is resolved PER SHAPE in
+        // the loop (only the 16-cell is clipped), so capture the distance here.
+        let cam_dist = self.camera_distance_to_focus();
 
         // Reused per-vertex projected-point buffer for the triangle-granularity
         // fill clip, taken out so the `append_layer` closure can hold it `&mut`
@@ -2245,6 +2262,10 @@ impl Demo {
             let Some(polytope) = entry.shape.polytope4() else {
                 continue;
             };
+            // Per-shape clip: finite for the 16-cell, none for the rest.
+            let view_radius = stereographic_view_radius(polytope, cam_dist);
+            let cross_clip = stereographic_clip_radius(&cross_projection, view_radius);
+            let cap_clip = stereographic_clip_radius(&cap_projection, view_radius);
             let topo = polytope.topology();
             let body_pos = body_position(slot, n);
             let body_pos_r3 = Vec3::new(body_pos[0], body_pos[1], body_pos[2]);
@@ -2438,11 +2459,10 @@ impl Demo {
         // Resolve once per frame; same projection applied to every body's wireframe so all
         // bodies share a consistent R³ embedding.
         let wireframe_projection = self.resolved_wireframe_projection();
-        // Camera-adaptive stereographic clip radius for this frame, captured once
-        // (Copy f32) so the perimeter closure and the per-edge `push_blended_edge`
-        // calls below share it without re-borrowing `self`. See
-        // `stereographic_view_radius` for why it tracks the camera distance.
-        let view_radius = stereographic_view_radius(self.camera_distance_to_focus());
+        // Camera-to-focus distance captured once (Copy f32); the stereographic
+        // clip radius is resolved PER SHAPE inside the loop below, since only the
+        // 16-cell is clipped (see `stereographic_view_radius`).
+        let cam_dist = self.camera_distance_to_focus();
         // Per-layer perimeter toggles + the honest layer's always-drop-w
         // projection (the active projection is forced to `Identity` for the
         // cross-section so its outline can never follow a distorting projection).
@@ -2484,6 +2504,10 @@ impl Demo {
             let Some(polytope) = entry.shape.polytope4() else {
                 continue;
             };
+            // Per-shape stereographic clip radius (the perimeter closure and the
+            // per-edge `push_blended_edge` below both consume it): finite + capped
+            // for the 16-cell, `f32::INFINITY` (no clip) for every other shape.
+            let view_radius = stereographic_view_radius(polytope, cam_dist);
             let topo = polytope.topology();
             let body_pos = body_position(slot, n);
             // Body's R³ position. The body sits at body_pos.w = 0 in 4D, so the perspective
@@ -3567,7 +3591,7 @@ impl RotatePolytopesApp {
                             // freecam left it. Freecam's `set_active(false)`
                             // releases the cursor grab.
                             demo.orbit = OrbitController::default();
-                            demo.orbit.set_orbit(9.5, -0.25);
+                            demo.orbit.set_orbit(8.0, -0.25);
                             demo.freecam.set_active(false, demo.camera.position);
                             out.line("camera: orbit (reset to world origin)");
                         }
@@ -5460,15 +5484,14 @@ mod section_cap_projection_tests {
     // temporal behavior is a visual property and needs human eyes-on (see the
     // wireframe overlay note); a test named "flicker_free" would be a doc lie.
 
-    /// The camera-adaptive clip radius stays below the camera distance at every
-    /// reasonable zoom (so a near-pole arc can never reach the camera plane and
-    /// rubberband, the zoom-robust property), clears the legitimate image of a
-    /// unit-circumradius polytope (so real geometry is never clipped), stays below
-    /// the pole-clamp magnitude ceiling (so the near-pole blow-up still reliably
-    /// exceeds it), and saturates at [`STEREOGRAPHIC_VIEW_RADIUS_MAX`] on zoom-out
-    /// (so the arc never reaches the under-tessellated steep region, which would
-    /// jag and bounce). The below-camera-distance and saturation properties are
-    /// the load-bearing ones.
+    /// The per-shape, camera-adaptive clip radius. For the 16-cell (the only shape
+    /// with vertices on the `+w` pole) the radius stays below the camera distance
+    /// at every reasonable zoom (no rubberband), clears the legitimate image of a
+    /// unit-circumradius polytope (real geometry never clipped), stays below the
+    /// pole-clamp magnitude ceiling (the near-pole blow-up still exceeds it), and
+    /// saturates at [`STEREOGRAPHIC_CELL16_RADIUS_MAX`] on zoom-out (the arc never
+    /// reaches the under-tessellated steep region). Every other shape is
+    /// unclipped (`INFINITY`), since its image is naturally bounded.
     #[test]
     fn stereographic_view_radius_tracks_camera_distance() {
         // The legit image of the worst non-pole vertex (the `+w`-cell corner at
@@ -5481,47 +5504,56 @@ mod section_cap_projection_tests {
         .length();
         let clamp_ceiling = (2.0 / rye_math::STEREOGRAPHIC_POLE_EPSILON).sqrt();
 
-        // Across the orbit's zoom range and beyond, the radius stays a fixed
-        // fraction below the camera distance, clears the figure, and sits under
-        // the clamp ceiling. At very close range the figure floor can exceed the
-        // distance (the eye is inside the figure); above the floor's reach the
+        // Across the orbit's zoom range and beyond, the 16-cell radius stays a
+        // fixed fraction below the camera distance, clears the figure, and sits
+        // under the clamp ceiling. At very close range the figure floor can exceed
+        // the distance (the eye is inside the figure); above the floor's reach the
         // strict-below-distance property holds, which is the rubberband fix.
         for distance in [2.0_f32, 4.0, 8.0, 16.0, 40.0] {
-            let r = stereographic_view_radius(distance);
+            let r = stereographic_view_radius(Polytope4::Cell16, distance);
             assert!(
                 r > legit,
-                "radius {r} at distance {distance} must clear the figure {legit}"
+                "16-cell radius {r} at distance {distance} must clear the figure {legit}"
             );
             assert!(
                 r < clamp_ceiling,
                 "radius {r} must stay below the clamp ceiling"
             );
-            // Above where the floor dominates, the radius is strictly below the
-            // camera distance (arcs stay in front of the eye).
             if distance * STEREOGRAPHIC_VIEW_RADIUS_FRACTION >= STEREOGRAPHIC_VIEW_RADIUS_FLOOR {
                 assert!(
                     r < distance,
-                    "radius {r} must stay below camera distance {distance} (no plane crossing)"
+                    "16-cell radius {r} must stay below camera distance {distance}"
                 );
             }
-            // Never past the gentle-region ceiling, at any distance.
             assert!(
-                r <= STEREOGRAPHIC_VIEW_RADIUS_MAX,
-                "radius {r} must never exceed the cap {STEREOGRAPHIC_VIEW_RADIUS_MAX}"
+                r <= STEREOGRAPHIC_CELL16_RADIUS_MAX,
+                "16-cell radius {r} must never exceed the cap {STEREOGRAPHIC_CELL16_RADIUS_MAX}"
             );
         }
 
-        // On zoom-out the radius saturates at the cap (does not grow into the
-        // under-tessellated steep region), which is what keeps far-zoom arcs
-        // smooth and bounce-free.
+        // Zoom-out saturates the 16-cell radius at its cap (no growth into the
+        // under-tessellated steep region), keeping far-zoom arcs smooth.
         assert_eq!(
-            stereographic_view_radius(40.0),
-            STEREOGRAPHIC_VIEW_RADIUS_MAX
+            stereographic_view_radius(Polytope4::Cell16, 40.0),
+            STEREOGRAPHIC_CELL16_RADIUS_MAX
         );
-        // The test reference equals the live value at an 8-unit camera distance
-        // (and beyond), so fixtures using the constant exercise a representative
-        // radius.
-        assert!((stereographic_view_radius(8.0) - STEREOGRAPHIC_VIEW_RADIUS).abs() < 1e-5);
+        // The test reference is the 16-cell value at an 8-unit camera distance.
+        assert!(
+            (stereographic_view_radius(Polytope4::Cell16, 8.0) - STEREOGRAPHIC_VIEW_RADIUS).abs()
+                < 1e-5
+        );
+
+        // Every other shape is unclipped at every distance: the tesseract,
+        // 24-cell, etc. have their vertices off the pole, so their image is
+        // bounded and we draw the full conformal extent (INFINITY -> no clip).
+        for polytope in [Polytope4::Tesseract, Polytope4::Cell24, Polytope4::Cell600] {
+            for distance in [2.0_f32, 8.0, 40.0] {
+                assert!(
+                    stereographic_view_radius(polytope, distance).is_infinite(),
+                    "{polytope:?} must be unclipped (no radius limit)"
+                );
+            }
+        }
     }
 
     /// `stereographic_clip_radius` returns `Some(R)` exactly for Stereographic and

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -79,18 +79,118 @@ use rye_render::{
 /// active caps within tenths of a unit of camera-z) without artifacting.
 const SECTION_FACES_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 
-/// Uniform R³ scale factor that `projection` applies to a 4D point with `w = w_slice`.
-/// For `Projection::Identity` (drop-w) the result is `1.0`; for `Projection::Perspective4D`
-/// it's `focal_distance / (focal_distance - w_slice)`, clamped against the same epsilon
-/// the impl uses internally. Used by the wireframe overlay to translate section caps (whose
-/// vertices all share `w = w_slice`) into the perspective-scaled R³ frame without re-running
-/// the cap algorithm in 4D.
-fn perspective_scale_at_w(w_slice: f32, projection: &rye_math::Projection<4>) -> f32 {
+/// Denominator floor for the affine Perspective4D scale, matching the
+/// `PROJECTION_DENOM_EPSILON` the `EuclideanR4` projection uses internally so the
+/// shim and the per-vertex path agree at the clamp. A vertex with
+/// `w == focal_distance` sits on the viewer's 3-flat; flooring keeps the scale
+/// large-but-finite rather than dividing by zero.
+const PERSPECTIVE_SCALE_DENOM_EPSILON: f32 = 1e-4;
+
+/// Body-local projected radius past which a stereographic sample is treated as
+/// the conformal point at infinity and DROPPED from the rendered polyline,
+/// rather than drawn as the large-but-finite point the pole-denominator clamp
+/// produces.
+///
+/// Why a drop, not a magnitude clamp: as a vertex sweeps through the pole under
+/// rotation, the pole-perpendicular numerator `p - dot*pole` passes through zero
+/// and reverses direction, so the projected point's direction flips 180 degrees
+/// across the crossing. Rescaling that point back to a fixed radius (a clamp)
+/// keeps the flip: the clamped point still jumps from `R*(+u)` to `R*(-u)`, a
+/// `2R` screen pop. Dropping the over-radius sub-segment instead lets the edge
+/// run out toward the view boundary and culls the offscreen blow-up; the
+/// remaining on-screen polyline is the true conformal image, untouched. This
+/// bounds and de-NaNs the artifact but does NOT make the at-pole instant
+/// continuous (a vertex crossing the pole is a genuine discontinuity of the
+/// projection); see the eyes-on caveat in the wireframe overlay.
+///
+/// Interdependent with [`rye_math::STEREOGRAPHIC_POLE_EPSILON`]: a sample inside
+/// the clamp band maps to magnitude at most `sqrt(2 / eps)` (~141 at the default
+/// `eps = 1e-4`), so this radius must sit strictly below that ceiling for the
+/// near-pole blow-up to reliably exceed it and be dropped, yet well above the
+/// legitimate on-screen extent of a unit-circumradius polytope's stereographic
+/// image (a `body_size`-scaled vertex with `w = 0.5` maps to radius ~1.7, and
+/// near-pole edge interiors reach a few units) so real geometry is never
+/// clipped. The value is a quarter of the clamp ceiling `sqrt(2 / eps)`, i.e.
+/// ~35: a quarter keeps the clip well clear of both the legitimate image (far
+/// below `R`) and the clamp-saturated near-pole blow-up (far above `R`), so the
+/// drop is unambiguous on both sides. Pinned against its formula by
+/// `stereographic_view_radius_sits_below_clamp_ceiling` (the literal is the f32
+/// value of `0.25 * sqrt(2 / eps)`, recorded because `f32::sqrt` is not `const`).
+const STEREOGRAPHIC_VIEW_RADIUS: f32 = 35.355_34;
+
+/// Body-local projected-radius clip for a `projection`, or `None` when the
+/// projection needs no clip. Only [`rye_math::Projection::Stereographic`] has a
+/// genuine point-at-infinity in its image (a vertex on the pole), so it is the
+/// only projection whose near-singularity samples are dropped; the affine
+/// projections and Schlegel's bounded-finite clamp keep every sample. The test
+/// compares the magnitude of the *pre-translate* projected point (the conformal
+/// image about the body's own center), which is invariant to the body's R³
+/// position and the camera, so the same 4D edge clips identically at every row
+/// slot and zoom.
+fn stereographic_clip_radius(projection: &rye_math::Projection<4>) -> Option<f32> {
     match *projection {
-        rye_math::Projection::Identity | rye_math::Projection::Orthographic { .. } => 1.0,
+        rye_math::Projection::Stereographic { .. } => Some(STEREOGRAPHIC_VIEW_RADIUS),
+        rye_math::Projection::Identity
+        | rye_math::Projection::Orthographic { .. }
+        | rye_math::Projection::Perspective4D { .. }
+        | rye_math::Projection::Schlegel { .. } => None,
+    }
+}
+
+/// Uniform R³ scale factor that an *affine* `projection` applies to a 4D point with
+/// `w = w_slice`. `Some(scale)` for the projections where a single scalar at the slice's
+/// w is exact: `Identity`/`Orthographic` (`1.0`) and `Perspective4D`
+/// (`focal_distance / (focal_distance - w_slice)`, clamped against the same epsilon the
+/// projection impl uses). `None` for `Schlegel`/`Stereographic`, which are non-affine: their
+/// R³ image of a point depends on all four coordinates, not just `w`, so no single scalar
+/// rescales the section cap correctly. Callers that get `None` must project the cap's 4D
+/// vertices per-vertex through `EuclideanR4::project_point` (see
+/// [`cap_vertex_projected_and_world`]), matching the wireframe path so cap outline
+/// and wireframe coincide.
+///
+/// `Orthographic` returns `1.0` because the only orthographic projection the demo's
+/// wireframe ever selects is `drop_axis: 3` (drop-w), which agrees exactly with the
+/// section algorithm's own internal drop-w at unit scale. Orthographic drops of a spatial
+/// axis are unreachable from the demo's [`crate::WireframeProjection`]; they would need the
+/// per-vertex path too, but no caller produces them.
+fn perspective_scale_at_w(w_slice: f32, projection: &rye_math::Projection<4>) -> Option<f32> {
+    match *projection {
+        rye_math::Projection::Identity | rye_math::Projection::Orthographic { .. } => Some(1.0),
         rye_math::Projection::Perspective4D { focal_distance } => {
-            focal_distance / (focal_distance - w_slice).max(1e-4)
+            Some(focal_distance / (focal_distance - w_slice).max(PERSPECTIVE_SCALE_DENOM_EPSILON))
         }
+        // Non-affine: the single-scalar cap shortcut does not exist. The caller falls back to
+        // per-vertex projection of the recovered 4D cap vertices.
+        rye_math::Projection::Schlegel { .. } | rye_math::Projection::Stereographic { .. } => None,
+    }
+}
+
+/// Whether `projection` maps a straight R⁴ chord to a straight R³ segment, so a
+/// polytope edge can be rendered as a single line between its projected endpoints.
+///
+/// `Identity` / `Orthographic` are linear and `Perspective4D` is a central
+/// projection (the bodies sit at `w = 0`, so the perspective divide is a
+/// line-preserving map onto R³): all three send a 4D segment to an R³ segment,
+/// the affine fast path. `Schlegel` and `Stereographic` are non-affine -- their
+/// R³ image of a point depends nonlinearly on all four coordinates, so the image
+/// of an edge is a *curve*, not the chord through its projected endpoints. An edge
+/// drawn as a single straight chord under those projections drifts off its own
+/// projected midpoint (measured ~0.17 R³ units for a unit-circumradius tesseract
+/// edge under the `+w`-pole stereographic map), and the per-vertex-projected
+/// cross-section cap, which lands on the true projected edge, then floats off the
+/// wireframe. The wireframe builder subdivides the edge under these projections so
+/// the rendered polyline follows the projected curve and the cap rejoins it.
+///
+/// This is the same affine/non-affine split [`perspective_scale_at_w`] reports as
+/// `Some`/`None`; kept as a distinct boolean so the wireframe edge path reads as a
+/// shape question ("is the projected edge straight?") rather than borrowing the
+/// section cap's scalar-shim return.
+fn projection_is_affine(projection: &rye_math::Projection<4>) -> bool {
+    match *projection {
+        rye_math::Projection::Identity
+        | rye_math::Projection::Orthographic { .. }
+        | rye_math::Projection::Perspective4D { .. } => true,
+        rye_math::Projection::Schlegel { .. } | rye_math::Projection::Stereographic { .. } => false,
     }
 }
 
@@ -101,6 +201,394 @@ fn perspective_scale_at_w(w_slice: f32, projection: &rye_math::Projection<4>) ->
 fn local_r3_to_world(p: [f32; 3], section_scale: f32, body_pos_r3: Vec3) -> [f32; 3] {
     let scaled = Vec3::from_array(p) * section_scale;
     (scaled + body_pos_r3).to_array()
+}
+
+/// Map one body-local section-cap vertex to world R³ under the active wireframe
+/// projection, returning BOTH the cap vertex's *body-local projected* point (the
+/// first tuple element, the point whose magnitude the stereographic clip tests)
+/// and its world R³ point (the second). Returning the projected point keeps the
+/// clip honest without re-projecting: the perimeter outline and the cap fill both
+/// drop a sample whose projected magnitude exceeds [`STEREOGRAPHIC_VIEW_RADIUS`],
+/// using the same pre-translate point [`stereographic_clip_radius`] is defined
+/// against.
+///
+/// `section_scale` is the affine fast path: `Some(scale)` carries the uniform R³
+/// scale at the slice's w (Identity/Orthographic/Perspective4D), and the cap
+/// vertex is just scaled and translated, identical to [`local_r3_to_world`]; the
+/// body-local point is then `cap * scale`, and affine projections carry no clip
+/// ([`stereographic_clip_radius`] is `None`) so its magnitude is never tested.
+/// `None` means the projection is non-affine (Schlegel/Stereographic), so the
+/// cap's 4D vertex is reconstructed and projected per-vertex through the SAME
+/// `EuclideanR4::project_point` the parent wireframe uses, then translated; this
+/// is what makes the flat cap outline land on the projected wireframe instead of
+/// a w-only-scaled ghost, and the body-local point is exactly that per-vertex
+/// projection.
+///
+/// The cap vertex's 4D coordinate is recoverable because the section algorithm
+/// intersects every cell edge with the w-slice, so each cap vertex shares
+/// `w = w_slice`; the algorithm drops w internally and returns only `(x, y, z)`,
+/// and appending `w_slice` is the exact inverse for the conformal/central maps
+/// that only read all four coordinates. (The algorithm's internal
+/// `SLICE_PERTURBATION_EPSILON` nudge can move the true w by at most `1e-5`; that
+/// is far below the visible threshold and below the per-vertex projection's own
+/// roundoff, so reconstructing at the un-nudged `w_slice` is exact for rendering.)
+fn cap_vertex_projected_and_world(
+    p_r3: [f32; 3],
+    w_slice: f32,
+    section_scale: Option<f32>,
+    projection: &rye_math::Projection<4>,
+    body_pos_r3: Vec3,
+) -> (Vec3, [f32; 3]) {
+    match section_scale {
+        Some(scale) => {
+            let projected = Vec3::from_array(p_r3) * scale;
+            (projected, local_r3_to_world(p_r3, scale, body_pos_r3))
+        }
+        None => {
+            let p4 = Vec4::new(p_r3[0], p_r3[1], p_r3[2], w_slice);
+            let projected =
+                <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+                    p4, projection,
+                );
+            (projected, (projected + body_pos_r3).to_array())
+        }
+    }
+}
+
+/// Project a body-local 4D point to world R³: through the wireframe's 4D->R³
+/// `projection`, then translated by the body's R³ position. Perspective4D
+/// already folds the w-dependent scale into the projection, so no extra scale
+/// factor is applied here (unlike [`local_r3_to_world`], which the cross-section
+/// path needs because it drops w before this stage).
+fn project_to_world(p: Vec4, projection: &rye_math::Projection<4>, body_pos_r3: Vec3) -> Vec3 {
+    <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(p, projection)
+        + body_pos_r3
+}
+
+/// Smallest endpoint radius (distance from body center) that still has a
+/// well-defined direction on the body's circumsphere. Below this, the slerp has
+/// no axis to interpolate and we fall back to the flat chord. No polytope vertex
+/// is this close to the center in practice; the guard only exists so a
+/// degenerate input can never divide by zero.
+const MIN_EDGE_RADIUS: f32 = 1e-6;
+
+/// Wireframe Hyperslice band test: does a w-interval `[interval_min,
+/// interval_max]` intersect the slab centered on `w_slice`?
+///
+/// The slab is `[w_slice - half, w_slice + half]` where `half = thickness / 2`,
+/// with `thickness` floored at [`HYPERSLICE_MIN_THICKNESS`] so a user-set 0
+/// still admits straddling intervals instead of demanding f32 exact equality
+/// (see the constant's docstring). The two intervals intersect iff
+/// `interval_min <= slab_max && interval_max >= slab_min` (closed-band `<=`,
+/// so an interval endpoint sitting exactly on `w_slice +/- half` is kept).
+/// This is the standard 1D interval-overlap predicate; the closed bound is
+/// what makes the tesseract's `w = +/- 0.5` vertices a deterministic
+/// exact-boundary case.
+///
+/// The Hyperslice cull feeds this the w-range of each CELL the edge belongs to
+/// (not the edge's own endpoints), so the kept-edge decision agrees with the
+/// cell-level active-edge coloring and the cross-section, which are also
+/// cell-level. See [`cell_w_range`] and the cull closure in
+/// `render_wireframe_overlay`.
+fn slab_overlaps(interval_min: f32, interval_max: f32, w_slice: f32, thickness: f32) -> bool {
+    let half = thickness.max(HYPERSLICE_MIN_THICKNESS) * 0.5;
+    let slab_min = w_slice - half;
+    let slab_max = w_slice + half;
+    interval_min <= slab_max && interval_max >= slab_min
+}
+
+/// The body-local w-range `[w_min, w_max]` of a cell, folded over its vertex
+/// indices into `local_vertices` (rotor-rotated, `body_size`-scaled). This is
+/// the single source of a cell's w-extent: [`compute_cell_strengths`] folds it
+/// for the crossing-strength gradient and the Hyperslice cull folds it for the
+/// slab test, so the cull can never drift from the activity coloring. The fold
+/// order is `(lo.min, hi.max)` exactly, preserved for bit-reproducibility.
+fn cell_w_range(cell: &[u32], local_vertices: &[Vec4]) -> (f32, f32) {
+    cell.iter()
+        .map(|&i| local_vertices[i as usize].w)
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), w| {
+            (lo.min(w), hi.max(w))
+        })
+}
+
+/// Append a flat R⁴ chord `a` -> `b` to `mesh`, subdivided into
+/// [`SPACE_TESSELLATION_SAMPLES`] sub-segments and projected per-sample so a
+/// non-affine `projection` renders the edge as the curve it actually is. The
+/// straight-chord geometry is unchanged (each sample is `a.lerp(b, s)`, never
+/// bowed toward the sphere); only the screen polyline is refined. Colors lerp
+/// linearly between the endpoints, matching [`push_blended_edge`]'s sampling
+/// convention so the two paths are visually seamless.
+///
+/// Under [`rye_math::Projection::Stereographic`] the polyline is clipped at
+/// [`STEREOGRAPHIC_VIEW_RADIUS`]: a sub-segment is emitted only when BOTH its
+/// endpoints' body-local projected magnitudes are within the radius, so a
+/// near-pole sample (which the pole-denominator clamp maps to a huge finite
+/// point) is dropped rather than drawn. The clip is a sample-granularity drop in
+/// the same streaming `continue` idiom as the rasterizer's non-finite cull, not
+/// a magnitude rescale: rescaling a near-pole sample to the radius would keep the
+/// 180-degree direction flip across a pole crossing (see
+/// [`STEREOGRAPHIC_VIEW_RADIUS`]). When the projected point re-enters the radius
+/// the polyline resumes from the new in-bounds sample, never bridging across the
+/// dropped gap, so the edge runs out toward the view boundary and the offscreen
+/// blow-up is culled. No clip is applied for other projections
+/// ([`stereographic_clip_radius`] returns `None`).
+///
+/// Used by [`push_blended_edge`] for the flat-space (`blend == 0`) case under a
+/// non-affine projection (Stereographic / Schlegel), where a single straight
+/// segment would drift off the projected edge and the per-vertex-projected
+/// cross-section cap would float off the wireframe. Affine projections never reach
+/// here; they keep the single-segment fast path.
+#[allow(clippy::too_many_arguments)]
+fn push_projected_chord(
+    mesh: &mut LineMesh<3>,
+    a: Vec4,
+    b: Vec4,
+    color_a: [f32; 4],
+    color_b: [f32; 4],
+    width: f32,
+    projection: &rye_math::Projection<4>,
+    body_pos_r3: Vec3,
+) {
+    let samples = SPACE_TESSELLATION_SAMPLES;
+    let clip_radius = stereographic_clip_radius(projection);
+    // Seed from sample 0 (`a` exactly). `sample_at` returns the pre-translate
+    // projected point (for the clip test) and the world point (for the mesh).
+    let sample_at = |p4: Vec4| {
+        let projected = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+            p4, projection,
+        );
+        (projected, (projected + body_pos_r3).to_array())
+    };
+    let (proj0, world0) = sample_at(a);
+    let mut prev_world = world0;
+    let mut prev_c = color_a;
+    let mut prev_in = sample_in_radius(proj0, clip_radius);
+    for k in 1..=samples {
+        let s = k as f32 / samples as f32;
+        // Sample the straight 4D chord; `s == 1` recovers `b` exactly.
+        let (proj, world) = sample_at(a.lerp(b, s));
+        let c = [
+            color_a[0] + (color_b[0] - color_a[0]) * s,
+            color_a[1] + (color_b[1] - color_a[1]) * s,
+            color_a[2] + (color_b[2] - color_a[2]) * s,
+            color_a[3] + (color_b[3] - color_a[3]) * s,
+        ];
+        let cur_in = sample_in_radius(proj, clip_radius);
+        // Emit only when both endpoints are within the clip radius. A dropped
+        // sample breaks the polyline; the next in-bounds pair starts a fresh
+        // sub-segment rather than bridging the gap through the pole region.
+        if prev_in && cur_in {
+            mesh.segments.push((prev_world, world));
+            mesh.colors.push((prev_c, c));
+            mesh.widths.push(width);
+        }
+        prev_world = world;
+        prev_c = c;
+        prev_in = cur_in;
+    }
+}
+
+/// Whether a body-local projected sample lies within the clip radius.
+/// `radius == None` (no clip for this projection) keeps every sample;
+/// `Some(r)` drops samples whose magnitude exceeds `r`. Uses `length_squared`
+/// against `r * r` to avoid the `sqrt`, and the `<=` keeps a sample sitting
+/// exactly on the boundary (matching the closed-band discipline elsewhere).
+#[inline]
+fn sample_in_radius(projected: Vec3, radius: Option<f32>) -> bool {
+    match radius {
+        None => true,
+        Some(r) => projected.length_squared() <= r * r,
+    }
+}
+
+/// In-place near-pole clip for the section-cap FILL, at TRIANGLE granularity: a
+/// just-appended triangle in `indices[start_i..]` survives only when all three of
+/// its vertices' body-local projected points are within `radius`, mirroring the
+/// per-segment perimeter rule so fill and outline cull in lockstep. A triangle
+/// with a kept and a dropped vertex would otherwise tear into a gap the perimeter
+/// already drops, reintroducing the fill/outline mismatch.
+///
+/// `projected[i - start_v]` is the body-local projected point of mesh vertex `i`
+/// ([`cap_vertex_projected_and_world`]'s first element); indices are absolute into
+/// `mesh.vertices` (see `polytope_section_faces_append`), so `start_v` rebases an
+/// index into the per-append `projected` slice. Dropped triangles leave orphan
+/// vertices no kept triangle references, exactly as a dropped perimeter segment
+/// leaves its endpoints unreferenced. `radius == None` keeps every triangle
+/// (affine layers), so the appended range is untouched and bit-identical to the
+/// unclipped path. Compaction is a streaming two-pointer retain with no
+/// allocation. Returns the kept-triangle count for the caller to truncate to.
+fn retain_in_radius_triangles(
+    indices: &mut Vec<[u32; 3]>,
+    start_i: usize,
+    start_v: usize,
+    projected: &[Vec3],
+    radius: Option<f32>,
+) {
+    if radius.is_none() {
+        return;
+    }
+    let appended = &mut indices[start_i..];
+    let mut write = 0usize;
+    for read in 0..appended.len() {
+        let tri = appended[read];
+        let in_radius = tri
+            .iter()
+            .all(|&i| sample_in_radius(projected[i as usize - start_v], radius));
+        if in_radius {
+            appended[write] = tri;
+            write += 1;
+        }
+    }
+    indices.truncate(start_i + write);
+}
+
+/// Append one polytope edge to `mesh`, morphed between a flat R⁴ chord and an
+/// S³ great-circle arc by `blend` (0 = chord, 1 = arc; see [`Demo::space_blend`]).
+///
+/// `a` / `b` are the body-local 4D endpoints (rotor-rotated and `body_size`-scaled).
+/// Both interpolation curves share these endpoints because the polytope's
+/// vertices sit on the body's circumsphere, so the morph only bows the edge
+/// interior outward onto the sphere. The edge is emitted as a single straight R³
+/// chord only when it is flat (`blend == 0`) AND the projection maps a chord to a
+/// chord ([`projection_is_affine`]); a non-affine projection subdivides even the
+/// flat chord (via [`push_projected_chord`]) so the screen polyline follows the
+/// projected curve and the section cap lands on it. The blended (`blend > 0`) path
+/// always subdivides into [`SPACE_TESSELLATION_SAMPLES`] sub-segments with a
+/// per-sample chord/arc blend and a linear color gradient between the endpoint
+/// colors.
+///
+/// `slerp_scratch` is a caller-owned buffer reused across edges to keep the
+/// great-circle sampling off the per-edge allocation path; it is cleared on
+/// entry.
+///
+/// Divergence from a metric-geodesic morph: a `BlendedSpace::exp_target`
+/// geodesic between the flat and spherical metrics, RK4-integrated, is the
+/// textbook approach; this deliberately bypasses it. Each sample here is a
+/// direct `flat.lerp(sphere, blend)` (below): the flat point is the R⁴ chord
+/// sample, the spherical point is the scaled great-circle arc sample, and the
+/// two are linearly blended in the ambient R⁴. This is not a metric geodesic;
+/// it is a straight-line interpolation between two precomputed curves. The
+/// wireframe only needs the chord-to-arc *visual* morph (bow the edge interior
+/// out onto the sphere), and the direct lerp delivers exactly that while being
+/// (a) bit-deterministic with no RK4 step-size or accumulation error and (b)
+/// far cheaper than per-sample geodesic integration, which matters because this
+/// runs over every edge of the 600-cell wireframe each frame (the documented
+/// dominant per-frame cost). The endpoints are shared by both curves, so no
+/// metric fidelity is lost where it would be visible; only the interior path
+/// differs, and the arc sample already carries the S³ curvature the morph is
+/// meant to show.
+#[allow(clippy::too_many_arguments)]
+fn push_blended_edge(
+    mesh: &mut LineMesh<3>,
+    a: Vec4,
+    b: Vec4,
+    color_a: [f32; 4],
+    color_b: [f32; 4],
+    width: f32,
+    blend: f32,
+    projection: &rye_math::Projection<4>,
+    body_pos_r3: Vec3,
+    slerp_scratch: &mut Vec<Vec4>,
+) {
+    // Single-segment fast path: one straight R³ chord per edge, bit-identical to
+    // the pre-blend behavior. Valid only when the edge is a flat chord (`blend <=
+    // 0`) AND the projection sends a straight R⁴ chord to a straight R³ segment
+    // (`projection_is_affine`). Under a non-affine projection (Stereographic /
+    // Schlegel) the projected edge is a CURVE, so a single chord drifts off its own
+    // projected midpoint and the per-vertex-projected section cap floats off the
+    // wireframe; those fall through to the subdivided path below, which samples the
+    // flat chord and projects each sample so the polyline follows the projected
+    // curve. Kept ahead of any extra work so steady-state perf in the default mode
+    // (flat space, affine projection) is unaffected.
+    if blend <= 0.0 {
+        if projection_is_affine(projection) {
+            let a3 = project_to_world(a, projection, body_pos_r3);
+            let b3 = project_to_world(b, projection, body_pos_r3);
+            mesh.segments.push((a3.to_array(), b3.to_array()));
+            mesh.colors.push((color_a, color_b));
+            mesh.widths.push(width);
+            return;
+        }
+        // Flat chord, non-affine projection: the edge is still geometrically the
+        // straight R⁴ chord (no sphere bow), but its R³ image is a curve, so
+        // subdivide the chord and project each sample. This is what lets the
+        // per-vertex-projected section cap rejoin the wireframe. No slerp buffer
+        // needed; the chord has no radial arc.
+        push_projected_chord(mesh, a, b, color_a, color_b, width, projection, body_pos_r3);
+        return;
+    }
+
+    let radius_a = a.length();
+    let radius_b = b.length();
+    if radius_a < MIN_EDGE_RADIUS || radius_b < MIN_EDGE_RADIUS {
+        // Vertex effectively at the body center: no radial direction for slerp, so
+        // the sphere arc is undefined and the edge degrades to the flat chord.
+        // Affine projections render it as a single straight segment; non-affine
+        // ones subdivide so the projected chord still curves. Never reached in
+        // practice (regular polytope vertices are at circumradius `body_size`).
+        if projection_is_affine(projection) {
+            let a3 = project_to_world(a, projection, body_pos_r3);
+            let b3 = project_to_world(b, projection, body_pos_r3);
+            mesh.segments.push((a3.to_array(), b3.to_array()));
+            mesh.colors.push((color_a, color_b));
+            mesh.widths.push(width);
+            return;
+        }
+        push_projected_chord(mesh, a, b, color_a, color_b, width, projection, body_pos_r3);
+        return;
+    }
+
+    let samples = SPACE_TESSELLATION_SAMPLES;
+    let clip_radius = stereographic_clip_radius(projection);
+    // Unit endpoints on S³ for the great-circle arc; the per-sample radius lerp
+    // below restores the body's scale and keeps the endpoints exactly on `a`/`b`.
+    let p0u = a / radius_a;
+    let p1u = b / radius_b;
+    slerp_scratch.clear();
+    <rye_math::SphericalS3Embedded as rye_math::RasterizableSpace<4>>::tessellate_segment(
+        p0u,
+        p1u,
+        samples,
+        slerp_scratch,
+    );
+
+    // Sample 0 is `a` exactly (flat == sphere == a), so seed `prev` from it and
+    // emit consecutive sub-segments from sample 1. `slerp_scratch` holds exactly
+    // `samples + 1` points, so skipping the first walks indices 1..=samples.
+    // Same stereographic clip as `push_projected_chord`: drop a sub-segment whose
+    // endpoint leaves the clip radius (a near-pole blended sample), resuming the
+    // polyline when it re-enters; `clip_radius == None` keeps every sample.
+    let proj0 =
+        <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(a, projection);
+    let mut prev_world = (proj0 + body_pos_r3).to_array();
+    let mut prev_c = color_a;
+    let mut prev_in = sample_in_radius(proj0, clip_radius);
+    for (k, &arc_pt) in slerp_scratch.iter().enumerate().skip(1) {
+        let s = k as f32 / samples as f32;
+        let flat = a.lerp(b, s);
+        let radius = radius_a + (radius_b - radius_a) * s;
+        let sphere = radius * arc_pt;
+        let proj = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+            flat.lerp(sphere, blend),
+            projection,
+        );
+        let world = (proj + body_pos_r3).to_array();
+        let c = [
+            color_a[0] + (color_b[0] - color_a[0]) * s,
+            color_a[1] + (color_b[1] - color_a[1]) * s,
+            color_a[2] + (color_b[2] - color_a[2]) * s,
+            color_a[3] + (color_b[3] - color_a[3]) * s,
+        ];
+        let cur_in = sample_in_radius(proj, clip_radius);
+        if prev_in && cur_in {
+            mesh.segments.push((prev_world, world));
+            mesh.colors.push((prev_c, c));
+            mesh.widths.push(width);
+        }
+        prev_world = world;
+        prev_c = c;
+        prev_in = cur_in;
+    }
 }
 use rye_scene::{Scene4, SceneNode4};
 use rye_shape::LineMesh;
@@ -117,7 +605,10 @@ mod ui;
 
 use active::combo_name;
 use catalog::{parse_row_from_args, SHAPE_CATALOG};
-use consts::{BODY_SIZE, BODY_Y, T_SCRUB_RATE, T_SLIDER_INITIAL, W_SCRUB_RATE};
+use consts::{
+    BODY_SIZE, BODY_Y, HYPERSLICE_MIN_THICKNESS, SPACE_TESSELLATION_SAMPLES, T_SCRUB_RATE,
+    T_SLIDER_INITIAL, W_SCRUB_RATE,
+};
 use state::{
     body_position, CameraMode, Demo, RotationMode, SurfaceMode, ViewMode, WireframeColorMode,
     WireframeProjection,
@@ -234,12 +725,7 @@ fn compute_cell_strengths(cells: &[&[u32]], local_vertices: &[Vec4], w_slice: f3
     cells
         .iter()
         .map(|cell| {
-            let (w_min, w_max) = cell
-                .iter()
-                .map(|&i| local_vertices[i as usize].w)
-                .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), w| {
-                    (lo.min(w), hi.max(w))
-                });
+            let (w_min, w_max) = cell_w_range(cell, local_vertices);
             let half_extent = (w_max - w_min) * 0.5;
             if half_extent <= 0.0 {
                 return 0.0;
@@ -459,17 +945,26 @@ impl Demo {
             parent_wireframe,
             wireframe_enabled: false,
             wireframe_nearest_active: true,
-            wireframe_perimeter: true,
+            cross_section: state::SectionLayer::CROSS_SECTION_DEFAULT,
+            projected_cap: state::SectionLayer::PROJECTED_CAP_DEFAULT,
             wireframe_color_mode: WireframeColorMode::default(),
             wireframe_projection: WireframeProjection::default(),
+            // Default projection is drop-w, so no Schlegel cache is needed at
+            // startup; it is resolved the moment the user selects Schlegel.
+            schlegel_params: None,
+            stereographic_pole: state::STEREOGRAPHIC_DEFAULT_POLE,
+            wireframe_hyperslice: false,
+            wireframe_hyperslice_thickness: consts::HYPERSLICE_DEFAULT_THICKNESS,
+            space_blend: 0.0,
             wireframe_width_px: 1.8,
             wireframe_alpha: 1.0,
             unique_edge_palette_cache: std::collections::HashMap::new(),
             surface_scale: 1.0,
-            surface_alpha: 1.0,
             floor_enabled: true,
             section_faces,
             section_faces_translucent,
+            section_faces_projected_scratch: rye_shape::TriangleMesh::<3>::default(),
+            section_clip_projected_scratch: Vec::new(),
             points_node,
             points_enabled: false,
             points_show_vertices: true,
@@ -479,6 +974,8 @@ impl Demo {
             section_faces_depth: None,
             section_world_vertices_scratch: Vec::new(),
             section_faces_mesh_scratch: rye_shape::TriangleMesh::<3>::default(),
+            body_uniform_scratch: Vec::new(),
+            slerp_scratch: Vec::new(),
             surface_mode: SurfaceMode::default(),
             row,
             w_slice: initial_w,
@@ -504,6 +1001,16 @@ impl Demo {
             example_callout: rye_egui::CalloutState {
                 window_pos: egui::Pos2::new(220.0, 120.0),
                 open: false,
+            },
+            // On by default: the moment a user picks a non-default projection or
+            // turns up Curvature, the annotation explains the mode without their
+            // having to read the source. `render_mode_annotation` no-ops while the
+            // scene is in its plain drop-w + flat-space default, so an open flag
+            // costs nothing until a non-default mode is selected. Default position
+            // sits below the example callout's default slot so the two don't stack.
+            mode_annotation_open: rye_egui::CalloutState {
+                window_pos: egui::Pos2::new(220.0, 300.0),
+                open: true,
             },
             show_formula: false,
             show_controls: true,
@@ -780,6 +1287,92 @@ impl Demo {
         // callout). Demonstrates the rye_egui::callout primitive against the first
         // polychoron in the row.
         self.render_example_callout(ctx, frame);
+        // Per-mode educational annotation (on by default; toggle via View > Mode
+        // annotation). No-ops in the default drop-w + flat-space scene; otherwise
+        // explains the active projection / curvature combination.
+        self.render_mode_annotation(ctx, frame);
+    }
+
+    /// Surface the per-projection / per-space-mode educational annotation via the
+    /// `rye_egui::callout` primitive, anchored to the leading polychoron's body
+    /// center. The text is the pure [`state::mode_annotation`] mapping of the
+    /// active `(wireframe_projection, effective_blend, raster-cap)` state,
+    /// reprojected per frame so the leader line tracks the shape as the camera
+    /// orbits. `effective_blend` is `space_blend` only while the wireframe overlay
+    /// is enabled (the bowed edges live there and nowhere else), so a curvature
+    /// value set while the overlay is off does not produce a spherical annotation
+    /// for geometry that is not on screen. No-op when the toggle is off, the row
+    /// has no polychoron, or the scene is in its plain default state (drop-w
+    /// projection AND no visible curvature), where the mapping returns `None` and
+    /// there is nothing non-obvious to explain.
+    ///
+    /// Anchoring to the body center (not a single vertex like
+    /// [`Self::render_example_callout`]) is deliberate: the annotation is about the
+    /// whole shape's projection / curvature, not one vertex, so the body center is
+    /// the honest anchor.
+    fn render_mode_annotation(&mut self, ctx: &egui::Context, frame: &mut FrameCtx<'_>) {
+        if !self.mode_annotation_open.open {
+            return;
+        }
+        // The flat cross-section cap is drawn only in Raster surface mode; this
+        // gates the three-way-overlap note inside `mode_annotation`.
+        let flat_cap_drawn = matches!(self.surface_mode, SurfaceMode::Raster);
+        // The spherical-curvature morph is wireframe-only: `space_blend` bows the
+        // edges in `push_blended_edge`, reached only from `render_wireframe_overlay`,
+        // and that path is skipped while the overlay is off. The caps and the
+        // projection stay visible without the wireframe, but the bowed edges do
+        // not, so report the blend as flat when the overlay is off (see
+        // `annotation_effective_blend`) and the annotation never claims curvature
+        // the user cannot see.
+        let effective_blend =
+            state::annotation_effective_blend(self.space_blend, self.wireframe_enabled);
+        let Some(annotation) =
+            state::mode_annotation(self.wireframe_projection, effective_blend, flat_cap_drawn)
+        else {
+            return;
+        };
+
+        // Anchor: the leading polychoron's body center in world R³. Same
+        // render-row selection the example callout and every per-body path use, so
+        // the annotation tracks whichever shape the projection diagram is about.
+        let render_row = state::render_row_entries(self.view_mode, &self.row, &self.strip_subject);
+        let n = render_row.len();
+        let Some((slot, _entry)) = render_row
+            .iter()
+            .enumerate()
+            .find(|(_, e)| e.shape.polytope4().is_some())
+        else {
+            return;
+        };
+        let body_pos = body_position(slot, n);
+        let world_pos = Vec3::new(body_pos[0], body_pos[1], body_pos[2]);
+
+        let view_dir = self.camera.view();
+        let cfg = &frame.rd.surface_bundle.config;
+        let ppp = ctx.pixels_per_point();
+        let vp_w = (cfg.width as f32 / ppp).round() as u32;
+        let vp_h = (cfg.height as f32 / ppp).round() as u32;
+        let Some(screen_pos) = rye_egui::world_to_screen(
+            world_pos,
+            &view_dir,
+            60.0_f32.to_radians(),
+            (vp_w, vp_h),
+            0.1,
+            100.0,
+        ) else {
+            return;
+        };
+
+        rye_egui::callout(
+            ctx,
+            "polytope-playground-mode-annotation",
+            screen_pos,
+            &mut self.mode_annotation_open,
+            annotation.title,
+            |ui| {
+                ui.label(&annotation.body);
+            },
+        );
     }
 
     /// Demonstrate the `rye_egui::callout` primitive against the first polychoron in
@@ -791,9 +1384,11 @@ impl Demo {
         if !self.example_callout.open {
             return;
         }
-        // Find the first polychoron in the row; its vertex 0 is the anchor target.
-        let Some((slot, entry)) = self
-            .row
+        // Find the first polychoron in the RENDERED row (the lone `strip_subject`
+        // in Single mode); its vertex 0 is the anchor target.
+        let render_row = state::render_row_entries(self.view_mode, &self.row, &self.strip_subject);
+        let n = render_row.len();
+        let Some((slot, entry)) = render_row
             .iter()
             .enumerate()
             .find(|(_, e)| e.shape.polytope4().is_some())
@@ -806,9 +1401,8 @@ impl Demo {
         let v_local_4d = self.effective_body_size() * self.rot_state.apply(canonical_v0);
         let v_local_r3 = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
             v_local_4d,
-            &self.wireframe_projection.to_projection(),
+            &self.resolved_wireframe_projection(),
         );
-        let n = self.row.len();
         let body_pos = body_position(slot, n);
         let world_pos = v_local_r3 + Vec3::new(body_pos[0], body_pos[1], body_pos[2]);
 
@@ -1130,8 +1724,20 @@ impl Demo {
     /// edge-indexed and has no canonical vertex assignment.
     fn render_points(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> Result<()> {
         let cfg = &rd.surface_bundle.config;
-        let n = self.row.len();
-        let wireframe_projection = self.wireframe_projection.to_projection();
+        // Rendered row: full `row` in Shapes, just the `strip_subject` in Single.
+        // Disjoint field borrow so the `&mut self.points_mesh_scratch` below stays
+        // accessible.
+        let render_row = state::render_row_entries(self.view_mode, &self.row, &self.strip_subject);
+        let n = render_row.len();
+        let wireframe_projection = self.resolved_wireframe_projection();
+        // Near-pole drop radius, shared with the wireframe edges and the cap
+        // outline (`stereographic_clip_radius`): under Stereographic a vertex or
+        // cell-center within the angular epsilon of the pole projects to the
+        // large-but-finite clamp point, which would draw as a giant disc while
+        // the touching edges are dropped. Gating the point push on the same
+        // predicate keeps the points overlay consistent with the wireframe.
+        // `None` for every other projection, so nothing is dropped there.
+        let points_clip_radius = stereographic_clip_radius(&wireframe_projection);
         // Active-mode palette: bright green for vertices that belong to a
         // currently-intersected cell, dim gray otherwise. Same hues the
         // wireframe overlay uses so the visual identity stays consistent.
@@ -1146,7 +1752,7 @@ impl Demo {
         mesh.colors.clear();
         mesh.sizes.clear();
 
-        for (slot, entry) in self.row.iter().enumerate() {
+        for (slot, entry) in render_row.iter().enumerate() {
             let Some(polytope) = entry.shape.polytope4() else {
                 continue;
             };
@@ -1201,6 +1807,11 @@ impl Demo {
                             v_local,
                             &wireframe_projection,
                         );
+                    // Drop a near-pole vertex (clean blink) instead of a giant
+                    // clamp disc; matches the wireframe/perimeter drop.
+                    if !sample_in_radius(v3_local, points_clip_radius) {
+                        continue;
+                    }
                     let v_world = v3_local + body_pos_r3;
                     let color = match color_mode {
                         // Position-gradient also covers UniqueEdge, since the
@@ -1243,6 +1854,10 @@ impl Demo {
                             c_local,
                             &wireframe_projection,
                         );
+                    // Same near-pole drop as the vertex loop above.
+                    if !sample_in_radius(c3_local, points_clip_radius) {
+                        continue;
+                    }
                     let c_world = c3_local + body_pos_r3;
                     let color = match color_mode {
                         WireframeColorMode::VertexGradient | WireframeColorMode::UniqueEdge => {
@@ -1288,28 +1903,117 @@ impl Demo {
         Ok(())
     }
 
+    /// Render the rasterized section as TWO independent overlaid layers in one
+    /// viewport:
+    ///
+    /// - the honest cross-section (the drop-w slice 3-flat, NEVER reprojected
+    ///   through the active wireframe projection; the same geometry the SDF
+    ///   raymarch shows), and
+    /// - the projected cap (the same slice reprojected through the active
+    ///   wireframe projection so it can sit on a Schlegel / stereographic
+    ///   wireframe).
+    ///
+    /// Each layer's fill alpha is its own switch (`SectionLayer::fill_visible`):
+    /// a layer with alpha 0 submits no triangles. The honest layer draws first so
+    /// the opt-in projected cap composites over it when both are on. Defaults draw
+    /// only the honest layer, so selecting a distorting projection never silently
+    /// reshapes the slice the user reads as "the cross-section."
     fn render_section_faces(&mut self, rd: &RenderDevice, view: &wgpu::TextureView) -> Result<()> {
         let cfg = &rd.surface_bundle.config;
-        let n = self.row.len();
+        let cross = self.cross_section;
+        let cap = self.projected_cap;
+        // Nothing to fill: both layers off. The perimeter outlines are drawn by
+        // the wireframe overlay, not here, so an all-alpha-zero section skips the
+        // triangle passes entirely.
+        if !cross.fill_visible() && !cap.fill_visible() {
+            return Ok(());
+        }
 
-        // Reuse the per-Demo scratch mesh; capacity grows once to fit the largest
-        // polychoron and stays there. Each frame's `clear()` keeps the underlying
-        // allocations.
+        // Resolve the active projection ONCE (the Schlegel arm reads
+        // `schlegel_params` + `rot_state` immutably) before any `&mut` scratch
+        // borrow. The honest layer overrides this to drop-w via
+        // `section_layer_projection`; the projected cap keeps it.
+        let wireframe_projection = self.resolved_wireframe_projection();
+        let w_slice = self.w_slice;
+
+        // Build whichever layers are visible, in one pass over the row so the
+        // body-local 4D section vertices are computed once and shared. Each layer
+        // gets its own scratch mesh; both keep their capacity across frames.
+        self.build_section_layer_meshes(wireframe_projection, w_slice, cross, cap);
+
+        // Camera matches the SDF raymarcher's effective view-projection (same as
+        // the wireframe overlay uses), so pixel-aligned composition over the SDF.
+        let view_dir = self.camera.view();
+        let aspect = cfg.width as f32 / cfg.height as f32;
+        let view_mat = Mat4::look_to_rh(view_dir.position, view_dir.forward, view_dir.up);
+        let proj_mat = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
+        let view_proj = proj_mat * view_mat;
+
+        // Honest cross-section first, then the projected cap on top.
+        if cross.fill_visible() {
+            self.execute_section_layer(rd, view, view_proj, cross.surface_alpha, true)?;
+        }
+        if cap.fill_visible() {
+            self.execute_section_layer(rd, view, view_proj, cap.surface_alpha, false)?;
+        }
+        Ok(())
+    }
+
+    /// Append every polychoral body's cross-section caps into the visible layer
+    /// scratch meshes, mapping each layer's body-local R³ caps to world R³ under
+    /// that layer's projection ([`state::section_layer_projection`]: drop-w for
+    /// the honest cross-section, the active `wireframe_projection` for the
+    /// projected cap). Both meshes are cleared on entry and reuse their
+    /// allocations across frames; a layer that is not `SectionLayer::fill_visible`
+    /// is skipped so its mesh stays empty.
+    ///
+    /// Single pass over the row: the body-local 4D section vertices
+    /// (`rot_state`-rotated, `effective_body_size`-scaled) are identical for both
+    /// layers, so they are computed once per body and both layers' caps are
+    /// appended from the same `polytope_section_faces_append` source before the
+    /// per-layer world transform.
+    fn build_section_layer_meshes(
+        &mut self,
+        wireframe_projection: rye_math::Projection<4>,
+        w_slice: f32,
+        cross: state::SectionLayer,
+        cap: state::SectionLayer,
+    ) {
+        let render_row = state::render_row_entries(self.view_mode, &self.row, &self.strip_subject);
+        let n = render_row.len();
         let body_size = self.effective_body_size();
-        let combined = &mut self.section_faces_mesh_scratch;
-        combined.vertices.clear();
-        combined.colors.clear();
-        combined.indices.clear();
 
-        // Same perspective scaling logic the wireframe path uses (see render_wireframe_overlay):
-        // section the body in body-local 4D, then translate the produced R³ caps by the body's
-        // R³ position with the active perspective scale at the slice's w. With drop-w this
-        // collapses to identity scaling; with Perspective4D the cap scales by
-        // `focal / (focal - w_slice)`.
-        let wireframe_projection = self.wireframe_projection.to_projection();
-        let section_scale = perspective_scale_at_w(self.w_slice, &wireframe_projection);
+        // The honest layer is always drop-w; the projected cap follows the active
+        // projection. `Identity` makes `perspective_scale_at_w` report `Some(1.0)`,
+        // so the honest cap is just scaled-by-one and translated (drop-w + world
+        // translate), bit-identical to the inhabitant's view of the slice 3-flat.
+        let cross_projection = state::section_layer_projection(true, wireframe_projection);
+        let cap_projection = state::section_layer_projection(false, wireframe_projection);
+        let cross_scale = perspective_scale_at_w(w_slice, &cross_projection);
+        let cap_scale = perspective_scale_at_w(w_slice, &cap_projection);
+        // Near-pole drop radius per layer, shared with the wireframe edges and the
+        // cap outline. The cross layer is drop-w (Identity), so its radius is
+        // `None` and every triangle is kept, bit-identical to before this clip.
+        // The cap layer is `None` unless the active projection is Stereographic.
+        let cross_clip = stereographic_clip_radius(&cross_projection);
+        let cap_clip = stereographic_clip_radius(&cap_projection);
 
-        for (slot, entry) in self.row.iter().enumerate() {
+        // Reused per-vertex projected-point buffer for the triangle-granularity
+        // fill clip, taken out so the `append_layer` closure can hold it `&mut`
+        // alongside the immutable `section_world_vertices_scratch` borrow without
+        // a second `&mut self`. Put back at the end so its capacity persists.
+        let mut proj_scratch = std::mem::take(&mut self.section_clip_projected_scratch);
+
+        let cross_mesh = &mut self.section_faces_mesh_scratch;
+        cross_mesh.vertices.clear();
+        cross_mesh.colors.clear();
+        cross_mesh.indices.clear();
+        let cap_mesh = &mut self.section_faces_projected_scratch;
+        cap_mesh.vertices.clear();
+        cap_mesh.colors.clear();
+        cap_mesh.indices.clear();
+
+        for (slot, entry) in render_row.iter().enumerate() {
             let Some(polytope) = entry.shape.polytope4() else {
                 continue;
             };
@@ -1317,9 +2021,10 @@ impl Demo {
             let body_pos = body_position(slot, n);
             let body_pos_r3 = Vec3::new(body_pos[0], body_pos[1], body_pos[2]);
 
-            // Body-local 4D scratch (rotor-rotated, scaled, NO world translate). Same
-            // rationale as the wireframe path: keep the body's R³ position out of the 4D
-            // perspective math so it doesn't get scaled by `focal / (focal - w)`.
+            // Body-local 4D section vertices (rotor-rotated, scaled, NO world
+            // translate): keep the body's R³ position out of the 4D perspective
+            // math so it doesn't get scaled by `focal / (focal - w)`. Shared by
+            // both layers below.
             self.section_world_vertices_scratch.clear();
             self.section_world_vertices_scratch.extend(
                 topo.vertices
@@ -1327,76 +2032,123 @@ impl Demo {
                     .map(|v| body_size * self.rot_state.apply(*v)),
             );
 
-            // Match the SDF's per-body solid coloring: every cap of this polychoron uses
-            // the body's identity color from the catalog. Per-face Lambert in the fragment
-            // shader adds the geometric depth; the underlying color is flat. Alpha is
-            // the user-tuneable `surface_alpha` (default 1.0); below 1.0 the wireframe
-            // overlay behind composites through via `SrcAlpha/OneMinusSrcAlpha` blending.
+            // Match the SDF's per-body solid coloring: every cap uses the body's
+            // catalog color; per-face Lambert adds the geometric depth. Alpha is
+            // the layer's own `surface_alpha`; below 1.0 the layer renders through
+            // the no-depth-write pipeline so layers behind composite through.
             let [r, g, b] = entry.body_color;
-            let start = combined.vertices.len();
-            polytope_section_faces_append(
-                topo.edges,
-                topo.cells,
-                &self.section_world_vertices_scratch,
-                WPlane::new(self.w_slice),
-                [r, g, b, self.surface_alpha],
-                combined,
-            );
-            // Translate this body's body-local cap vertices into world R³. Indices were
-            // emitted with the correct vertex offset already (the `_append` API handles
-            // that internally); only the vertex positions need rebasing.
-            for v in &mut combined.vertices[start..] {
-                *v = local_r3_to_world(*v, section_scale, body_pos_r3);
+
+            // Append + world-transform a single layer's caps for this body. The
+            // section algorithm emits body-local drop-w R³;
+            // `cap_vertex_projected_and_world` maps it through the layer's
+            // projection (affine scale-and-translate, or per-vertex reconstruction
+            // at `w_slice` for non-affine) and also returns the body-local
+            // projected point the near-pole clip tests. Under a clipped projection
+            // (Stereographic) a fill triangle is dropped when ANY of its three
+            // projected vertices exceeds `clip_radius`, matching the per-segment
+            // perimeter rule so fill and outline cull in lockstep. The triangle
+            // drop is in-place over the just-appended index range; dropped
+            // triangles leave orphan vertices that no kept triangle references.
+            let append_layer = |mesh: &mut rye_shape::TriangleMesh<3>,
+                                proj_scratch: &mut Vec<Vec3>,
+                                alpha: f32,
+                                projection: &rye_math::Projection<4>,
+                                scale: Option<f32>,
+                                clip_radius: Option<f32>| {
+                let start_v = mesh.vertices.len();
+                let start_i = mesh.indices.len();
+                polytope_section_faces_append(
+                    topo.edges,
+                    topo.cells,
+                    &self.section_world_vertices_scratch,
+                    WPlane::new(w_slice),
+                    [r, g, b, alpha],
+                    mesh,
+                );
+                proj_scratch.clear();
+                for v in &mut mesh.vertices[start_v..] {
+                    let (projected, world) =
+                        cap_vertex_projected_and_world(*v, w_slice, scale, projection, body_pos_r3);
+                    *v = world;
+                    proj_scratch.push(projected);
+                }
+                // Drop fill triangles touching a near-pole vertex (no-op for the
+                // affine `None` layers, which keep every triangle).
+                retain_in_radius_triangles(
+                    &mut mesh.indices,
+                    start_i,
+                    start_v,
+                    proj_scratch,
+                    clip_radius,
+                );
+            };
+
+            if cross.fill_visible() {
+                append_layer(
+                    cross_mesh,
+                    &mut proj_scratch,
+                    cross.surface_alpha,
+                    &cross_projection,
+                    cross_scale,
+                    cross_clip,
+                );
+            }
+            if cap.fill_visible() {
+                append_layer(
+                    cap_mesh,
+                    &mut proj_scratch,
+                    cap.surface_alpha,
+                    &cap_projection,
+                    cap_scale,
+                    cap_clip,
+                );
             }
         }
 
-        // Empty mesh handling lives in `TriangleRasterNode::execute` (it short-circuits
-        // when `index_count == 0`); no need for a redundant early-return here.
+        // Return the reused buffer so its capacity persists across frames.
+        self.section_clip_projected_scratch = proj_scratch;
+    }
 
-        // Camera matches the SDF raymarcher's effective view-projection (same as the
-        // wireframe overlay uses), so pixel-aligned composition over the SDF pass.
-        let view_dir = self.camera.view();
-        let aspect = cfg.width as f32 / cfg.height as f32;
-        let view_mat = Mat4::look_to_rh(view_dir.position, view_dir.forward, view_dir.up);
-        let proj_mat = Mat4::perspective_rh(60.0_f32.to_radians(), aspect, 0.1, 100.0);
-        let view_proj = proj_mat * view_mat;
-
+    /// Upload + execute one already-built section layer's triangle mesh. Picks the
+    /// opaque vs translucent node by the layer's `alpha`: opaque (>= 1.0) writes
+    /// depth so caps occlude one another within a polytope; translucent (< 1.0)
+    /// skips depth-write so the parent wireframe (and any layer drawn behind) shows
+    /// through. `is_cross_section` selects which scratch mesh to upload. Each call
+    /// is a self-contained submit, so the two nodes are reused across both layers.
+    fn execute_section_layer(
+        &mut self,
+        rd: &RenderDevice,
+        view: &wgpu::TextureView,
+        view_proj: Mat4,
+        alpha: f32,
+        is_cross_section: bool,
+    ) -> Result<()> {
+        // Disjoint field borrows: the depth attachment, the chosen scratch mesh,
+        // and the chosen node are three distinct fields, so the borrow checker
+        // accepts the immutable depth + scratch reads alongside the `&mut` node
+        // within this one method body (the same pattern the pre-split path used).
         // The shared depth attachment is ensured + cleared once per frame by
-        // `ensure_and_clear_shared_depth` at the top of the Shapes-view render path;
-        // here we just consume the view for the triangle pass's depth-write.
-        let depth = self
+        // `ensure_and_clear_shared_depth`; here we just consume its view.
+        let depth_view = &self
             .section_faces_depth
             .as_ref()
-            .expect("shared depth buffer must be ensured before section_faces");
-
-        // Pick the depth-write variant based on `surface_alpha`: opaque
-        // (1.0) writes depth so caps occlude one another correctly within
-        // a polytope; translucent (< 1.0) skips depth-write so the parent
-        // wireframe drawn after sees through. The two nodes carry their
-        // own GPU buffers, so we upload the mesh into whichever path
-        // we're about to execute.
-        if self.surface_alpha >= 1.0 {
-            self.section_faces.set_camera(&rd.queue, view_proj);
-            self.section_faces.upload::<EuclideanR3, 3>(
-                &rd.device,
-                &rd.queue,
-                combined,
-                &rye_math::Projection::Identity,
-            );
-            self.section_faces
-                .execute(rd, view, Some(&depth.view), None)?;
+            .expect("shared depth buffer must be ensured before section_faces")
+            .view;
+        let mesh = if is_cross_section {
+            &self.section_faces_mesh_scratch
         } else {
-            self.section_faces_translucent
-                .set_camera(&rd.queue, view_proj);
-            self.section_faces_translucent.upload::<EuclideanR3, 3>(
-                &rd.device,
-                &rd.queue,
-                combined,
-                &rye_math::Projection::Identity,
-            );
-            self.section_faces_translucent
-                .execute(rd, view, Some(&depth.view), None)?;
-        }
+            &self.section_faces_projected_scratch
+        };
+        // Empty-mesh handling lives in `TriangleRasterNode::execute` (it short-
+        // circuits when `index_count == 0`); no redundant early-return here.
+        let node = if alpha >= 1.0 {
+            &mut self.section_faces
+        } else {
+            &mut self.section_faces_translucent
+        };
+        node.set_camera(&rd.queue, view_proj);
+        node.upload::<EuclideanR3, 3>(&rd.device, &rd.queue, mesh, &rye_math::Projection::Identity);
+        node.execute(rd, view, Some(depth_view), None)?;
         Ok(())
     }
 
@@ -1418,9 +2170,13 @@ impl Demo {
         view: &wgpu::TextureView,
     ) -> Result<()> {
         let cfg = &rd.surface_bundle.config;
-        let n = self.row.len();
+        // Rendered row: full `row` in Shapes, just the `strip_subject` in Single.
+        // Bound via disjoint field borrows so the `&mut self.unique_edge_palette_cache`
+        // inside the loop stays accessible; no allocation on this hot path.
+        let render_row = state::render_row_entries(self.view_mode, &self.row, &self.strip_subject);
+        let n = render_row.len();
 
-        // Build combined meshes across the entire row.
+        // Build combined meshes across the rendered row.
         let mut section_edges = LineMesh::<3>::default();
         let mut parent_lines = LineMesh::<3>::default();
         // Uniform-alpha endpoints when `nearest-active` is off; the active-mode mapping
@@ -1445,9 +2201,42 @@ impl Demo {
         let color_mode = self.wireframe_color_mode;
         // Resolve once per frame; same projection applied to every body's wireframe so all
         // bodies share a consistent R³ embedding.
-        let wireframe_projection = self.wireframe_projection.to_projection();
+        let wireframe_projection = self.resolved_wireframe_projection();
+        // Per-layer perimeter toggles + the honest layer's always-drop-w
+        // projection (the active projection is forced to `Identity` for the
+        // cross-section so its outline can never follow a distorting projection).
+        let cross_perimeter = self.cross_section.perimeter;
+        let cap_perimeter = self.projected_cap.perimeter;
+        let cross_section_projection = state::section_layer_projection(true, wireframe_projection);
+        // Flat-chord vs S³-arc morph for every edge (0 = chord). Captured once so
+        // the per-edge helper stays free of `&self`.
+        let space_blend = self.space_blend;
+        // Wireframe Hyperslice cull: when on, only edges whose body-local
+        // w-interval intersects the slab around `w_slice` survive. Captured
+        // once per frame. This is a third, independent slicing affordance
+        // alongside the SDF raymarch's w-slice (raymarch/hyperslice4d.rs) and
+        // the cyan section perimeter; it culls the *parent wireframe edges* to
+        // those near the current 4D cut so the graph thins to "what the slice
+        // is passing through" instead of the whole polytope. A demo-side
+        // per-edge FILTER, deliberately NOT a `Projection` variant: the
+        // projection returns a Vec3 that has already discarded w, so it cannot
+        // honestly carry a keep/drop signal, and a sentinel-NaN projection
+        // would mis-clip boundary-crossing edges at vertex granularity.
+        //
+        // The `Hyperslice` projection mode IS this cull paired with drop-w: it
+        // resolves to `Projection::Identity` (the slicing is the cull, not a
+        // projection), so selecting it activates the filter even when the
+        // independent `wireframe_hyperslice` toggle is off. The standalone toggle
+        // still composes the cull with any other projection mode.
+        let hyperslice_on = self.hyperslice_cull_active();
+        let hyperslice_thickness = self.wireframe_hyperslice_thickness;
+        let hyperslice_w_slice = self.w_slice;
+        // Reused great-circle sampling buffer, taken from the demo so its
+        // capacity persists across frames; `push_blended_edge` clears it per
+        // edge, and it is put back after the loop.
+        let mut slerp_scratch = std::mem::take(&mut self.slerp_scratch);
 
-        for (slot, entry) in self.row.iter().enumerate() {
+        for (slot, entry) in render_row.iter().enumerate() {
             let Some(polytope) = entry.shape.polytope4() else {
                 continue;
             };
@@ -1469,27 +2258,63 @@ impl Demo {
                 .map(|v| body_size * self.rot_state.apply(*v))
                 .collect();
 
-            // Cross-section perimeter edges. The cyan outlines bound each cell cap on the
-            // slice; gated by `wireframe_perimeter` so users can show the parent edge graph
-            // on its own. `polytope_section_overlay_with_vertices` uses drop-w internally,
-            // so its R³ output is in body-local frame; we apply the perspective scale at
-            // w_slice (uniform across the cap because every cap point shares the slice's w)
-            // and translate to world R³.
-            if self.wireframe_perimeter {
-                let section_scale = perspective_scale_at_w(self.w_slice, &wireframe_projection);
-                let (_tri, mut perim) = polytope_section_overlay_with_vertices(
+            // Cross-section perimeter outlines, one per enabled layer overlaid in
+            // this one viewport. `polytope_section_overlay_with_vertices` returns
+            // the slice's body-local drop-w R³ perimeter (computed once, shared by
+            // both layers): the honest cross-section maps it through drop-w (NEVER
+            // the active projection, so its outline matches the SDF slice), and the
+            // projected cap maps it through the active `wireframe_projection` so its
+            // outline sits on the projected wireframe. Each layer maps endpoints to
+            // world R³ and, under a clipped projection (Stereographic), drops a
+            // whole perimeter segment when either endpoint's body-local projected
+            // magnitude exceeds the clip radius (per-segment because a perimeter
+            // segment is a single cap edge, not a polyline).
+            if cross_perimeter || cap_perimeter {
+                let (_tri, perim) = polytope_section_overlay_with_vertices(
                     topo.edges,
                     topo.cells,
                     &local_vertices,
                     WPlane::new(self.w_slice),
                 );
-                for (a, b) in &mut perim.segments {
-                    *a = local_r3_to_world(*a, section_scale, body_pos_r3);
-                    *b = local_r3_to_world(*b, section_scale, body_pos_r3);
+                let w_slice = self.w_slice;
+                let mut push_perimeter = |projection: &rye_math::Projection<4>| {
+                    let section_scale = perspective_scale_at_w(w_slice, projection);
+                    let clip_radius = stereographic_clip_radius(projection);
+                    for ((a, b), (color, width)) in perim
+                        .segments
+                        .iter()
+                        .zip(perim.colors.iter().zip(perim.widths.iter()))
+                    {
+                        let (pa, wa) = cap_vertex_projected_and_world(
+                            *a,
+                            w_slice,
+                            section_scale,
+                            projection,
+                            body_pos_r3,
+                        );
+                        let (pb, wb) = cap_vertex_projected_and_world(
+                            *b,
+                            w_slice,
+                            section_scale,
+                            projection,
+                            body_pos_r3,
+                        );
+                        if !sample_in_radius(pa, clip_radius) || !sample_in_radius(pb, clip_radius)
+                        {
+                            continue;
+                        }
+                        section_edges.segments.push((wa, wb));
+                        section_edges.colors.push(*color);
+                        section_edges.widths.push(*width);
+                    }
+                };
+                // Honest cross-section first (drop-w), then the projected cap.
+                if cross_perimeter {
+                    push_perimeter(&cross_section_projection);
                 }
-                section_edges.segments.append(&mut perim.segments);
-                section_edges.colors.append(&mut perim.colors);
-                section_edges.widths.append(&mut perim.widths);
+                if cap_perimeter {
+                    push_perimeter(&wireframe_projection);
+                }
             }
 
             // Per-cell "crossing strength" in [0, 1] - shared with render_points
@@ -1523,6 +2348,33 @@ impl Demo {
                     .iter()
                     .zip(cell_strengths.iter())
                     .any(|(cell, &s)| s > 0.0 && cell.contains(&i) && cell.contains(&j))
+            };
+
+            // Hyperslice cull, evaluated per edge before any color / projection
+            // / tessellation work. The kept-edge decision is CELL-level, matching
+            // `edge_is_active` and the cross-section: an edge survives iff some
+            // cell containing BOTH endpoints has its w-range overlapping the slab.
+            // The edge-level test (its own endpoints straddling the slab) would
+            // cull a far-side edge of an active cell even though that edge is
+            // colored active-green, since the coloring reads the whole cell's
+            // w-range, not the edge's. Folding `cell_w_range` here keeps the two
+            // in lockstep.
+            //
+            // This is the slab-with-thickness band, a SUPERSET of `edge_is_active`
+            // (which is the zero-width `w_min < w_slice < w_max` plane): the cull
+            // keeps every active-green edge plus the thickness margin the user
+            // dials in, so active edges are never culled while the band still
+            // thins the graph. Same `cells.iter()` membership cost as the two
+            // coloring closures above, so the cull introduces no new asymptotic
+            // work and no per-frame allocation.
+            let edge_in_slab_cell = |i: u32, j: u32| -> bool {
+                topo.cells.iter().any(|cell| {
+                    if !(cell.contains(&i) && cell.contains(&j)) {
+                        return false;
+                    }
+                    let (w_min, w_max) = cell_w_range(cell, &local_vertices);
+                    slab_overlaps(w_min, w_max, hyperslice_w_slice, hyperslice_thickness)
+                })
             };
 
             // Parent wireframe: every polytope edge as a world-R³ line. Base RGB is
@@ -1579,6 +2431,16 @@ impl Demo {
                 let ja = j as usize;
                 let a = local_vertices[ia];
                 let b = local_vertices[ja];
+                // Cell-level Hyperslice cull (see `edge_in_slab_cell`),
+                // evaluated before any color / projection / tessellation work so
+                // a culled edge costs only the membership fold. The local-`w`
+                // frame the slab tests against is the same one the SDF marcher
+                // and the section algorithm slice (the body sits at world
+                // `w = 0`). The `&&` short-circuits the fold entirely when the
+                // affordance is off.
+                if hyperslice_on && !edge_in_slab_cell(i, j) {
+                    continue;
+                }
                 let (mut color_a, mut color_b) = match color_mode {
                     WireframeColorMode::VertexGradient => (
                         vertex_color_by_position(topo.vertices[ia]),
@@ -1609,27 +2471,29 @@ impl Demo {
                 };
                 color_a[3] = alpha;
                 color_b[3] = alpha;
-                // Project 4D endpoints to R³ through the active wireframe projection (in
-                // body-local frame), then translate by `body_pos_r3` to land in world R³.
-                // For DropW the projection is identity-on-(x, y, z); for Perspective4D each
-                // component scales by `focal / (focal - w)`.
-                let a3_local =
-                    <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
-                        a,
-                        &wireframe_projection,
-                    );
-                let b3_local =
-                    <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
-                        b,
-                        &wireframe_projection,
-                    );
-                let a3 = a3_local + body_pos_r3;
-                let b3 = b3_local + body_pos_r3;
-                parent_lines.segments.push((a3.to_array(), b3.to_array()));
-                parent_lines.colors.push((color_a, color_b));
-                parent_lines.widths.push(parent_width);
+                // Emit the edge in body-local 4D, projected to world R³. At
+                // `space_blend == 0` this is one chord per edge (the historical
+                // behavior); above 0 the edge bows toward its S³ great-circle arc.
+                // Projection is shared with the flat path: DropW is identity-on-
+                // (x, y, z), Perspective4D scales each component by focal/(focal-w).
+                push_blended_edge(
+                    &mut parent_lines,
+                    a,
+                    b,
+                    color_a,
+                    color_b,
+                    parent_width,
+                    space_blend,
+                    &wireframe_projection,
+                    body_pos_r3,
+                    &mut slerp_scratch,
+                );
             }
         }
+
+        // Put the great-circle sampling buffer back so its capacity is reused
+        // next frame instead of reallocating.
+        self.slerp_scratch = slerp_scratch;
 
         // Upload (each call is a no-op when its mesh is empty).
         self.section_edges.upload::<EuclideanR3, 3>(
@@ -1720,6 +2584,143 @@ struct RotatePolytopesApp {
     perf: rye_app::trace::PerfOverlay,
 }
 
+/// Shared handler for the `wireframe space` subcommand and the top-level
+/// `space` alias. Both write the same `space_blend` field (the flat<->spherical
+/// edge morph; see [`Demo::space_blend`]): `flat` -> 0.0 (R⁴ chords),
+/// `spherical` -> 1.0 (S³ great-circle arcs), `blend <t>` -> a `t` accepted only
+/// inside `[0, 1]`. A bare invocation reports the current value. Factored out so
+/// the canonical control (`wireframe space`, since the morph IS a
+/// wireframe-geometry property) and the one-keypress thesis alias (`space
+/// spherical`) cannot drift apart.
+///
+/// `space_blend` is read ONLY by [`Demo::render_wireframe_overlay`], which the
+/// frame loop skips entirely while `wireframe_enabled` is `false` (the default).
+/// So a verb that turns the morph ON has to enable the wireframe too, or the
+/// headline `space spherical` keypress mutates a field nothing draws and the
+/// user sees no change. This handler therefore takes `wireframe_enabled` and
+/// flips it on whenever it sets a NON-ZERO blend (`spherical`, or `blend <t>`
+/// with `t > 0`): the great-circle arcs only exist in the wireframe layer, so
+/// asking to see them is implicitly asking for that layer. `flat` and `blend 0`
+/// leave `wireframe_enabled` untouched, never force it off: zero blend is the
+/// default flat geometry and a user may have the wireframe up for unrelated
+/// reasons (color mode, projection, hyperslice). Bare query and rejected input
+/// touch neither field.
+///
+/// Both fields are `&mut` primitives rather than `&mut Demo` so the two
+/// registrations still share one body (they cannot diverge) AND the handler
+/// stays unit-testable without a GPU-backed `Demo`.
+fn run_space_command(
+    space_blend: &mut f32,
+    wireframe_enabled: &mut bool,
+    args: &[&str],
+    out: &mut rye_egui::console::ConsoleWriter,
+) -> anyhow::Result<()> {
+    // Turning the morph on without the wireframe layer drawn is a silent no-op;
+    // surface that the layer was auto-enabled so the user knows where the arcs
+    // came from and can toggle it off again if they only wanted the SDF view.
+    let mut enable_wireframe = |out: &mut rye_egui::console::ConsoleWriter| {
+        if !*wireframe_enabled {
+            *wireframe_enabled = true;
+            out.line("wireframe overlay auto-enabled (the morph draws there)");
+        }
+    };
+    match args.first().copied() {
+        None => {
+            out.line(format!(
+                "wireframe space blend: {space_blend:.3} (0 = flat, 1 = spherical)"
+            ));
+        }
+        Some("flat") => {
+            *space_blend = 0.0;
+            out.line("wireframe space: flat (R⁴ chords)");
+        }
+        Some("spherical") => {
+            *space_blend = 1.0;
+            out.line("wireframe space: spherical (S³ great-circle arcs)");
+            enable_wireframe(out);
+        }
+        Some("blend") => match args.get(1) {
+            None => out.line(format!("wireframe space blend: {space_blend:.3}")),
+            Some(s) => match s.parse::<f32>() {
+                Ok(t) if (0.0..=1.0).contains(&t) => {
+                    *space_blend = t;
+                    out.line(format!("wireframe space blend: set to {t:.3}"));
+                    // Only a positive blend bows the edges; `blend 0` is flat
+                    // geometry and must not silently flip the overlay on.
+                    if t > 0.0 {
+                        enable_wireframe(out);
+                    }
+                }
+                _ => out.line(format!(
+                    "wireframe space blend: invalid `{s}` (need a float in [0, 1])"
+                )),
+            },
+        },
+        Some(other) => out.line(format!(
+            "wireframe space: unknown `{other}` (try flat|spherical|blend)"
+        )),
+    }
+    Ok(())
+}
+
+/// Lower bound on a VISIBLE section-layer fill alpha. Mirrors the old `surface
+/// alpha` floor: below this the cap is so faint it reads as off, so the grammar
+/// rejects it and steers the user to `0` (the explicit off state) instead, the
+/// same open-lower-bound discipline `surface scale` uses.
+const SECTION_ALPHA_MIN_VISIBLE: f32 = 0.05;
+
+/// Shared handler for `section cross-alpha` / `section cap-alpha`: query (bare),
+/// or set the layer's `surface_alpha`. `0` is the explicit off state (no fill
+/// submitted); a value in `[SECTION_ALPHA_MIN_VISIBLE, 1.0]`
+/// sets a visible fill. `layer_name` ("cross" / "cap") is only for the report
+/// line. Takes `&mut SectionLayer` (not `&mut Demo`) so the two registrations
+/// share one body and the handler stays unit-testable without a GPU-backed
+/// `Demo`.
+fn run_section_alpha(
+    layer_name: &str,
+    layer: &mut state::SectionLayer,
+    args: &[&str],
+    out: &mut rye_egui::console::ConsoleWriter,
+) -> anyhow::Result<()> {
+    match args.first().copied() {
+        None => {
+            let state = if layer.fill_visible() {
+                if layer.surface_alpha >= 1.0 {
+                    "opaque"
+                } else {
+                    "translucent"
+                }
+            } else {
+                "off"
+            };
+            out.line(format!(
+                "section {layer_name}-alpha: {:.3} ({state})",
+                layer.surface_alpha
+            ));
+        }
+        Some(token) => {
+            let parsed: f32 = token
+                .parse()
+                .map_err(|e| anyhow!("invalid alpha `{token}`: {e}"))?;
+            // `0` is the off state; any other value must be a visible alpha in
+            // `[SECTION_ALPHA_MIN_VISIBLE, 1.0]`. A value in `(0, MIN)` is too
+            // faint to read, so reject it rather than silently rounding.
+            let valid = parsed == 0.0 || (SECTION_ALPHA_MIN_VISIBLE..=1.0).contains(&parsed);
+            if !valid {
+                return Err(anyhow!(
+                    "section {layer_name}-alpha {parsed} out of range; expected 0 (off) or {SECTION_ALPHA_MIN_VISIBLE}..=1.0"
+                ));
+            }
+            layer.surface_alpha = parsed;
+            out.line(format!(
+                "section {layer_name}-alpha: set to {parsed:.3}{}",
+                if parsed == 0.0 { " (off)" } else { "" }
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl RotatePolytopesApp {
     fn build_console() -> Console<Demo> {
         let mut c = Console::<Demo>::new();
@@ -1755,6 +2756,27 @@ impl RotatePolytopesApp {
                 Ok(())
             },
         ));
+        // Top-level alias for `wireframe space`. The canonical control lives under
+        // `wireframe space` because the morph IS a wireframe-geometry property,
+        // but the spec's thesis demo is the one-keypress `space spherical`, so we
+        // also surface a thin top-level verb dispatching the SAME
+        // [`run_space_command`] handler. `cmd` passes `(args, ctx, out)` whereas
+        // the subcommand passes `(ctx, args, out)`; the closure just reorders.
+        c.register(
+            rye_egui::cmd(
+                "space",
+                "edge geometry: flat (R⁴ chords) | spherical (S³ arcs) | blend <t in [0,1]>",
+                |args: &[&str], demo: &mut Demo, out| {
+                    run_space_command(
+                        &mut demo.space_blend,
+                        &mut demo.wireframe_enabled,
+                        args,
+                        out,
+                    )
+                },
+            )
+            .with_args(&[&["flat", "spherical", "blend"]]),
+        );
         // Cross-section + parent-wireframe overlay. Tab-completion is context-aware
         // via [`SubcommandSet`]: each subcommand's value slot lists only that
         // subcommand's choices. Bare invocations flip:
@@ -1772,14 +2794,6 @@ impl RotatePolytopesApp {
                     "per-edge alpha gradient by cell-crossing strength (bare flips)",
                     |d, v| {
                         d.wireframe_nearest_active = v.unwrap_or(!d.wireframe_nearest_active);
-                        Ok(())
-                    },
-                )
-                .toggle(
-                    "perimeter",
-                    "cyan cross-section perimeter outlines (bare flips)",
-                    |d, v| {
-                        d.wireframe_perimeter = v.unwrap_or(!d.wireframe_perimeter);
                         Ok(())
                     },
                 )
@@ -1873,20 +2887,218 @@ impl RotatePolytopesApp {
                         Ok(())
                     },
                 )
-                .choice(
+                .custom(
                     "perspective",
-                    "wireframe 4D->R³ projection (bare cycles): drop-w (default) or w-depth",
-                    &["drop-w", "w-depth"],
-                    |d, name| {
-                        d.wireframe_projection = match name {
-                            Some(n) => WireframeProjection::from_token(n).ok_or_else(|| {
-                                anyhow!("unknown projection `{n}` (try drop-w|w-depth)")
+                    "wireframe 4D->R³ projection (bare cycles): drop-w | w-depth | schlegel <cell> | stereographic | hyperslice",
+                    &[&["drop-w", "w-depth", "schlegel", "stereographic", "hyperslice"]],
+                    &[],
+                    |d, args, out| {
+                        let next = match args.first().copied() {
+                            // Bare: cycle through ALL in variant order. Schlegel
+                            // re-enters at whatever cell index it last carried (or
+                            // 0 on first visit) so a cycle through it doesn't reset
+                            // the user's chosen cell.
+                            None => {
+                                let all = WireframeProjection::ALL;
+                                let i = all
+                                    .iter()
+                                    .position(|p| p.same_variant(d.wireframe_projection))
+                                    .unwrap_or(0);
+                                let mut next = all[(i + 1) % all.len()];
+                                if let (
+                                    WireframeProjection::Schlegel { .. },
+                                    WireframeProjection::Schlegel { cell_index },
+                                ) = (next, d.wireframe_projection)
+                                {
+                                    next = WireframeProjection::Schlegel { cell_index };
+                                }
+                                next
+                            }
+                            Some("schlegel") => {
+                                // `schlegel [<cell-index>]`: the index is an optional
+                                // trailing positional. Clamp to the selected
+                                // polytope's cell count so an out-of-range request
+                                // reports the valid bound instead of silently
+                                // wrapping. With no polychoron in the row the index
+                                // is accepted as-is (the cache resolves to None and
+                                // the wireframe draws nothing).
+                                let requested = match args.get(1).copied() {
+                                    None => 0,
+                                    Some(tok) => tok.parse::<u32>().map_err(|e| {
+                                        anyhow!("invalid cell index `{tok}`: {e}")
+                                    })?,
+                                };
+                                let cell_index = match d.schlegel_subject() {
+                                    Some(p) => {
+                                        let max = p.cell_count() as u32 - 1;
+                                        if requested > max {
+                                            out.line(format!(
+                                                "schlegel cell {requested} out of range for the leading polytope (0..={max}); clamped to {max}"
+                                            ));
+                                        }
+                                        requested.min(max)
+                                    }
+                                    None => requested,
+                                };
+                                WireframeProjection::Schlegel { cell_index }
+                            }
+                            Some(token) => WireframeProjection::from_token(token).ok_or_else(|| {
+                                anyhow!(
+                                    "unknown projection `{token}` (try drop-w|w-depth|schlegel|stereographic|hyperslice)"
+                                )
                             })?,
-                            None => match d.wireframe_projection {
-                                WireframeProjection::DropW => WireframeProjection::WDepth,
-                                WireframeProjection::WDepth => WireframeProjection::DropW,
-                            },
                         };
+                        d.wireframe_projection = next;
+                        // Resolve + cache the Schlegel face-plane params now (at
+                        // select time) so the per-frame upload never re-runs the
+                        // LazyLock cell-table fit. No-op (clears the cache) for the
+                        // other modes.
+                        d.resolve_schlegel_cache();
+                        out.line(format!(
+                            "wireframe perspective: {}",
+                            match d.wireframe_projection {
+                                WireframeProjection::Schlegel { cell_index } =>
+                                    format!("schlegel (cell {cell_index})"),
+                                other => other.label().to_lowercase(),
+                            }
+                        ));
+                        Ok(())
+                    },
+                )
+                .custom(
+                    "pole",
+                    "stereographic projection pole (bare reports; sub: reset | +w | <x y z w>)",
+                    &[&["reset", "+w"]],
+                    &[],
+                    |d, args, out| {
+                        match args.first().copied() {
+                            None => {
+                                let p = d.stereographic_pole;
+                                out.line(format!(
+                                    "stereographic pole: ({:.3}, {:.3}, {:.3}, {:.3})",
+                                    p.x, p.y, p.z, p.w
+                                ));
+                            }
+                            // The default is a cell-center direction (off every
+                            // 16-cell vertex; see STEREOGRAPHIC_DEFAULT_POLE).
+                            Some("reset") | Some("default") => {
+                                d.stereographic_pole = state::STEREOGRAPHIC_DEFAULT_POLE;
+                                out.line("stereographic pole: reset to the cell-center default");
+                            }
+                            // The textbook `(x, y, z) / (1 - w)` pole, the old
+                            // default; offered as a named shortcut so a user can
+                            // recover the classic look without typing coordinates.
+                            Some("+w") => {
+                                d.stereographic_pole = Vec4::W;
+                                out.line("stereographic pole: set to +w (textbook map)");
+                            }
+                            // Explicit pole: four floats, normalized onto S³ (the
+                            // map only uses the direction). Reject a near-zero
+                            // vector, which has no well-defined direction.
+                            Some(_) => {
+                                let coords: Result<Vec<f32>> = args
+                                    .iter()
+                                    .map(|t| {
+                                        t.parse::<f32>()
+                                            .map_err(|e| anyhow!("invalid pole component `{t}`: {e}"))
+                                    })
+                                    .collect();
+                                let coords = coords?;
+                                if coords.len() != 4 {
+                                    return Err(anyhow!(
+                                        "pole needs 4 components `<x y z w>`, got {}",
+                                        coords.len()
+                                    ));
+                                }
+                                let raw = Vec4::new(coords[0], coords[1], coords[2], coords[3]);
+                                if raw.length() < MIN_EDGE_RADIUS {
+                                    return Err(anyhow!(
+                                        "pole vector is too close to zero to have a direction"
+                                    ));
+                                }
+                                let pole = raw.normalize();
+                                d.stereographic_pole = pole;
+                                out.line(format!(
+                                    "stereographic pole: set to ({:.3}, {:.3}, {:.3}, {:.3})",
+                                    pole.x, pole.y, pole.z, pole.w
+                                ));
+                            }
+                        }
+                        Ok(())
+                    },
+                )
+                .custom(
+                    "space",
+                    "edge geometry: flat (R⁴ chords) | spherical (S³ arcs) | blend <t in [0,1]>",
+                    &[&["flat", "spherical", "blend"]],
+                    &[],
+                    |d, args, out| {
+                        run_space_command(
+                            &mut d.space_blend,
+                            &mut d.wireframe_enabled,
+                            args,
+                            out,
+                        )
+                    },
+                )
+                .custom(
+                    "hyperslice",
+                    "cull parent edges to a w-slab around the slice (bare flips; sub: on|off|thickness <N>)",
+                    &[&["on", "off", "thickness"]],
+                    &[],
+                    |d, args, out| {
+                        match args.first().copied() {
+                            None => {
+                                d.wireframe_hyperslice = !d.wireframe_hyperslice;
+                                out.line(format!(
+                                    "wireframe hyperslice: {} (slab full-width {:.3})",
+                                    if d.wireframe_hyperslice { "on" } else { "off" },
+                                    d.wireframe_hyperslice_thickness
+                                ));
+                            }
+                            Some("on") => {
+                                d.wireframe_hyperslice = true;
+                                out.line(format!(
+                                    "wireframe hyperslice: on (slab full-width {:.3})",
+                                    d.wireframe_hyperslice_thickness
+                                ));
+                            }
+                            Some("off") => {
+                                d.wireframe_hyperslice = false;
+                                out.line("wireframe hyperslice: off (full edge graph)");
+                            }
+                            Some("thickness") => match args.get(1).copied() {
+                                None => out.line(format!(
+                                    "wireframe hyperslice thickness: {:.3}",
+                                    d.wireframe_hyperslice_thickness
+                                )),
+                                Some(token) => {
+                                    let t: f32 = token.parse().map_err(|e| {
+                                        anyhow!("invalid thickness `{token}`: {e}")
+                                    })?;
+                                    // Lower bound is the predicate's own floor (a razor
+                                    // band that still admits straddling edges); upper bound
+                                    // is the full slider span `2 * W_RANGE`, at which the
+                                    // slab covers every reachable w and the filter is a
+                                    // no-op (equivalent to "off").
+                                    let max = 2.0 * consts::W_RANGE;
+                                    if !(HYPERSLICE_MIN_THICKNESS..=max).contains(&t) {
+                                        return Err(anyhow!(
+                                            "hyperslice thickness {t} out of range; expected {HYPERSLICE_MIN_THICKNESS}..={max}"
+                                        ));
+                                    }
+                                    d.wireframe_hyperslice_thickness = t;
+                                    out.line(format!(
+                                        "wireframe hyperslice thickness: set to {t:.3}"
+                                    ));
+                                }
+                            },
+                            Some(other) => {
+                                return Err(anyhow!(
+                                    "unknown hyperslice subcommand `{other}` (try on|off|thickness)"
+                                ));
+                            }
+                        }
                         Ok(())
                     },
                 )
@@ -1956,7 +3168,7 @@ impl RotatePolytopesApp {
         c.register(
             rye_egui::cmd(
                 "surface",
-                "polychoral surface mode: raster | sdf | off (bare = off); `scale <N>` to resize",
+                "polychoral surface mode: raster | sdf | off (bare = off); `scale <N>` to resize (per-layer cap alpha lives under `section`)",
                 |args, demo: &mut Demo, out| {
                     if matches!(args.first().copied(), Some("scale")) {
                         match args.get(1).copied() {
@@ -1991,37 +3203,9 @@ impl RotatePolytopesApp {
                         }
                         return Ok(());
                     }
-                    if matches!(args.first().copied(), Some("alpha")) {
-                        match args.get(1).copied() {
-                            None => {
-                                out.line(format!(
-                                    "surface alpha: {:.3} ({} pipeline)",
-                                    demo.surface_alpha,
-                                    if demo.surface_alpha >= 1.0 {
-                                        "opaque"
-                                    } else {
-                                        "translucent"
-                                    }
-                                ));
-                            }
-                            Some(token) => {
-                                let parsed: f32 = token.parse().map_err(|e| {
-                                    anyhow!("invalid alpha `{token}`: {e}")
-                                })?;
-                                if !(0.05..=1.0).contains(&parsed) {
-                                    return Err(anyhow!(
-                                        "surface alpha {parsed} out of range; expected 0.05..=1.0 (use `surface off` for invisible)"
-                                    ));
-                                }
-                                demo.surface_alpha = parsed;
-                                out.line(format!("surface alpha: set to {parsed:.3}"));
-                            }
-                        }
-                        return Ok(());
-                    }
                     let next = match args.first().copied() {
                         Some(token) => SurfaceMode::from_token(token).ok_or_else(|| {
-                            anyhow!("unknown arg `{token}` (try raster|sdf|off|scale|alpha)")
+                            anyhow!("unknown arg `{token}` (try raster|sdf|off|scale; cap alpha lives under `section`)")
                         })?,
                         None => SurfaceMode::Off,
                     };
@@ -2041,23 +3225,74 @@ impl RotatePolytopesApp {
                     Ok(())
                 },
             )
-            .with_args(&[&["raster", "sdf", "off", "scale", "alpha"]])
+            .with_args(&[&["raster", "sdf", "off", "scale"]])
             .with_long_help(
                 "Selects how the six regular convex 4-polytopes (5-cell, tesseract, 16-cell,\n\
-                 24-cell, 120-cell, 600-cell) are rendered, plus runtime scale + alpha knobs.\n\
+                 24-cell, 120-cell, 600-cell) are rendered, plus a runtime scale knob.\n\
                  \n\
                  subcommands:\n  \
                  raster      Rasterized cross-section cell-caps (the default). Face-normal\n                             Lambert lit, per-body solid color. Much faster for the\n                             120-cell + 600-cell and exact (no SDF approximation).\n  \
                  sdf         SDF raymarch. The historical pre-rasterizer path; smoother\n                             shading but the 120-cell and 600-cell carry a face-plane\n                             approximation BUG. Kept for visual comparison.\n  \
                  off         No surface rendered. Wireframe overlay + cross-section\n                             perimeter stay visible if enabled; the cap interiors are\n                             blank. Useful for inspecting the wireframe on its own.\n  \
-                 scale <N>   Multiply the canonical body radius by N (default 1.0; range\n                             0.05..=10.0). Affects SDF kernel, raster cross-section caps,\n                             wireframe overlay, perimeter, and points sprites uniformly.\n  \
-                 alpha <N>   Section-faces opacity (default 1.0; range 0.05..=1.0). Below\n                             1.0 the cap renders through a no-depth-write pipeline so\n                             the parent wireframe behind composes through. Use `surface\n                             off` for fully invisible caps.\n\
+                 scale <N>   Multiply the canonical body radius by N (default 1.0; range\n                             0.05..=10.0). Affects SDF kernel, raster cross-section caps,\n                             wireframe overlay, perimeter, and points sprites uniformly.\n\
                  \n\
                  Bare `surface` (no argument) is shorthand for `surface off`.\n\
+                 \n\
+                 The rasterized cross-section splits into two overlaid layers with\n\
+                 independent perimeter + fill alpha: see the `section` command (the honest\n\
+                 drop-w cross-section and the projection-following cap).\n\
                  \n\
                  Smooth-surface shapes (Clifford torus, duocylinder, spherinder, 3-sphere)\n\
                  ignore the mode and always render via the SDF; they have no rasterizer\n\
                  path. Surface scale still applies to their SDF body radius.",
+            ),
+        );
+
+        // Section layers: the rasterized cross-section is two overlaid layers in
+        // one viewport, each with its own perimeter outline + fill alpha.
+        //   - `cross`: the honest drop-w slice (NEVER reprojected; the geometry the
+        //     SDF raymarch shows). On by default so selecting Schlegel /
+        //     stereographic never silently distorts the slice.
+        //   - `cap`: the same slice reprojected through the active wireframe
+        //     projection, so it can sit on a Schlegel / stereographic wireframe.
+        //     Off by default.
+        // Alpha `0` is the layer's off state; `(0, 1]` sets a visible fill (below 1
+        // composites through the depth-write-disabled pipeline). Side-by-side /
+        // multi-viewport comparison is deferred to the multi-viewport milestone.
+        c.register(
+            rye_egui::subcommands::<Demo>(
+                "section",
+                "rasterized cross-section layers: cross (honest drop-w) + cap (projection-following), each with perimeter + alpha",
+            )
+            .toggle(
+                "cross-perimeter",
+                "honest drop-w cross-section perimeter outline (bare flips)",
+                |d, v| {
+                    d.cross_section.perimeter = v.unwrap_or(!d.cross_section.perimeter);
+                    Ok(())
+                },
+            )
+            .toggle(
+                "cap-perimeter",
+                "projected-cap perimeter outline (bare flips)",
+                |d, v| {
+                    d.projected_cap.perimeter = v.unwrap_or(!d.projected_cap.perimeter);
+                    Ok(())
+                },
+            )
+            .custom(
+                "cross-alpha",
+                "honest cross-section fill alpha (0 = off; range (0, 1])",
+                &[&[]],
+                &[],
+                |d, args, out| run_section_alpha("cross", &mut d.cross_section, args, out),
+            )
+            .custom(
+                "cap-alpha",
+                "projected-cap fill alpha (0 = off; range (0, 1])",
+                &[&[]],
+                &[],
+                |d, args, out| run_section_alpha("cap", &mut d.projected_cap, args, out),
             ),
         );
 
@@ -2573,6 +3808,672 @@ mod color_tests {
         ];
         let strengths = compute_cell_strengths(&cells, &local_vertices, 0.0);
         assert!(strengths[0].abs() < 1e-5);
+    }
+}
+
+#[cfg(test)]
+mod blended_edge_tests {
+    //! Tests for `push_blended_edge`, the wireframe-edge tessellator behind the
+    //! `space` command. The S³ slerp math itself is pinned in
+    //! `rye_math::spherical_embedded`; these tests pin the demo-side contract:
+    //! the flat fast path, the curved sub-segment count, and that a curved edge
+    //! is actually longer than its chord (i.e. it bows out).
+    use super::*;
+
+    fn flat_drop_w() -> rye_math::Projection<4> {
+        rye_math::Projection::Identity
+    }
+
+    /// Total length of all segments in the mesh, in world R³.
+    fn polyline_length(mesh: &LineMesh<3>) -> f32 {
+        mesh.segments
+            .iter()
+            .map(|(p0, p1)| (Vec3::from_array(*p1) - Vec3::from_array(*p0)).length())
+            .sum()
+    }
+
+    const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+
+    /// `blend == 0` emits exactly one chord segment, equal to the projected
+    /// endpoints. This is the historical (pre-`space`) wireframe behavior.
+    #[test]
+    fn blend_zero_emits_single_chord() {
+        let a = Vec4::new(0.7, 0.0, 0.0, 0.0);
+        let b = Vec4::new(0.0, 0.7, 0.0, 0.0);
+        let mut mesh = LineMesh::<3>::default();
+        let mut scratch = Vec::new();
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            WHITE,
+            WHITE,
+            1.0,
+            0.0,
+            &flat_drop_w(),
+            Vec3::ZERO,
+            &mut scratch,
+        );
+        assert_eq!(mesh.segments.len(), 1);
+        let chord = (Vec3::new(0.0, 0.7, 0.0) - Vec3::new(0.7, 0.0, 0.0)).length();
+        assert!((polyline_length(&mesh) - chord).abs() < 1e-6);
+    }
+
+    /// `blend > 0` subdivides the edge into `SPACE_TESSELLATION_SAMPLES`
+    /// sub-segments.
+    #[test]
+    fn blend_positive_emits_tessellated_segments() {
+        let a = Vec4::new(0.7, 0.0, 0.0, 0.0);
+        let b = Vec4::new(0.0, 0.7, 0.0, 0.0);
+        let mut mesh = LineMesh::<3>::default();
+        let mut scratch = Vec::new();
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            WHITE,
+            WHITE,
+            1.0,
+            1.0,
+            &flat_drop_w(),
+            Vec3::ZERO,
+            &mut scratch,
+        );
+        assert_eq!(mesh.segments.len(), SPACE_TESSELLATION_SAMPLES);
+    }
+
+    /// A spherical edge bows off its chord: the tessellated polyline is strictly
+    /// longer than the straight chord between the same endpoints. Uses two
+    /// equal-radius endpoints a quarter circle apart in the xy-plane, so drop-w
+    /// preserves the bulge.
+    #[test]
+    fn spherical_edge_is_longer_than_chord() {
+        let a = Vec4::new(0.7, 0.0, 0.0, 0.0);
+        let b = Vec4::new(0.0, 0.7, 0.0, 0.0);
+        let chord = (Vec3::new(0.0, 0.7, 0.0) - Vec3::new(0.7, 0.0, 0.0)).length();
+
+        let mut arc = LineMesh::<3>::default();
+        let mut scratch = Vec::new();
+        push_blended_edge(
+            &mut arc,
+            a,
+            b,
+            WHITE,
+            WHITE,
+            1.0,
+            1.0,
+            &flat_drop_w(),
+            Vec3::ZERO,
+            &mut scratch,
+        );
+        let arc_len = polyline_length(&arc);
+        // Quarter circle of radius 0.7 has arc length 0.7·π/2 ≈ 1.0996 vs chord
+        // 0.7·√2 ≈ 0.9899. The 16-segment approximation undershoots the true arc
+        // slightly but still clears the chord comfortably.
+        assert!(
+            arc_len > chord + 0.05,
+            "arc {arc_len} should exceed chord {chord}"
+        );
+    }
+
+    /// A half-blend lands between flat and spherical: its polyline length is
+    /// strictly between the chord and the full arc. Pins the morph as monotone,
+    /// not a step.
+    #[test]
+    fn half_blend_is_between_flat_and_spherical() {
+        let a = Vec4::new(0.7, 0.0, 0.0, 0.0);
+        let b = Vec4::new(0.0, 0.7, 0.0, 0.0);
+        let chord = (Vec3::new(0.0, 0.7, 0.0) - Vec3::new(0.7, 0.0, 0.0)).length();
+
+        let make = |blend: f32| {
+            let mut mesh = LineMesh::<3>::default();
+            let mut scratch = Vec::new();
+            push_blended_edge(
+                &mut mesh,
+                a,
+                b,
+                WHITE,
+                WHITE,
+                1.0,
+                blend,
+                &flat_drop_w(),
+                Vec3::ZERO,
+                &mut scratch,
+            );
+            polyline_length(&mesh)
+        };
+        let half = make(0.5);
+        let full = make(1.0);
+        assert!(
+            half > chord,
+            "half-blend {half} should exceed chord {chord}"
+        );
+        assert!(
+            half < full,
+            "half-blend {half} should be under full arc {full}"
+        );
+    }
+
+    /// A representative non-trivial Perspective4D projection (the affine
+    /// 4D->R³ map the wireframe selects for the curved/perspective view). Focal
+    /// distance is comfortably outside the unit-circumradius polytope so no
+    /// vertex straddles the eye plane.
+    fn perspective() -> rye_math::Projection<4> {
+        rye_math::Projection::Perspective4D {
+            focal_distance: 3.0,
+        }
+    }
+
+    /// `blend == 0` through an affine projection (Perspective4D) emits exactly
+    /// one segment, and its two endpoints equal `project_to_world(a)` /
+    /// `project_to_world(b)` to the bit. This pins the single-segment fast path
+    /// at the top of `push_blended_edge` under a NON-identity affine projection:
+    /// the existing `blend_zero_emits_single_chord` only exercised drop-w
+    /// (Identity), so the w-dependent perspective scale was untested on the fast
+    /// path. Uses a real tesseract edge (endpoints at w = +/- 0.5) so the
+    /// perspective divide actually moves the projected points.
+    #[test]
+    fn blend_zero_is_bit_identical_to_flat_chord() {
+        // Two adjacent tesseract vertices sharing the x edge: they differ only
+        // in w, so the perspective scale differs per endpoint and the chord is
+        // not w-invariant.
+        let a = Vec4::new(0.5, 0.5, 0.5, 0.5);
+        let b = Vec4::new(0.5, 0.5, 0.5, -0.5);
+        let proj = perspective();
+        let body_pos = Vec3::new(1.0, -2.0, 0.5);
+
+        let mut mesh = LineMesh::<3>::default();
+        let mut scratch = Vec::new();
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            WHITE,
+            WHITE,
+            1.0,
+            0.0,
+            &proj,
+            body_pos,
+            &mut scratch,
+        );
+
+        assert_eq!(mesh.segments.len(), 1, "affine flat chord is one segment");
+        let expected_a = project_to_world(a, &proj, body_pos).to_array();
+        let expected_b = project_to_world(b, &proj, body_pos).to_array();
+        let (seg_a, seg_b) = mesh.segments[0];
+        assert_eq!(seg_a, expected_a, "start equals projected a");
+        assert_eq!(seg_b, expected_b, "end equals projected b");
+    }
+
+    /// At any blend in [0, 1] the FIRST emitted point equals `project_to_world(a)`
+    /// and the LAST equals `project_to_world(b)`, exactly. The morph bows only the
+    /// edge interior; the endpoints are shared by the flat chord and the S³ arc
+    /// (the vertices already lie on the body's circumsphere), so the glue must be
+    /// bit-exact at every t or the section cap would detach from the wireframe.
+    /// Walks a non-affine projection (Stereographic) so the subdivided path is
+    /// taken even at blend == 0, plus the blended path at several interior t.
+    #[test]
+    fn blend_endpoints_exact_at_all_t() {
+        let a = Vec4::new(0.5, 0.5, 0.5, 0.5);
+        let b = Vec4::new(-0.5, 0.5, 0.5, -0.5);
+        // Stereographic from the +w pole: non-affine, so even blend == 0 takes
+        // the subdivided `push_projected_chord` branch, and blend > 0 takes the
+        // slerp branch. Both must still glue the endpoints exactly.
+        let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
+        let body_pos = Vec3::new(-0.25, 1.5, 0.0);
+        let expected_a = project_to_world(a, &proj, body_pos).to_array();
+        let expected_b = project_to_world(b, &proj, body_pos).to_array();
+
+        for &blend in &[0.0_f32, 0.001, 0.25, 0.5, 0.75, 1.0] {
+            let mut mesh = LineMesh::<3>::default();
+            let mut scratch = Vec::new();
+            push_blended_edge(
+                &mut mesh,
+                a,
+                b,
+                WHITE,
+                WHITE,
+                1.0,
+                blend,
+                &proj,
+                body_pos,
+                &mut scratch,
+            );
+            assert!(!mesh.segments.is_empty(), "blend {blend}: emitted nothing");
+            let first = mesh.segments.first().unwrap().0;
+            let last = mesh.segments.last().unwrap().1;
+            assert_eq!(
+                first, expected_a,
+                "blend {blend}: first point equals proj(a)"
+            );
+            assert_eq!(last, expected_b, "blend {blend}: last point equals proj(b)");
+        }
+    }
+}
+
+#[cfg(test)]
+mod space_command_tests {
+    //! Tests for the flat<->spherical morph control surfaced two ways: the
+    //! Render-modal Curvature slider and the `wireframe space` / top-level
+    //! `space` console verbs. Both write the same `space_blend` field; these
+    //! pin that the field is written and clamped identically across surfaces.
+    use super::*;
+    use rye_app::egui;
+    use rye_egui::console::ConsoleWriter;
+    use std::cell::Cell;
+
+    /// Render the modal's Curvature slider headless against `seed` and return the
+    /// value it leaves behind. `__run_test_ui` hands the closure a `Fn` context
+    /// (no `&mut` captures), so the bound value lives in a `Cell` driven through
+    /// `Slider::from_get_set`; this is behaviorally the same widget the modal
+    /// builds via `Slider::new(&mut space_blend, 0.0..=1.0)` (which itself
+    /// desugars to `from_get_set` over the field) with the same range and the
+    /// default `SliderClamping::Always`.
+    fn slider_clamped(seed: f32) -> f32 {
+        let cell = Cell::new(seed as f64);
+        egui::__run_test_ui(|ui| {
+            ui.add(egui::Slider::from_get_set(0.0..=1.0, |v: Option<f64>| {
+                if let Some(v) = v {
+                    cell.set(v);
+                }
+                cell.get()
+            }));
+        });
+        cell.get() as f32
+    }
+
+    /// The modal Curvature slider writes `space_blend` and clamps it to [0, 1].
+    /// The default `SliderClamping::Always` re-clamps the bound value to the
+    /// range on every render (egui 0.33, `Slider::add_contents` calls
+    /// `set_value(old_value)` when clamping is `Always`), so rendering the widget
+    /// once against an out-of-range seed must pull the field back into [0, 1].
+    #[test]
+    fn space_blend_slider_writes_field() {
+        assert_eq!(slider_clamped(5.0), 1.0, "above-range value clamps to 1.0");
+        assert_eq!(slider_clamped(-3.0), 0.0, "below-range value clamps to 0.0");
+        assert_eq!(
+            slider_clamped(0.375),
+            0.375,
+            "in-range value is preserved exactly"
+        );
+    }
+
+    /// `space spherical` (top-level alias) and `wireframe space spherical`
+    /// (canonical subcommand) move `space_blend` to the same value, because both
+    /// registrations dispatch the single shared `run_space_command` handler.
+    /// Driving the registered console for each path needs a GPU-backed `Demo`
+    /// ctx, which a unit test cannot build; instead this exercises the shared
+    /// handler directly (the exact `&mut space_blend` both call sites pass),
+    /// which IS the aliasing guarantee: the two verbs cannot diverge while they
+    /// share this function. Covers every verb plus the clamp rejection.
+    #[test]
+    fn space_toplevel_aliases_wireframe_space() {
+        // Seed the wireframe ON so this test isolates the blend mutation from the
+        // auto-enable behavior (covered separately by
+        // `space_command_enables_wireframe_for_visible_morph`).
+        let run = |start: f32, args: &[&str]| -> f32 {
+            let mut blend = start;
+            let mut wireframe = true;
+            let mut out = ConsoleWriter::new();
+            run_space_command(&mut blend, &mut wireframe, args, &mut out)
+                .expect("handler is infallible");
+            blend
+        };
+
+        assert_eq!(run(0.4, &["spherical"]), 1.0, "spherical -> 1.0");
+        assert_eq!(run(0.4, &["flat"]), 0.0, "flat -> 0.0");
+        assert_eq!(run(0.4, &["blend", "0.625"]), 0.625, "blend t -> t");
+
+        // Bare query and unknown/invalid args must NOT mutate the field.
+        assert_eq!(run(0.4, &[]), 0.4, "bare query leaves blend untouched");
+        assert_eq!(run(0.4, &["nonsense"]), 0.4, "unknown verb is inert");
+        assert_eq!(
+            run(0.4, &["blend", "9.0"]),
+            0.4,
+            "out-of-range blend is rejected, not clamped silently"
+        );
+        assert_eq!(
+            run(0.4, &["blend", "notafloat"]),
+            0.4,
+            "unparseable blend is rejected"
+        );
+    }
+
+    /// The morph is read ONLY by the wireframe overlay, which the frame loop
+    /// skips while `wireframe_enabled` is false (the default). So a verb that
+    /// sets a NON-ZERO blend must also turn the wireframe on, or the headline
+    /// `space spherical` keypress mutates a field nothing draws. This pins that
+    /// invariant per verb, and the inverse: verbs that leave the geometry flat
+    /// (`flat`, `blend 0`, bare query, rejected input) never flip the overlay,
+    /// since zero blend is the default geometry and the user may have the
+    /// wireframe up (or deliberately down) for unrelated reasons.
+    #[test]
+    fn space_command_enables_wireframe_for_visible_morph() {
+        // Returns the wireframe-enabled flag after running `args` against a
+        // wireframe that started OFF (the demo default).
+        let wireframe_after = |args: &[&str]| -> bool {
+            let mut blend = 0.0_f32;
+            let mut wireframe = false;
+            let mut out = ConsoleWriter::new();
+            run_space_command(&mut blend, &mut wireframe, args, &mut out)
+                .expect("handler is infallible");
+            wireframe
+        };
+
+        // Non-zero blend is invisible without the overlay: auto-enable it.
+        assert!(
+            wireframe_after(&["spherical"]),
+            "`space spherical` must enable the wireframe so the arcs show"
+        );
+        assert!(
+            wireframe_after(&["blend", "0.5"]),
+            "`space blend 0.5` (positive) must enable the wireframe"
+        );
+
+        // Flat geometry must not silently flip the overlay on.
+        assert!(
+            !wireframe_after(&["flat"]),
+            "`space flat` is the default geometry; it must not enable the wireframe"
+        );
+        assert!(
+            !wireframe_after(&["blend", "0"]),
+            "`space blend 0` is flat; it must not enable the wireframe"
+        );
+        assert!(
+            !wireframe_after(&[]),
+            "bare query must not touch the overlay"
+        );
+        assert!(
+            !wireframe_after(&["blend", "9.0"]),
+            "rejected (out-of-range) blend must not touch the overlay"
+        );
+
+        // A wireframe the user already turned ON stays on through `flat`: the
+        // morph control must never force the overlay OFF.
+        let mut blend = 1.0_f32;
+        let mut wireframe = true;
+        let mut out = ConsoleWriter::new();
+        run_space_command(&mut blend, &mut wireframe, &["flat"], &mut out)
+            .expect("handler is infallible");
+        assert!(
+            wireframe,
+            "`space flat` must not force an enabled wireframe off"
+        );
+    }
+
+    /// `run_section_alpha` is the shared handler behind both `section cross-alpha`
+    /// and `section cap-alpha`. It must: set a visible alpha in range, accept `0`
+    /// as the explicit off state, reject the faint `(0, MIN_VISIBLE)` band and
+    /// over-range / unparseable input (no silent clamp), and leave the field
+    /// untouched on a bare query. Driving the registered console needs a
+    /// GPU-backed `Demo`; exercising the handler directly IS the aliasing
+    /// guarantee, since both registrations pass their layer to this one body.
+    #[test]
+    fn section_alpha_sets_off_and_visible_rejects_faint_and_bad() {
+        let run = |start: f32, args: &[&str]| -> (f32, bool) {
+            let mut layer = state::SectionLayer {
+                perimeter: true,
+                surface_alpha: start,
+            };
+            let mut out = ConsoleWriter::new();
+            let ok = run_section_alpha("cross", &mut layer, args, &mut out).is_ok();
+            (layer.surface_alpha, ok)
+        };
+
+        // A visible alpha in [MIN_VISIBLE, 1.0] is set.
+        assert_eq!(run(1.0, &["0.5"]), (0.5, true), "in-range alpha is set");
+        assert_eq!(run(0.5, &["1.0"]), (1.0, true), "opaque alpha is set");
+        // `0` is the explicit off state, accepted.
+        assert_eq!(run(0.85, &["0"]), (0.0, true), "0 turns the layer off");
+        // The faint sub-MIN band is rejected, not rounded.
+        let (val, ok) = run(0.85, &["0.01"]);
+        assert!(!ok, "faint (0, MIN) alpha must be rejected");
+        assert_eq!(val, 0.85, "rejected faint alpha leaves the field untouched");
+        // Over-range and unparseable are rejected, field untouched.
+        assert_eq!(run(0.85, &["2.0"]).0, 0.85, "over-range alpha is rejected");
+        assert_eq!(
+            run(0.85, &["notafloat"]).0,
+            0.85,
+            "unparseable alpha is rejected"
+        );
+        // Bare query reports without mutating.
+        assert_eq!(run(0.7, &[]), (0.7, true), "bare query leaves the field");
+    }
+}
+
+#[cfg(test)]
+mod hyperslice_filter_tests {
+    //! Tests for the wireframe Hyperslice cull. The cull is CELL-level: an edge
+    //! survives iff some cell containing BOTH its endpoints has its body-local
+    //! w-range overlapping the slab `[w_slice - t/2, w_slice + t/2]`. The split
+    //! is `cell_w_range` (the cell's w-interval over the rotated, scaled
+    //! vertices, shared with `compute_cell_strengths`) and `slab_overlaps` (the
+    //! 1D band-overlap predicate). The `slab_overlaps` tests pin the band
+    //! semantics (closed boundary, zero/negative-thickness floor, determinism);
+    //! the cell-level tests pin the agreement with the active-edge coloring and
+    //! that the cull still culls.
+    use super::*;
+
+    /// Mirror of the production cull closure `edge_in_slab_cell` in
+    /// `render_wireframe_overlay`: keep the edge `(i, j)` iff some cell holding
+    /// both endpoints has a slab-overlapping w-range. Tests drive this so the
+    /// invariant tracks the exact composition the renderer uses, while the
+    /// renderer keeps the closure inline (no extra public surface, no per-frame
+    /// allocation).
+    fn kept_by_cull(
+        i: u32,
+        j: u32,
+        cells: &[&[u32]],
+        local_vertices: &[Vec4],
+        w_slice: f32,
+        thickness: f32,
+    ) -> bool {
+        cells.iter().any(|cell| {
+            if !(cell.contains(&i) && cell.contains(&j)) {
+                return false;
+            }
+            let (w_min, w_max) = cell_w_range(cell, local_vertices);
+            slab_overlaps(w_min, w_max, w_slice, thickness)
+        })
+    }
+
+    /// A w-range lying entirely outside the slab does not overlap. With
+    /// `w_slice = 0` and a thin slab, a range `[0.8, 0.9]` (well above the slab)
+    /// and the symmetric `[-0.9, -0.8]` both return false.
+    #[test]
+    fn slab_overlaps_off_band_is_false() {
+        assert!(!slab_overlaps(0.8, 0.9, 0.0, 0.2));
+        assert!(!slab_overlaps(-0.9, -0.8, 0.0, 0.2));
+    }
+
+    /// A range straddling the slice, and a range wholly inside the slab, both
+    /// overlap. The predicate is true whenever the range touches the band.
+    #[test]
+    fn slab_overlaps_on_band_is_true() {
+        // Straddles w_slice = 0.
+        assert!(slab_overlaps(-0.5, 0.5, 0.0, 0.2));
+        // Wholly inside a wide slab.
+        assert!(slab_overlaps(-0.05, 0.05, 0.0, 0.2));
+        // Slab centered off-origin, range inside it.
+        assert!(slab_overlaps(0.45, 0.55, 0.5, 0.2));
+    }
+
+    /// The band is CLOSED: a range endpoint sitting exactly on `w_slice +/- t/2`
+    /// overlaps, and the result is identical across repeated evaluations (pure
+    /// f32 arithmetic, no state). Uses the tesseract's canonical `w = +/- 0.5`
+    /// w-range as the exact-boundary case: with `w_slice = 0` and `t = 1.0` the
+    /// slab is `[-0.5, +0.5]`, so a range `[-0.5, +0.5]` lands both ends exactly
+    /// on the boundary.
+    #[test]
+    fn slab_overlaps_closed_boundary_and_deterministic() {
+        let keep = slab_overlaps(-0.5, 0.5, 0.0, 1.0);
+        assert!(keep, "range ends exactly on the closed band must overlap");
+
+        // One end grazing the upper boundary, the other inside.
+        assert!(slab_overlaps(0.0, 0.5, 0.0, 1.0));
+        // One end grazing the lower boundary from outside.
+        assert!(slab_overlaps(-0.6, -0.5, 0.0, 1.0));
+
+        // Determinism: same inputs, same answer, every time.
+        for _ in 0..16 {
+            assert_eq!(slab_overlaps(-0.5, 0.5, 0.0, 1.0), keep);
+        }
+    }
+
+    /// Thickness 0 is floored to [`HYPERSLICE_MIN_THICKNESS`], so the slab
+    /// degrades to a razor band around `w_slice`: only a range that CROSSES the
+    /// slice overlaps, and the test neither panics nor produces an infinity. A
+    /// range straddling `w_slice = 0` overlaps; one entirely to one side (even
+    /// very close) does not.
+    #[test]
+    fn slab_overlaps_zero_thickness_floor() {
+        // Crosses w_slice = 0: overlaps even at thickness 0 (floor keeps the
+        // band a hair wide).
+        assert!(slab_overlaps(-0.3, 0.3, 0.0, 0.0));
+        // Entirely on one side, just above the floor's reach: no overlap.
+        assert!(!slab_overlaps(0.1, 0.3, 0.0, 0.0));
+        // A range endpoint exactly at w_slice still counts (closed band).
+        assert!(slab_overlaps(0.0, 0.3, 0.0, 0.0));
+    }
+
+    /// A negative thickness (nonsensical input, but possible from a future
+    /// slider bug) is floored the same way as 0, so the predicate stays a valid
+    /// razor band rather than an inverted slab that keeps nothing or everything.
+    #[test]
+    fn slab_overlaps_negative_thickness_floor() {
+        assert!(slab_overlaps(-0.3, 0.3, 0.0, -5.0));
+        assert!(!slab_overlaps(0.1, 0.3, 0.0, -5.0));
+    }
+
+    /// The repro that motivated the cell-level cull (the 16-cell at
+    /// `w_slice = -0.182`): an edge whose BOTH endpoints sit on the far side of
+    /// the slab is still kept, because the CELL it belongs to is being sliced.
+    ///
+    /// Minimal model: one cell with vertices spanning `w in [-0.5, +0.5]` so its
+    /// w-range strictly straddles `w_slice = -0.182`. The edge under test
+    /// (vertices 2,3) has both endpoints at `w = +0.5`, far outside the slab as
+    /// an endpoint-pair. The OLD edge-level test on those endpoints would cull
+    /// it; the cell-level cull keeps it, matching the active-green coloring,
+    /// which also reads the whole cell's w-range.
+    #[test]
+    fn far_side_edge_of_active_cell_is_kept() {
+        let w_slice = -0.182_f32;
+        let thickness = 0.2_f32;
+        // 0,1 on the near side (w = -0.5), 2,3 on the far side (w = +0.5).
+        let local_vertices = [
+            Vec4::new(0.0, 0.0, 0.0, -0.5),
+            Vec4::new(1.0, 0.0, 0.0, -0.5),
+            Vec4::new(0.0, 1.0, 0.0, 0.5),
+            Vec4::new(1.0, 1.0, 0.0, 0.5),
+        ];
+        let cell: &[u32] = &[0, 1, 2, 3];
+        let cells: &[&[u32]] = &[cell];
+
+        // The far-side edge's own w-interval [0.5, 0.5] misses the slab
+        // [-0.282, -0.082]: the old edge-level rule would cull it.
+        assert!(
+            !slab_overlaps(0.5, 0.5, w_slice, thickness),
+            "the far-side edge's own endpoints do not straddle the slab"
+        );
+        // The containing cell's w-range [-0.5, 0.5] DOES straddle the slab, so
+        // the cell-level cull keeps the far-side edge.
+        assert!(
+            kept_by_cull(2, 3, cells, &local_vertices, w_slice, thickness),
+            "far-side edge of a sliced cell must be kept by the cell-level cull"
+        );
+    }
+
+    /// Agreement contract: every edge that the active-edge coloring lights up
+    /// (its containing cell has `strength > 0`, i.e. the slice is strictly inside
+    /// the cell's w-range) is kept by the cull. The slab band is a SUPERSET of
+    /// the strict-interior plane, so `active => kept` holds for any thickness at
+    /// or above the floor. Drives the same near/far cell as the repro but checks
+    /// every edge of it.
+    #[test]
+    fn cull_keeps_every_active_edge() {
+        let w_slice = -0.182_f32;
+        let thickness = HYPERSLICE_MIN_THICKNESS; // razor band: the strictest cull
+        let local_vertices = [
+            Vec4::new(0.0, 0.0, 0.0, -0.5),
+            Vec4::new(1.0, 0.0, 0.0, -0.5),
+            Vec4::new(0.0, 1.0, 0.0, 0.5),
+            Vec4::new(1.0, 1.0, 0.0, 0.5),
+        ];
+        let cell: &[u32] = &[0, 1, 2, 3];
+        let cells: &[&[u32]] = &[cell];
+        let edges: &[[u32; 2]] = &[[0, 1], [0, 2], [1, 3], [2, 3]];
+
+        let strengths = compute_cell_strengths(cells, &local_vertices, w_slice);
+        assert!(
+            strengths[0] > 0.0,
+            "the cell must be active for this contract to mean anything"
+        );
+        for &[i, j] in edges {
+            assert!(
+                kept_by_cull(i, j, cells, &local_vertices, w_slice, thickness),
+                "active cell's edge ({i},{j}) must be kept even at the razor band"
+            );
+        }
+    }
+
+    /// The cull still culls: an edge whose only containing cell has its w-range
+    /// entirely outside the slab is dropped. Single cell far above the slice;
+    /// its edges are all removed.
+    #[test]
+    fn cull_drops_edge_when_no_containing_cell_overlaps() {
+        let w_slice = 0.0_f32;
+        let thickness = 0.2_f32; // slab [-0.1, 0.1]
+        let local_vertices = [
+            Vec4::new(0.0, 0.0, 0.0, 0.6),
+            Vec4::new(1.0, 0.0, 0.0, 0.6),
+            Vec4::new(0.0, 1.0, 0.0, 0.8),
+            Vec4::new(1.0, 1.0, 0.0, 0.8),
+        ];
+        let cell: &[u32] = &[0, 1, 2, 3];
+        let cells: &[&[u32]] = &[cell];
+        // Cell w-range [0.6, 0.8] is entirely above the slab [-0.1, 0.1].
+        assert!(!kept_by_cull(
+            0,
+            1,
+            cells,
+            &local_vertices,
+            w_slice,
+            thickness
+        ));
+        assert!(!kept_by_cull(
+            2,
+            3,
+            cells,
+            &local_vertices,
+            w_slice,
+            thickness
+        ));
+    }
+
+    /// The extracted `cell_w_range` reproduces the `(w_min, w_max)` implicit in
+    /// `compute_cell_strengths`, so the single-source refactor cannot drift: the
+    /// strength is `1 - |w_slice - mid| / half_extent` with `mid` and
+    /// `half_extent` derived from exactly this range. Checked at the cell's
+    /// w-midpoint, where the strength must be exactly 1.0.
+    #[test]
+    fn cell_w_range_matches_compute_cell_strengths() {
+        let local_vertices = [
+            Vec4::new(0.0, 0.0, 0.0, -0.3),
+            Vec4::new(1.0, 0.0, 0.0, 0.1),
+            Vec4::new(0.0, 1.0, 0.0, 0.7),
+        ];
+        let cell: &[u32] = &[0, 1, 2];
+        let cells: &[&[u32]] = &[cell];
+
+        let (w_min, w_max) = cell_w_range(cell, &local_vertices);
+        assert_eq!((w_min, w_max), (-0.3, 0.7), "fold picks the w extremes");
+
+        let mid = (w_min + w_max) * 0.5;
+        let strengths = compute_cell_strengths(cells, &local_vertices, mid);
+        assert_eq!(
+            strengths[0], 1.0,
+            "strength at the cell's w-midpoint is the gradient peak"
+        );
     }
 }
 
@@ -3166,6 +5067,897 @@ mod drag_tests {
         assert!(
             ctx.is_being_dragged(id),
             "drag should be active for make_persistent_id keys too"
+        );
+    }
+}
+
+#[cfg(test)]
+mod section_cap_projection_tests {
+    //! Tests for the section-cap world transform under each wireframe projection.
+    //! The affine modes (Identity/Orthographic/Perspective4D) take the scalar shim
+    //! `perspective_scale_at_w` -> `Some(scale)`; the non-affine modes
+    //! (Schlegel/Stereographic) return `None`, and `cap_vertex_projected_and_world`
+    //! reconstructs the cap vertex's 4D coordinate at `w_slice` and projects it
+    //! per-vertex through `EuclideanR4::project_point`, matching the parent
+    //! wireframe so the flat cross-section lands on the projected edge graph.
+    use super::*;
+
+    /// `perspective_scale_at_w` reports `Some(scale)` exactly for the affine
+    /// projections (where a single scalar at the slice's w is exact) and `None`
+    /// for the non-affine ones (where no single scalar rescales the cap). This is
+    /// the guard the consumers branch on; if a non-affine arm silently grew a
+    /// scalar it would render the cross-section as a w-only-scaled ghost.
+    #[test]
+    fn perspective_scale_returns_none_for_non_affine() {
+        // Affine: Identity at any w is unit scale.
+        assert_eq!(
+            perspective_scale_at_w(0.3, &rye_math::Projection::Identity),
+            Some(1.0)
+        );
+        // Affine: Perspective4D at w_slice is `focal / (focal - w_slice)`.
+        let focal = 2.0;
+        let w_slice = 0.5;
+        let got = perspective_scale_at_w(
+            w_slice,
+            &rye_math::Projection::Perspective4D {
+                focal_distance: focal,
+            },
+        );
+        assert_eq!(got, Some(focal / (focal - w_slice)));
+        // Non-affine: both report `None`.
+        assert_eq!(
+            perspective_scale_at_w(0.0, &rye_math::Projection::Stereographic { pole: Vec4::W }),
+            None
+        );
+        assert_eq!(
+            perspective_scale_at_w(
+                0.0,
+                &rye_math::Projection::Schlegel {
+                    cell_normal: Vec4::W,
+                    cell_offset: 0.5,
+                    viewpoint_distance: 0.75,
+                }
+            ),
+            None
+        );
+    }
+
+    /// A cap vertex at `w = w_slice` lands at the same world R³ point whether the
+    /// affine scalar shim or a direct per-vertex `EuclideanR4::project_point` with
+    /// `Perspective4D` transforms it. This pins the equivalence the shim relies on:
+    /// for an affine projection, scaling the dropped-w cap by `focal / (focal -
+    /// w_slice)` IS the projection of `(x, y, z, w_slice)`, so the affine fast path
+    /// is not an approximation. If they ever diverged, caps and wireframe would
+    /// separate under W-depth.
+    #[test]
+    fn section_cap_matches_wireframe_under_perspective4d() {
+        let focal = 2.0;
+        let w_slice = 0.4;
+        let proj = rye_math::Projection::Perspective4D {
+            focal_distance: focal,
+        };
+        let body_pos = Vec3::new(1.3, -0.7, 0.2);
+        let scale = perspective_scale_at_w(w_slice, &proj);
+        assert!(scale.is_some(), "Perspective4D must take the affine shim");
+        // A handful of off-axis cap vertices, all sharing the slice's w.
+        for cap_r3 in [[0.5, 0.0, 0.0], [0.0, 0.3, -0.2], [-0.4, 0.1, 0.6]] {
+            // Affine shim path (what the cap rendering uses).
+            let via_shim =
+                cap_vertex_projected_and_world(cap_r3, w_slice, scale, &proj, body_pos).1;
+            // Per-vertex projection of the reconstructed 4D cap vertex (what the
+            // wireframe path uses for its vertices).
+            let p4 = Vec4::new(cap_r3[0], cap_r3[1], cap_r3[2], w_slice);
+            let via_wireframe = (project_to_world(p4, &proj, body_pos)).to_array();
+            for k in 0..3 {
+                assert!(
+                    (via_shim[k] - via_wireframe[k]).abs() < 1e-5,
+                    "cap {cap_r3:?} component {k}: shim {} vs wireframe {}",
+                    via_shim[k],
+                    via_wireframe[k]
+                );
+            }
+        }
+    }
+
+    /// Under Stereographic, the equatorial slice (`w_slice = 0`) sits opposite the
+    /// `+w` pole, so no cap vertex hits the projection's pole singularity: every
+    /// reconstructed-and-projected cap vertex maps to an all-finite world R³ point.
+    /// This pins the per-vertex non-affine path (`section_scale = None`) against
+    /// NaN/Inf leaking into the upload buffer at the cross-section.
+    ///
+    /// Cap vertices are edge-slice intersections, so they live on the polytope's
+    /// 1-skeleton at a radius bounded away from the center; the test stays away from
+    /// the exact origin, which is not a reachable cap vertex (no convex-polytope edge
+    /// passes through the interior center) and which `EuclideanR4::project_point`
+    /// cannot normalize onto S³. A near-origin vertex is included to probe the small-
+    /// radius end of the real range.
+    #[test]
+    fn section_cap_per_vertex_finite_under_stereographic() {
+        let w_slice = 0.0;
+        let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
+        let body_pos = Vec3::new(0.5, 0.0, -0.3);
+        let scale = perspective_scale_at_w(w_slice, &proj);
+        assert_eq!(scale, None, "Stereographic must take the per-vertex path");
+        // Cap vertices spread across the equatorial 3-flat, from a small but nonzero
+        // radius out to near the unit shell.
+        for cap_r3 in [
+            [0.5, 0.0, 0.0],
+            [0.0, -0.4, 0.3],
+            [0.95, 0.0, 0.0],
+            [0.02, -0.01, 0.015],
+        ] {
+            let world = cap_vertex_projected_and_world(cap_r3, w_slice, scale, &proj, body_pos).1;
+            for (k, c) in world.iter().enumerate() {
+                assert!(
+                    c.is_finite(),
+                    "cap {cap_r3:?} produced non-finite world component {k}: {c}"
+                );
+            }
+        }
+    }
+
+    /// `projection_is_affine` is true exactly for the chord-to-chord projections
+    /// (Identity / Orthographic / Perspective4D) and false for the curving ones
+    /// (Schlegel / Stereographic). This is the predicate the wireframe edge builder
+    /// branches on to decide between a single straight segment and a subdivided
+    /// polyline; it must agree with `perspective_scale_at_w`'s `Some`/`None` split,
+    /// since both encode the same affine/non-affine distinction.
+    #[test]
+    fn projection_affine_classification_matches_scale_shim() {
+        let cases = [
+            rye_math::Projection::Identity,
+            rye_math::Projection::Orthographic { drop_axis: 3 },
+            rye_math::Projection::Perspective4D {
+                focal_distance: 2.0,
+            },
+            rye_math::Projection::Schlegel {
+                cell_normal: Vec4::W,
+                cell_offset: 0.5,
+                viewpoint_distance: 0.75,
+            },
+            rye_math::Projection::Stereographic { pole: Vec4::W },
+        ];
+        for proj in cases {
+            assert_eq!(
+                projection_is_affine(&proj),
+                perspective_scale_at_w(0.0, &proj).is_some(),
+                "affine flag must match the scale-shim Some/None split for {proj:?}"
+            );
+        }
+        assert!(projection_is_affine(&rye_math::Projection::Identity));
+        assert!(!projection_is_affine(
+            &rye_math::Projection::Stereographic { pole: Vec4::W }
+        ));
+    }
+
+    /// The repair invariant: under a non-affine projection (Stereographic), the
+    /// parent wireframe edge built by `push_blended_edge` is subdivided so the
+    /// screen polyline follows the projected curve, and a section-cap vertex (the
+    /// edge's slice intersection, projected per-vertex through
+    /// `cap_vertex_projected_and_world`)
+    /// lands ON that polyline. The pre-repair single straight chord between the two
+    /// projected endpoints missed the cap by a measurable margin (~0.17 R³ units for
+    /// a unit-circumradius tesseract w-edge under the `+w`-pole map); the test
+    /// asserts the subdivided polyline closes that gap to well under the chord error.
+    ///
+    /// Uses a generic polytope edge whose endpoints differ in the spatial axes too
+    /// (not a pure radial w-edge, whose projected endpoints stay collinear with the
+    /// cap and would hide the defect), so the stereographic image genuinely bows off
+    /// the chord. `body_pos = ZERO` so the comparison is in the projection's own
+    /// frame.
+    #[test]
+    fn stereographic_wireframe_polyline_tracks_section_cap() {
+        let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
+        let body_pos = Vec3::ZERO;
+        let w_slice = 0.0;
+        // Endpoints straddling `w = 0` with distinct spatial coords; the slice cuts
+        // the edge at a non-midpoint, away from any radial special case.
+        let a = Vec4::new(0.30, 0.60, 0.20, 0.50);
+        let b = Vec4::new(0.70, 0.10, 0.40, -0.30);
+        // Section cap vertex: the edge's true intersection with `w = w_slice`.
+        // `edge_section` returns its drop-w R³; `cap_vertex_projected_and_world`
+        // reconstructs it at `w_slice` and projects per-vertex (the non-affine path).
+        let t_cut = (w_slice - a.w) / (b.w - a.w);
+        let cut = a.lerp(b, t_cut);
+        let cap_r3 = [cut.x, cut.y, cut.z];
+        let scale = perspective_scale_at_w(w_slice, &proj);
+        assert_eq!(
+            scale, None,
+            "Stereographic must take the per-vertex cap path"
+        );
+        let cap = Vec3::from_array(
+            cap_vertex_projected_and_world(cap_r3, w_slice, scale, &proj, body_pos).1,
+        );
+
+        // Build the parent wireframe edge through the real code path (flat space:
+        // blend = 0). Under Stereographic this routes to `push_projected_chord`, so
+        // `mesh` holds SPACE_TESSELLATION_SAMPLES sub-segments, not one chord.
+        let mut mesh = LineMesh::<3>::default();
+        let mut scratch = Vec::new();
+        let white = [1.0, 1.0, 1.0, 1.0];
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            white,
+            white,
+            1.0,
+            0.0,
+            &proj,
+            body_pos,
+            &mut scratch,
+        );
+        assert!(
+            mesh.segments.len() > 1,
+            "non-affine flat edge must subdivide, got {} segment(s)",
+            mesh.segments.len()
+        );
+
+        // Min distance from the cap vertex to the polyline (any sub-segment).
+        let poly_gap = mesh
+            .segments
+            .iter()
+            .map(|(s, e)| {
+                point_to_segment_distance(cap, Vec3::from_array(*s), Vec3::from_array(*e))
+            })
+            .fold(f32::INFINITY, f32::min);
+
+        // The pre-repair single chord between the two projected endpoints.
+        let pa = project_to_world(a, &proj, body_pos);
+        let pb = project_to_world(b, &proj, body_pos);
+        let chord_gap = point_to_segment_distance(cap, pa, pb);
+
+        // The defect (single chord) misses the cap by a real margin; the repaired
+        // polyline tracks it. The chord error for this edge is ~0.16; require the
+        // polyline to beat it by more than 10x and sit near the sampling floor.
+        assert!(
+            chord_gap > 0.05,
+            "expected the single-chord defect to miss the cap, gap {chord_gap}"
+        );
+        assert!(
+            poly_gap < chord_gap * 0.1,
+            "subdivided polyline must track the cap: poly_gap {poly_gap} vs chord_gap {chord_gap}"
+        );
+    }
+
+    /// Affine projections keep the single-segment fast path: a flat edge under
+    /// Perspective4D emits exactly one wireframe segment (no needless subdivision),
+    /// and the cap vertex sits on it. Guards the perf-sensitive common case from
+    /// accidentally taking the subdivided branch.
+    #[test]
+    fn affine_wireframe_keeps_single_segment_and_caps_land_on_it() {
+        let proj = rye_math::Projection::Perspective4D {
+            focal_distance: 2.0,
+        };
+        let body_pos = Vec3::ZERO;
+        let w_slice = 0.0;
+        let a = Vec4::new(0.5, 0.4, -0.3, 0.5);
+        let b = Vec4::new(0.5, 0.4, -0.3, -0.5);
+        let mut mesh = LineMesh::<3>::default();
+        let mut scratch = Vec::new();
+        let white = [1.0, 1.0, 1.0, 1.0];
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            white,
+            white,
+            1.0,
+            0.0,
+            &proj,
+            body_pos,
+            &mut scratch,
+        );
+        assert_eq!(
+            mesh.segments.len(),
+            1,
+            "affine flat edge must stay a single segment"
+        );
+        let mid = a.lerp(b, 0.5);
+        let cap_r3 = [mid.x, mid.y, mid.z];
+        let scale = perspective_scale_at_w(w_slice, &proj);
+        let cap = Vec3::from_array(
+            cap_vertex_projected_and_world(cap_r3, w_slice, scale, &proj, body_pos).1,
+        );
+        let (s, e) = mesh.segments[0];
+        let gap = point_to_segment_distance(cap, Vec3::from_array(s), Vec3::from_array(e));
+        assert!(
+            gap < 1e-5,
+            "affine cap must lie on its single-segment edge, gap {gap}"
+        );
+    }
+
+    /// The two-layer split's world-transform invariant: the HONEST cross-section
+    /// layer maps a cap vertex to the SAME world R³ point under every active
+    /// wireframe projection (because [`state::section_layer_projection`] forces it
+    /// to drop-w), while the PROJECTED cap layer moves with the active projection.
+    /// This is the render-path counterpart to the state-model
+    /// `section_layer_projection_honest_ignores_projected_follows` test: it pins
+    /// that the projection override actually changes where the cap lands, so a
+    /// projection change is provably non-destructive to the honest slice and
+    /// provably effective on the projected cap.
+    #[test]
+    fn honest_section_cap_is_projection_invariant_projected_cap_is_not() {
+        let body_pos = Vec3::new(0.7, -0.2, 0.4);
+        let w_slice = 0.3;
+        // A cap vertex with distinct spatial coords so a non-affine projection
+        // genuinely relocates it (a pure-radial point could stay collinear).
+        let cap_r3 = [0.4, -0.25, 0.15];
+        let actives = [
+            rye_math::Projection::Identity,
+            rye_math::Projection::Perspective4D {
+                focal_distance: 2.0,
+            },
+            rye_math::Projection::Stereographic { pole: Vec4::W },
+            rye_math::Projection::Schlegel {
+                cell_normal: Vec4::W,
+                cell_offset: 0.5,
+                viewpoint_distance: 0.9,
+            },
+        ];
+
+        // Honest layer (drop-w): the world cap is the body-local cap scaled by 1
+        // and translated, identical under every active projection.
+        let honest_reference = {
+            let proj = state::section_layer_projection(true, rye_math::Projection::Identity);
+            let scale = perspective_scale_at_w(w_slice, &proj);
+            cap_vertex_projected_and_world(cap_r3, w_slice, scale, &proj, body_pos).1
+        };
+        let mut projected_caps = Vec::new();
+        for active in actives {
+            // Honest layer is drop-w regardless of `active`.
+            let honest_proj = state::section_layer_projection(true, active);
+            assert_eq!(
+                honest_proj,
+                rye_math::Projection::Identity,
+                "honest layer must stay drop-w under {active:?}"
+            );
+            let honest_scale = perspective_scale_at_w(w_slice, &honest_proj);
+            let honest = cap_vertex_projected_and_world(
+                cap_r3,
+                w_slice,
+                honest_scale,
+                &honest_proj,
+                body_pos,
+            )
+            .1;
+            for k in 0..3 {
+                assert!(
+                    (honest[k] - honest_reference[k]).abs() < 1e-6,
+                    "honest cap drifted under {active:?}: {honest:?} vs {honest_reference:?}"
+                );
+            }
+
+            // Projected layer follows `active`.
+            let cap_proj = state::section_layer_projection(false, active);
+            assert_eq!(cap_proj, active, "projected layer must follow {active:?}");
+            let cap_scale = perspective_scale_at_w(w_slice, &cap_proj);
+            projected_caps.push(
+                cap_vertex_projected_and_world(cap_r3, w_slice, cap_scale, &cap_proj, body_pos).1,
+            );
+        }
+
+        // The projected cap must NOT all collapse to the honest drop-w point: at
+        // least one non-identity projection relocates it. (Identity's projected
+        // cap equals the honest one by construction; the others must differ.)
+        let moved = projected_caps
+            .iter()
+            .any(|c| (0..3).any(|k| (c[k] - honest_reference[k]).abs() > 1e-4));
+        assert!(
+            moved,
+            "projected cap must move under at least one active projection; \
+             got {projected_caps:?} all equal to honest {honest_reference:?}"
+        );
+    }
+
+    /// Distance from `p` to the segment `[s, e]` (clamped to the segment, not the
+    /// infinite line), the metric the polyline-tracking tests use to ask "does the
+    /// cap sit on this edge?".
+    fn point_to_segment_distance(p: Vec3, s: Vec3, e: Vec3) -> f32 {
+        let d = e - s;
+        let len_sq = d.length_squared();
+        if len_sq < 1e-20 {
+            return (p - s).length();
+        }
+        let t = ((p - s).dot(d) / len_sq).clamp(0.0, 1.0);
+        (p - (s + t * d)).length()
+    }
+
+    // ---- Stereographic pole clip ----------------------------------------
+    //
+    // These pin the near-pole clip the stereographic wireframe needs: a vertex
+    // landing on (or sweeping through) the projection pole maps to the
+    // large-but-finite point the pole-denominator clamp produces, and the
+    // wireframe builder drops the over-radius sub-segments rather than drawing
+    // them. The clip is a DROP, not a magnitude rescale; the tests below
+    // distinguish the two and pin boundedness, finiteness, the no-rescale
+    // (segment-count) discriminator, and non-perturbation of off-pole edges.
+    //
+    // NOT pinned here, and NOT claimed by any test name: flicker-freeness under
+    // continuous rotation. A vertex crossing the pole is a genuine projection
+    // discontinuity (the pole-perpendicular numerator reverses sign across the
+    // crossing); the clip bounds and de-NaNs the artifact and runs the edge out
+    // to the view boundary, but the at-pole instant remains discontinuous. That
+    // temporal behavior is a visual property and needs human eyes-on (see the
+    // wireframe overlay note); a test named "flicker_free" would be a doc lie.
+
+    /// `STEREOGRAPHIC_VIEW_RADIUS` equals its documented formula
+    /// `0.25 * sqrt(2 / eps)` and sits strictly below the pole-clamp magnitude
+    /// ceiling `sqrt(2 / eps)` yet well above the legitimate stereographic image
+    /// of a unit-circumradius polytope. Pins the recorded literal against its
+    /// derivation (it is a literal only because `f32::sqrt` is not `const`) and
+    /// the interdependence with the pole clamp: if `STEREOGRAPHIC_POLE_EPSILON`
+    /// changed without re-deriving the radius, the clip could fall above the
+    /// clamp ceiling and never engage, or below the real image and clip true
+    /// geometry.
+    #[test]
+    fn stereographic_view_radius_sits_below_clamp_ceiling() {
+        let eps = rye_math::STEREOGRAPHIC_POLE_EPSILON;
+        let clamp_ceiling = (2.0 / eps).sqrt();
+        // A quarter of the clamp ceiling: see STEREOGRAPHIC_VIEW_RADIUS.
+        let derived = 0.25 * clamp_ceiling;
+        assert!(
+            (STEREOGRAPHIC_VIEW_RADIUS - derived).abs() < 1e-2,
+            "recorded radius {STEREOGRAPHIC_VIEW_RADIUS} must match formula {derived}"
+        );
+        // Strictly below the clamp-saturated near-pole magnitude, so a sample in
+        // the clamp band reliably exceeds R and is dropped.
+        assert!(
+            STEREOGRAPHIC_VIEW_RADIUS < clamp_ceiling,
+            "radius {STEREOGRAPHIC_VIEW_RADIUS} must sit below the clamp ceiling {clamp_ceiling}"
+        );
+        // Well above the legit image: project an actual unit tesseract vertex
+        // (the `+w`-cell corner, the worst non-pole case at w = 0.5) and require
+        // the clip radius to clear its image magnitude by more than 10x, so real
+        // geometry is never dropped. A bare `R > literal` would be a const-vs-const
+        // tautology; this pins the radius against a genuine projected sample.
+        let legit = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+            Vec4::new(0.5, 0.5, 0.5, 0.5),
+            &rye_math::Projection::Stereographic { pole: Vec4::W },
+        );
+        assert!(
+            STEREOGRAPHIC_VIEW_RADIUS > 10.0 * legit.length(),
+            "radius {STEREOGRAPHIC_VIEW_RADIUS} must clear the legit image \
+             ({}) by a wide margin",
+            legit.length()
+        );
+    }
+
+    /// `stereographic_clip_radius` returns `Some(R)` exactly for Stereographic and
+    /// `None` for every other projection: only Stereographic has a genuine
+    /// point-at-infinity (a vertex on the pole) in its image, so it is the only
+    /// projection whose samples are clip-tested. Pins the gate the edge builders
+    /// branch on; a stray `Some` on an affine projection would clip legitimate
+    /// geometry, a stray `None` on Stereographic would draw the pole blow-up.
+    #[test]
+    fn stereographic_clip_radius_only_for_stereographic() {
+        assert_eq!(
+            stereographic_clip_radius(&rye_math::Projection::Stereographic { pole: Vec4::W }),
+            Some(STEREOGRAPHIC_VIEW_RADIUS)
+        );
+        for proj in [
+            rye_math::Projection::Identity,
+            rye_math::Projection::Orthographic { drop_axis: 3 },
+            rye_math::Projection::Perspective4D {
+                focal_distance: 2.0,
+            },
+            rye_math::Projection::Schlegel {
+                cell_normal: Vec4::W,
+                cell_offset: 0.5,
+                viewpoint_distance: 0.75,
+            },
+        ] {
+            assert_eq!(
+                stereographic_clip_radius(&proj),
+                None,
+                "non-stereographic projection {proj:?} must carry no clip"
+            );
+        }
+    }
+
+    /// Build the parent wireframe edge `a -> b` under the `+w`-pole stereographic
+    /// projection with `body_pos = ZERO`, so each emitted endpoint's world coord
+    /// equals its body-local projected point. Returns the segment endpoints.
+    fn build_stereographic_edge(a: Vec4, b: Vec4) -> Vec<([f32; 3], [f32; 3])> {
+        let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
+        let mut mesh = LineMesh::<3>::default();
+        let mut scratch = Vec::new();
+        let white = [1.0, 1.0, 1.0, 1.0];
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            white,
+            white,
+            1.0,
+            0.0,
+            &proj,
+            Vec3::ZERO,
+            &mut scratch,
+        );
+        mesh.segments
+    }
+
+    /// A unit point at angular distance `theta_deg` from the `+w` pole, in the
+    /// w-x plane. `theta_deg -> 0` approaches the pole singularity.
+    fn near_pole(theta_deg: f32) -> Vec4 {
+        let t = theta_deg.to_radians();
+        Vec4::new(t.sin(), 0.0, 0.0, t.cos())
+    }
+
+    /// Boundedness: every emitted endpoint of a stereographic wireframe edge has
+    /// body-local projected magnitude <= `STEREOGRAPHIC_VIEW_RADIUS`, even for an
+    /// edge that grazes the pole. The edge runs from 1 degree off the pole (well
+    /// inside the clip band, image magnitude ~114) out to the equator; the clip
+    /// drops the near-pole samples, so no emitted endpoint carries the blow-up.
+    #[test]
+    fn stereographic_clip_output_bounded_by_radius() {
+        let segs = build_stereographic_edge(near_pole(1.0), Vec4::new(1.0, 0.0, 0.0, 0.0));
+        assert!(
+            !segs.is_empty(),
+            "edge must emit at least one in-bounds segment"
+        );
+        let r = STEREOGRAPHIC_VIEW_RADIUS;
+        for (s, e) in &segs {
+            for end in [Vec3::from_array(*s), Vec3::from_array(*e)] {
+                assert!(
+                    end.length() <= r + 1e-3,
+                    "emitted endpoint {end:?} (|.| = {}) exceeds clip radius {r}",
+                    end.length()
+                );
+            }
+        }
+    }
+
+    /// The discriminating test the radius-clamp alternative fails: the clip is a
+    /// DROP, not a magnitude rescale. A pole-grazing edge tessellated into
+    /// `SPACE_TESSELLATION_SAMPLES` sub-segments must emit FEWER than that many
+    /// segments (the near-pole ones are dropped). A radius clamp would rescale the
+    /// offending samples back onto a sphere of radius `R` and keep every segment,
+    /// preserving the 180-degree direction flip across a pole crossing; this
+    /// asserts segments genuinely vanish, so the implementation cannot quietly be
+    /// a clamp. Also asserts no retained endpoint sits at the clamp ring (no
+    /// emitted endpoint within a hair of `R`), which a clamp would manufacture.
+    #[test]
+    fn stereographic_clip_drops_segments_not_rescales() {
+        // Edge from 1 degree off the pole to the equator: the first samples sit
+        // inside the ~3.24-degree clip band (image magnitude > R) and are dropped.
+        let segs = build_stereographic_edge(near_pole(1.0), Vec4::new(1.0, 0.0, 0.0, 0.0));
+        assert!(
+            segs.len() < SPACE_TESSELLATION_SAMPLES,
+            "near-pole edge must drop sub-segments (got {} of {})",
+            segs.len(),
+            SPACE_TESSELLATION_SAMPLES
+        );
+        // No retained endpoint sits on the clamp ring at radius ~R: a rescale
+        // clamp would pin the dropped samples there, a drop never does.
+        let r = STEREOGRAPHIC_VIEW_RADIUS;
+        for (s, e) in &segs {
+            for end in [Vec3::from_array(*s), Vec3::from_array(*e)] {
+                assert!(
+                    (end.length() - r).abs() > 0.5,
+                    "endpoint {end:?} sits on the clamp ring at radius {r}; clip must drop, not rescale"
+                );
+            }
+        }
+    }
+
+    /// Finiteness: an edge with one endpoint exactly on the pole produces only
+    /// finite endpoints, never NaN/Inf, and bounded by the clip radius. The pole
+    /// itself maps to the origin (the perpendicular numerator is zero there); its
+    /// near-pole neighbors blow up and are dropped. Extends the rasterizer's
+    /// finite-drop guard from "finite" to "finite AND bounded" for the
+    /// stereographic case.
+    #[test]
+    fn stereographic_pole_endpoint_edge_is_finite_and_bounded() {
+        let segs = build_stereographic_edge(Vec4::W, Vec4::new(1.0, 0.0, 0.0, 0.0));
+        let r = STEREOGRAPHIC_VIEW_RADIUS;
+        for (s, e) in &segs {
+            for end in [Vec3::from_array(*s), Vec3::from_array(*e)] {
+                assert!(
+                    end.is_finite(),
+                    "pole-edge endpoint must be finite: {end:?}"
+                );
+                assert!(
+                    end.length() <= r + 1e-3,
+                    "pole-edge endpoint {end:?} exceeds clip radius {r}"
+                );
+            }
+        }
+    }
+
+    /// Non-perturbation off the pole: an edge well clear of the pole keeps every
+    /// sub-segment (nothing dropped) and each emitted endpoint equals the raw
+    /// `project_to_world` of the corresponding chord sample bit-for-bit. The clip
+    /// is a pure post-filter on already-projected samples; it must not move a
+    /// retained sample. This guards the conformal interior: the clip changes
+    /// nothing where the projection is well-behaved.
+    #[test]
+    fn stereographic_clip_does_not_perturb_off_pole_edge() {
+        let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
+        // An edge straddling w = 0, far from the +w pole on both ends.
+        let a = Vec4::new(0.30, 0.60, 0.20, 0.10);
+        let b = Vec4::new(0.70, 0.10, 0.40, -0.30);
+        let segs = build_stereographic_edge(a, b);
+        assert_eq!(
+            segs.len(),
+            SPACE_TESSELLATION_SAMPLES,
+            "off-pole edge must retain every sub-segment (none clipped)"
+        );
+        // Reconstruct the un-clipped projected polyline directly and compare.
+        let samples = SPACE_TESSELLATION_SAMPLES;
+        let mut prev = project_to_world(a, &proj, Vec3::ZERO).to_array();
+        for (k, seg) in segs.iter().enumerate() {
+            let s = (k + 1) as f32 / samples as f32;
+            let cur = project_to_world(a.lerp(b, s), &proj, Vec3::ZERO).to_array();
+            assert_eq!(seg.0, prev, "segment {k} start must match raw projection");
+            assert_eq!(seg.1, cur, "segment {k} end must match raw projection");
+            prev = cur;
+        }
+    }
+
+    /// The clip adds no per-edge allocation. Building a pole-grazing blended edge
+    /// (which exercises the clip drop) then re-building it leaves `slerp_scratch`
+    /// at the capacity it reached on the first edge: the clip is a streaming
+    /// `continue`, not a `filter().collect()`, so the reused great-circle buffer
+    /// never grows on account of dropped samples. Mirrors the rasterizer's
+    /// `upload_drops_non_finite_without_reallocating`.
+    #[test]
+    fn stereographic_clip_reuses_scratch_without_realloc() {
+        let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
+        let white = [1.0, 1.0, 1.0, 1.0];
+        let mut scratch = Vec::new();
+        let mut mesh = LineMesh::<3>::default();
+        // Blended (blend > 0) edge so the slerp buffer is actually populated; one
+        // endpoint near the pole so the clip drops interior samples.
+        let a = near_pole(1.0);
+        let b = Vec4::new(1.0, 0.0, 0.0, 0.0);
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            white,
+            white,
+            0.5,
+            1.0,
+            &proj,
+            Vec3::ZERO,
+            &mut scratch,
+        );
+        let cap_after_first = scratch.capacity();
+        // The slerp buffer holds `samples + 1` points, so its capacity must be
+        // at least that after the first build.
+        assert!(cap_after_first > SPACE_TESSELLATION_SAMPLES);
+        // Re-run: the buffer is cleared and refilled to the same length, so no
+        // growth despite the clip dropping segments.
+        push_blended_edge(
+            &mut mesh,
+            a,
+            b,
+            white,
+            white,
+            0.5,
+            1.0,
+            &proj,
+            Vec3::ZERO,
+            &mut scratch,
+        );
+        assert_eq!(
+            scratch.capacity(),
+            cap_after_first,
+            "clip must not grow the reused slerp scratch"
+        );
+    }
+
+    // ---- Cap-fill + points-overlay near-pole drop ----------------------
+    //
+    // These pin GAP closures the perimeter outline already had: the
+    // projected-cap FILL (`retain_in_radius_triangles`, triangle-granularity)
+    // and the points overlay (`sample_in_radius` per vertex / cell-center).
+    // Both reuse the SAME predicate the wireframe edges and the cap perimeter
+    // use, so fill, outline, edges, and points all cull on one ~3.24-degree
+    // drop cone. As with the edge clip, none of these claim flicker-freeness;
+    // see the note above.
+
+    /// Demo default pole, exercised by the render path via
+    /// `resolved_wireframe_projection`. A literal here, kept in sync with the
+    /// state constant by `state::stereographic_default_pole_is_unit_cell_center`.
+    fn default_stereographic() -> rye_math::Projection<4> {
+        rye_math::Projection::Stereographic {
+            pole: state::STEREOGRAPHIC_DEFAULT_POLE,
+        }
+    }
+
+    /// The body-local projected point a near-pole cap vertex maps to under the
+    /// `+w` pole: a w-slice cap vertex within the angular epsilon of `+w`. Returns
+    /// the projected point the fill / perimeter / points clip all test.
+    fn cap_projected(cap_r3: [f32; 3], w_slice: f32, proj: &rye_math::Projection<4>) -> Vec3 {
+        let scale = perspective_scale_at_w(w_slice, proj);
+        cap_vertex_projected_and_world(cap_r3, w_slice, scale, proj, Vec3::ZERO).0
+    }
+
+    /// The cap FILL drops a triangle touching a near-pole vertex and keeps a
+    /// triangle whose vertices are all far from the pole, at TRIANGLE granularity:
+    /// a fan triangle with one near-pole vertex vanishes entirely (its index
+    /// triple is removed), while a far fan keeps every triangle. Mirrors
+    /// `stereographic_clip_drops_segments_not_rescales` for the fill path.
+    #[test]
+    fn cap_fill_triangle_dropped_near_pole() {
+        let r = STEREOGRAPHIC_VIEW_RADIUS;
+        // Three projected points: index 0 and 1 well inside the radius, index 2
+        // far outside it (the near-pole blow-up). Two fan triangles share the
+        // centroid (0): [0,1,2] touches the near-pole vertex, [0,1,1] does not.
+        let projected = [
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(r * 2.0, 0.0, 0.0),
+        ];
+        let mut indices = vec![[0u32, 1, 2], [0u32, 1, 1]];
+        retain_in_radius_triangles(&mut indices, 0, 0, &projected, Some(r));
+        assert_eq!(
+            indices,
+            vec![[0u32, 1, 1]],
+            "the triangle touching the near-pole vertex must be dropped, the far one kept"
+        );
+
+        // All-far fan: nothing dropped, bit-identical to the input.
+        let all_far = [
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.5, 0.5, 0.0),
+        ];
+        let mut far_indices = vec![[0u32, 1, 2]];
+        retain_in_radius_triangles(&mut far_indices, 0, 0, &all_far, Some(r));
+        assert_eq!(
+            far_indices,
+            vec![[0u32, 1, 2]],
+            "a fan entirely within the radius must keep every triangle"
+        );
+
+        // Affine layer (`None`): every triangle kept regardless of magnitude.
+        let mut affine_indices = vec![[0u32, 1, 2]];
+        retain_in_radius_triangles(&mut affine_indices, 0, 0, &projected, None);
+        assert_eq!(
+            affine_indices,
+            vec![[0u32, 1, 2]],
+            "no clip (affine) must keep every triangle even past the radius"
+        );
+    }
+
+    /// Fill and perimeter cull in LOCKSTEP: for a shared near-pole cap vertex,
+    /// the predicate the fill uses (`retain_in_radius_triangles` via
+    /// `sample_in_radius` on `cap_vertex_projected_and_world`'s projected point)
+    /// agrees with the perimeter's per-segment `sample_in_radius` on the very same
+    /// projected point and radius. Pins the RANK 1 fill/outline agreement: both
+    /// drop exactly when the body-local projected magnitude exceeds the radius.
+    #[test]
+    fn cap_fill_matches_perimeter_clip() {
+        let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
+        let clip = stereographic_clip_radius(&proj);
+        // A near-pole cap vertex (w-slice close to +w, off-axis so it projects to
+        // a large finite point) and a far one on the equatorial slice.
+        let near = cap_projected([0.05, 0.02, 0.01], 0.999, &proj);
+        let far = cap_projected([0.5, 0.0, 0.0], 0.0, &proj);
+        // The perimeter drops a segment when EITHER endpoint fails the test.
+        let perimeter_keeps_near = sample_in_radius(near, clip);
+        let perimeter_keeps_far = sample_in_radius(far, clip);
+        assert!(
+            !perimeter_keeps_near,
+            "near-pole cap projected to {near:?} (|.| = {}) must fail the clip",
+            near.length()
+        );
+        assert!(perimeter_keeps_far, "far cap must pass the clip");
+        // The fill compaction over a single fan touching the near vertex must
+        // drop it iff the perimeter would, on the same projected points + radius.
+        let projected = [Vec3::ZERO, far, near];
+        let mut indices = vec![[0u32, 1, 2]];
+        retain_in_radius_triangles(&mut indices, 0, 0, &projected, clip);
+        let fill_keeps = !indices.is_empty();
+        assert_eq!(
+            fill_keeps,
+            perimeter_keeps_near && perimeter_keeps_far,
+            "fill triangle keep/drop must match the perimeter's endpoint test"
+        );
+        assert!(!fill_keeps, "the near-pole fan must be dropped");
+    }
+
+    /// The points overlay drops a near-pole vertex and keeps a far one, the same
+    /// `sample_in_radius` gate `render_points` applies after projecting each
+    /// vertex / cell-center. Pins the RANK 2 consistency: a giant near-pole disc
+    /// is culled (clean blink) just as the touching edge is. Affine projection
+    /// (`clip_radius == None`) keeps every point.
+    #[test]
+    fn points_overlay_drops_near_pole_vertex() {
+        let proj = rye_math::Projection::Stereographic { pole: Vec4::W };
+        let clip = stereographic_clip_radius(&proj);
+        // Body-local vertex within the angular epsilon of +w: project it the same
+        // way render_points does, then apply the gate.
+        let v_near = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+            near_pole(1.0),
+            &proj,
+        );
+        let v_far = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
+            Vec4::new(1.0, 0.0, 0.0, 0.0),
+            &proj,
+        );
+        assert!(
+            !sample_in_radius(v_near, clip),
+            "near-pole vertex (|.| = {}) must be dropped from the points overlay",
+            v_near.length()
+        );
+        assert!(
+            sample_in_radius(v_far, clip),
+            "far vertex (|.| = {}) must be kept",
+            v_far.length()
+        );
+        // Affine projection carries no clip: even the near-pole image is kept
+        // (Identity has no point-at-infinity, so the magnitude is bounded anyway).
+        let affine_clip = stereographic_clip_radius(&rye_math::Projection::Identity);
+        assert!(
+            sample_in_radius(v_near, affine_clip),
+            "affine projection must keep every point (no clip)"
+        );
+    }
+
+    /// The default-pole render path actually projects through the cell-center pole
+    /// (not `+w`), and the cap clip applies to it: a cap vertex near the cell
+    /// center is dropped, one far from it kept. Pins that
+    /// `resolved_wireframe_projection`'s pole substitution flows into the cap fill
+    /// without re-deriving the projection. Also a demo-level guard that the
+    /// conformal map is the pure rye-math primitive (an equatorial-ish cap vertex
+    /// far from any pole projects to a bounded, finite, kept point).
+    #[test]
+    fn cap_fill_uses_default_cell_center_pole() {
+        let proj = default_stereographic();
+        let clip = stereographic_clip_radius(&proj);
+        // A 4D point in the cell-center pole's near neighborhood (NOT exactly on
+        // it: the pole itself maps to a small point because the perpendicular
+        // numerator vanishes there; the blow-up is in the punctured neighborhood).
+        // `(0.5, 0.5, 0.5, 0.49)` normalizes to dot ~ 0.99996 with the pole, image
+        // magnitude ~87, well past the ~35 radius, so it drops.
+        let near = cap_projected([0.5, 0.5, 0.5], 0.49, &proj);
+        assert!(
+            !sample_in_radius(near, clip),
+            "cap vertex near the cell-center pole (|.| = {}) must drop",
+            near.length()
+        );
+        // A point far from the cell-center direction (negative lanes) stays
+        // bounded and finite, the pure conformal image, and is kept.
+        let far = cap_projected([-0.4, -0.3, 0.2], 0.0, &proj);
+        assert!(
+            far.is_finite() && sample_in_radius(far, clip),
+            "off-pole cap vertex must stay finite + in-radius: {far:?}"
+        );
+    }
+
+    /// The cap-fill clip scratch (`section_clip_projected_scratch`, taken via
+    /// `std::mem::take`) retains capacity across two compactions, so the hot path
+    /// has no per-frame allocation. Mirrors
+    /// `stereographic_clip_reuses_scratch_without_realloc` for the fill path:
+    /// fill the buffer, drop triangles, re-fill, and assert no growth.
+    #[test]
+    fn cap_fill_scratch_reused_without_realloc() {
+        let r = STEREOGRAPHIC_VIEW_RADIUS;
+        // Simulate the per-append fill of `proj_scratch`: push projected points,
+        // compact, then clear + re-push (what build_section_layer_meshes does per
+        // body, twice across two frames).
+        let mut proj_scratch: Vec<Vec3> = Vec::new();
+        let fill = |scratch: &mut Vec<Vec3>| {
+            scratch.clear();
+            scratch.push(Vec3::ZERO);
+            scratch.push(Vec3::new(1.0, 0.0, 0.0));
+            scratch.push(Vec3::new(r * 2.0, 0.0, 0.0));
+            let mut indices = vec![[0u32, 1, 2], [0u32, 1, 1]];
+            retain_in_radius_triangles(&mut indices, 0, 0, scratch, Some(r));
+        };
+        fill(&mut proj_scratch);
+        let cap_after_first = proj_scratch.capacity();
+        assert!(cap_after_first >= 3);
+        fill(&mut proj_scratch);
+        assert_eq!(
+            proj_scratch.capacity(),
+            cap_after_first,
+            "fill clip must reuse the projected-point scratch without growth"
         );
     }
 }

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -87,36 +87,35 @@ const SECTION_FACES_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Dep
 const PERSPECTIVE_SCALE_DENOM_EPSILON: f32 = 1e-4;
 
 /// Body-local projected radius past which a stereographic sample is treated as
-/// the conformal point at infinity and DROPPED from the rendered polyline,
-/// rather than drawn as the large-but-finite point the pole-denominator clamp
-/// produces.
+/// the conformal point at infinity and cut from the rendered polyline (the arc
+/// runs out to this radius; samples beyond it are the near-pole blow-up).
 ///
-/// Why a drop, not a magnitude clamp: as a vertex sweeps through the pole under
-/// rotation, the pole-perpendicular numerator `p - dot*pole` passes through zero
-/// and reverses direction, so the projected point's direction flips 180 degrees
-/// across the crossing. Rescaling that point back to a fixed radius (a clamp)
-/// keeps the flip: the clamped point still jumps from `R*(+u)` to `R*(-u)`, a
-/// `2R` screen pop. Dropping the over-radius sub-segment instead lets the edge
-/// run out toward the view boundary and culls the offscreen blow-up; the
-/// remaining on-screen polyline is the true conformal image, untouched. This
-/// bounds and de-NaNs the artifact but does NOT make the at-pole instant
-/// continuous (a vertex crossing the pole is a genuine discontinuity of the
-/// projection); see the eyes-on caveat in the wireframe overlay.
+/// **The cap must sit below the camera distance.** A stereographic near-pole edge
+/// images to an arc that runs off toward infinity; the cap bounds it at this
+/// world radius. The wireframe is centered near the orbit target, and the camera
+/// orbits it at [`OrbitController`]'s distance (the demo's default is `9.5`, the
+/// minimum `1.5`). If the cap exceeds the camera distance, an arc endpoint at
+/// radius `R` in the camera's direction lands AT or BEHIND the eye, and the
+/// perspective projection of a point grazing the eye plane is hyper-sensitive: a
+/// small rotation step swings its screen image from the far edge (a "long" arc)
+/// to a finite on-screen point (a "short" arc), the long/short rubberband. The
+/// engine's near-plane line clip (`line_raster.wgsl`) removes the sign-flip
+/// *width* artifact of a behind-eye endpoint, but it cannot remove this
+/// *length* discontinuity, which is inherent to an extended arc reaching past a
+/// close camera. Keeping `R` comfortably below the orbit distance keeps every arc
+/// endpoint well in front of the eye, so the projection stays smooth and bounded
+/// and the arc has no way to graze the camera plane.
 ///
-/// Interdependent with [`rye_math::STEREOGRAPHIC_POLE_EPSILON`]: a sample inside
-/// the clamp band maps to magnitude at most `sqrt(2 / eps)` (~141 at the default
-/// `eps = 1e-4`), so this radius must sit strictly below that ceiling for the
-/// near-pole blow-up to reliably exceed it and be dropped, yet well above the
-/// legitimate on-screen extent of a unit-circumradius polytope's stereographic
-/// image (a `body_size`-scaled vertex with `w = 0.5` maps to radius ~1.7, and
-/// near-pole edge interiors reach a few units) so real geometry is never
-/// clipped. The value is a quarter of the clamp ceiling `sqrt(2 / eps)`, i.e.
-/// ~35: a quarter keeps the clip well clear of both the legitimate image (far
-/// below `R`) and the clamp-saturated near-pole blow-up (far above `R`), so the
-/// drop is unambiguous on both sides. Pinned against its formula by
-/// `stereographic_view_radius_sits_below_clamp_ceiling` (the literal is the f32
-/// value of `0.25 * sqrt(2 / eps)`, recorded because `f32::sqrt` is not `const`).
-const STEREOGRAPHIC_VIEW_RADIUS: f32 = 35.355_34;
+/// `6.0` sits below the default `9.5` orbit (nearest approach to the eye `~3.5`,
+/// a gentle off-axis sweep) and far above the legitimate image extent of a
+/// unit-circumradius polytope (a `w = 0.5` vertex maps to radius `~1.7`), so real
+/// geometry is never clipped while the near-pole arcs read as an extended halo
+/// rather than offscreen-bouncing infinities. It is also well under the
+/// pole-clamp ceiling `sqrt(2 / eps)` (~141), so the near-pole blow-up still
+/// reliably exceeds it. NOTE: not yet adaptive to zoom; a zoom-in past `R` would
+/// reintroduce the grazing sweep (the near-plane clip still prevents the width
+/// artifact). Pinned by `stereographic_view_radius_below_camera_distance`.
+const STEREOGRAPHIC_VIEW_RADIUS: f32 = 6.0;
 
 /// Cap on the reconstructed near-pole image magnitude (see `near_pole_view_point`).
 /// A point within the pole-denominator clamp band is a point-at-infinity; the
@@ -5367,44 +5366,45 @@ mod section_cap_projection_tests {
     // temporal behavior is a visual property and needs human eyes-on (see the
     // wireframe overlay note); a test named "flicker_free" would be a doc lie.
 
-    /// `STEREOGRAPHIC_VIEW_RADIUS` equals its documented formula
-    /// `0.25 * sqrt(2 / eps)` and sits strictly below the pole-clamp magnitude
-    /// ceiling `sqrt(2 / eps)` yet well above the legitimate stereographic image
-    /// of a unit-circumradius polytope. Pins the recorded literal against its
-    /// derivation (it is a literal only because `f32::sqrt` is not `const`) and
-    /// the interdependence with the pole clamp: if `STEREOGRAPHIC_POLE_EPSILON`
-    /// changed without re-deriving the radius, the clip could fall above the
-    /// clamp ceiling and never engage, or below the real image and clip true
-    /// geometry.
+    /// `STEREOGRAPHIC_VIEW_RADIUS` sits below the camera orbit distance (so a
+    /// near-pole arc can never reach the camera plane and rubberband), above the
+    /// legitimate stereographic image of a unit-circumradius polytope (so real
+    /// geometry is never clipped), and below the pole-clamp magnitude ceiling
+    /// `sqrt(2 / eps)` (so the near-pole blow-up still reliably exceeds it). The
+    /// camera-distance bound is the load-bearing one: it is what removes the
+    /// long/short length jump the near-plane line clip alone cannot.
     #[test]
-    fn stereographic_view_radius_sits_below_clamp_ceiling() {
-        let eps = rye_math::STEREOGRAPHIC_POLE_EPSILON;
-        let clamp_ceiling = (2.0 / eps).sqrt();
-        // A quarter of the clamp ceiling: see STEREOGRAPHIC_VIEW_RADIUS.
-        let derived = 0.25 * clamp_ceiling;
+    fn stereographic_view_radius_below_camera_distance() {
+        // The demo's default orbit distance (see `Demo::new`, `set_orbit(9.5, ..)`).
+        // The wireframe sits near the orbit target, so this is the eye's distance
+        // from the stereographic image; an arc capped below it stays in front of
+        // the eye at every orientation.
+        const DEFAULT_ORBIT_DISTANCE: f32 = 9.5;
         assert!(
-            (STEREOGRAPHIC_VIEW_RADIUS - derived).abs() < 1e-2,
-            "recorded radius {STEREOGRAPHIC_VIEW_RADIUS} must match formula {derived}"
+            STEREOGRAPHIC_VIEW_RADIUS < DEFAULT_ORBIT_DISTANCE,
+            "radius {STEREOGRAPHIC_VIEW_RADIUS} must stay below the camera distance \
+             {DEFAULT_ORBIT_DISTANCE} so arcs never reach the camera plane"
         );
-        // Strictly below the clamp-saturated near-pole magnitude, so a sample in
-        // the clamp band reliably exceeds R and is dropped.
+
+        // Below the pole-clamp ceiling, so a clamp-band sample reliably exceeds R.
+        let clamp_ceiling = (2.0 / rye_math::STEREOGRAPHIC_POLE_EPSILON).sqrt();
         assert!(
             STEREOGRAPHIC_VIEW_RADIUS < clamp_ceiling,
             "radius {STEREOGRAPHIC_VIEW_RADIUS} must sit below the clamp ceiling {clamp_ceiling}"
         );
-        // Well above the legit image: project an actual unit tesseract vertex
-        // (the `+w`-cell corner, the worst non-pole case at w = 0.5) and require
-        // the clip radius to clear its image magnitude by more than 10x, so real
-        // geometry is never dropped. A bare `R > literal` would be a const-vs-const
-        // tautology; this pins the radius against a genuine projected sample.
+
+        // Above the legit image: project an actual unit tesseract vertex (the
+        // `+w`-cell corner, the worst non-pole case at w = 0.5, image magnitude
+        // sqrt(3) ~ 1.73) and require the cap to clear it with margin, so real
+        // geometry is never clipped. Pins the radius against a genuine sample
+        // rather than a const-vs-const tautology.
         let legit = <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(
             Vec4::new(0.5, 0.5, 0.5, 0.5),
             &rye_math::Projection::Stereographic { pole: Vec4::W },
         );
         assert!(
-            STEREOGRAPHIC_VIEW_RADIUS > 10.0 * legit.length(),
-            "radius {STEREOGRAPHIC_VIEW_RADIUS} must clear the legit image \
-             ({}) by a wide margin",
+            STEREOGRAPHIC_VIEW_RADIUS > 2.0 * legit.length(),
+            "radius {STEREOGRAPHIC_VIEW_RADIUS} must clear the legit image ({})",
             legit.length()
         );
     }
@@ -5525,7 +5525,7 @@ mod section_cap_projection_tests {
     /// The clip cuts a straddling sub-segment AT the view boundary and DROPS a
     /// sub-segment whose interior runs deep through the pole; it is neither a
     /// whole-segment drop nor a magnitude rescale. The fixture is an edge whose
-    /// great-circle interior passes straight through the `+w` pole (endpoints 5
+    /// great-circle interior passes straight through the `+w` pole (endpoints 30
     /// degrees off the pole on opposite sides), so the deep-pole samples blow up
     /// while both endpoints stay well inside `R`. Three guarantees:
     ///
@@ -5544,11 +5544,11 @@ mod section_cap_projection_tests {
     #[test]
     fn stereographic_clip_cuts_to_boundary_and_drops_deep_pole() {
         let r = STEREOGRAPHIC_VIEW_RADIUS;
-        // Endpoints 5 degrees off the pole on opposite sides of the w-x plane;
+        // Endpoints 30 degrees off the pole on opposite sides of the w-x plane;
         // their connecting great circle passes through the +w pole at its
-        // midpoint. The endpoints' image magnitude is cot(2.5 deg) ~ 22.9 < R, so
+        // midpoint. The endpoints' image magnitude is cot(15 deg) ~ 3.73 < R, so
         // they are kept, while the midpoint samples blow up past R.
-        let off = 5.0_f32.to_radians();
+        let off = 30.0_f32.to_radians();
         let a = Vec4::new(off.sin(), 0.0, 0.0, off.cos());
         let b = Vec4::new(-off.sin(), 0.0, 0.0, off.cos());
         let segs = build_spherical_stereographic_edge(a, b);

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -130,7 +130,7 @@ const STEREOGRAPHIC_VIEW_RADIUS_FLOOR: f32 = 2.5;
 /// boundary (the bounce). `10.0` keeps the 16-cell's arcs extended but bounded
 /// within the (mostly) well-sampled region. To extend further AND stay smooth,
 /// raise this together with the arc sample count (or subdivide adaptively by
-/// projected segment length) — a future arc-extent slider would drive both.
+/// projected segment length); a future arc-extent slider would drive both.
 const STEREOGRAPHIC_CELL16_RADIUS_MAX: f32 = 10.0;
 
 /// Reference clip radius for tests (which have no live camera): the value
@@ -153,7 +153,7 @@ const STEREOGRAPHIC_VIEW_RADIUS: f32 = 6.0;
 ///
 /// **Every other polytope has its vertices OFF the `+w` pole** (the tesseract's
 /// reach `dot = ½`, the 24-cell's `1/√2`, etc.), so its stereographic image is
-/// naturally bounded and is drawn with NO clip (`f32::INFINITY` — the clip never
+/// naturally bounded and is drawn with NO clip (`f32::INFINITY`, so the clip never
 /// engages), giving the full undistorted conformal extent. A vertex only reaches
 /// the pole if rotated exactly onto it, a transient the near-plane line clip
 /// already keeps finite.
@@ -185,7 +185,7 @@ const STEREOGRAPHIC_POLE_FAR_CAP: f32 = 1.0e4;
 /// near-singularity samples are clipped; the affine projections and Schlegel's
 /// bounded-finite clamp keep every sample. `view_radius` is the camera-adaptive
 /// [`stereographic_view_radius`] in the live render path (tests pass the fixed
-/// [`STEREOGRAPHIC_VIEW_RADIUS`]); it is a body-local radius, so the same 4D edge
+/// `STEREOGRAPHIC_VIEW_RADIUS`); it is a body-local radius, so the same 4D edge
 /// clips identically at every row slot regardless of the body's R³ position.
 fn stereographic_clip_radius(
     projection: &rye_math::Projection<4>,
@@ -273,7 +273,7 @@ fn local_r3_to_world(p: [f32; 3], section_scale: f32, body_pos_r3: Vec3) -> [f32
 /// first tuple element, the point whose magnitude the stereographic clip tests)
 /// and its world R³ point (the second). Returning the projected point keeps the
 /// clip honest without re-projecting: the perimeter outline and the cap fill both
-/// drop a sample whose projected magnitude exceeds [`STEREOGRAPHIC_VIEW_RADIUS`],
+/// drop a sample whose projected magnitude exceeds `STEREOGRAPHIC_VIEW_RADIUS`,
 /// using the same pre-translate point [`stereographic_clip_radius`] is defined
 /// against.
 ///
@@ -390,14 +390,14 @@ fn cell_w_range(cell: &[u32], local_vertices: &[Vec4]) -> (f32, f32) {
 /// convention so the two paths are visually seamless.
 ///
 /// Under [`rye_math::Projection::Stereographic`] the polyline is clipped at
-/// [`STEREOGRAPHIC_VIEW_RADIUS`]: a sub-segment is emitted only when BOTH its
+/// `STEREOGRAPHIC_VIEW_RADIUS`: a sub-segment is emitted only when BOTH its
 /// endpoints' body-local projected magnitudes are within the radius, so a
 /// near-pole sample (which the pole-denominator clamp maps to a huge finite
 /// point) is dropped rather than drawn. The clip is a sample-granularity drop in
 /// the same streaming `continue` idiom as the rasterizer's non-finite cull, not
 /// a magnitude rescale: rescaling a near-pole sample to the radius would keep the
 /// 180-degree direction flip across a pole crossing (see
-/// [`STEREOGRAPHIC_VIEW_RADIUS`]). When the projected point re-enters the radius
+/// `STEREOGRAPHIC_VIEW_RADIUS`). When the projected point re-enters the radius
 /// the polyline resumes from the new in-bounds sample, never bridging across the
 /// dropped gap, so the edge runs out toward the view boundary and the offscreen
 /// blow-up is culled. No clip is applied for other projections

--- a/crates/polytope_playground/src/main.rs
+++ b/crates/polytope_playground/src/main.rs
@@ -311,6 +311,11 @@ fn cap_vertex_projected_and_world(
 /// already folds the w-dependent scale into the projection, so no extra scale
 /// factor is applied here (unlike [`local_r3_to_world`], which the cross-section
 /// path needs because it drops w before this stage).
+///
+/// Test-only: the render paths inline this (they also need the pre-translate
+/// projected point for the stereographic clip, which this discards), so it
+/// survives solely as a tessellation/projection oracle for the wireframe tests.
+#[cfg(test)]
 fn project_to_world(p: Vec4, projection: &rye_math::Projection<4>, body_pos_r3: Vec3) -> Vec3 {
     <rye_math::EuclideanR4 as rye_math::RasterizableSpace<4>>::project_point(p, projection)
         + body_pos_r3

--- a/crates/polytope_playground/src/shapes.rs
+++ b/crates/polytope_playground/src/shapes.rs
@@ -143,6 +143,10 @@ impl Demo {
         }
         if row_changed {
             self.rebuild_bodies();
+            // A row edit can change the leading polychoron the Schlegel diagram
+            // projects through (and its cell count); re-resolve so a stale cache
+            // can't index the wrong polytope's face planes.
+            self.resolve_schlegel_cache();
         }
     }
 

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -11,7 +11,7 @@
 use std::collections::HashMap;
 
 use rye_app::{freecam::Freecam, Camera, OrbitController};
-use rye_math::{Bivector, Bivector4, EuclideanR3, Plane4, Rotor4};
+use rye_math::{Bivector, Bivector4, EuclideanR3, Plane4, Projection, Rotor, Rotor4};
 use rye_physics::polytope::Polytope4;
 use rye_render::raymarch::{BodyUniform, Hyperslice4DNode, RaymarchShape};
 
@@ -46,11 +46,46 @@ pub(crate) enum ViewMode {
     /// one common `w_slice`. Shape order in the row is meaningful; drag-and-drop
     /// rearranges the scene's left-to-right layout.
     Shapes,
+    /// Single-shape inspection: exactly one [`ShapeEntry`] (the `strip_subject`,
+    /// independent of the row) rendered at one `w_slice` with the full
+    /// surface / wireframe / projection / points stack. Shares the Shapes-view
+    /// render path verbatim, only over a one-element row
+    /// ([`Demo::render_row`]), so every overlay affordance carries over.
+    ///
+    /// REQUIRED for Schlegel: a cell-index boundary selection is meaningless
+    /// across a row of different polytopes (a 5-cell has 5 cells, a 600-cell
+    /// has 600), so the unambiguous single subject is what makes the
+    /// cell-index stepper well-defined. Stereographic reads far better on one
+    /// body too. Stereographic / Hyperslice still work in [`Self::Shapes`]
+    /// (they are per-vertex maps that apply to every body uniformly); only
+    /// Schlegel's cell-index strictly needs Single.
+    Single,
     /// Single-shape filmstrip: one [`ShapeEntry`] (independent of the row) rendered N
     /// times across evenly-spaced `w_slice` values around the slider's current `w`.
     /// Order of the scene's row is irrelevant in this mode; the row UI is hidden
     /// entirely.
     Filmstrip,
+}
+
+/// The slice of [`ShapeEntry`]s the scene actually renders for `view_mode`, the
+/// single source of truth every per-body render path and the SDF body upload
+/// reads. [`ViewMode::Single`] yields exactly the `strip_subject` (a one-element
+/// borrow of the subject, no allocation); every other mode renders the full
+/// `row`. [`ViewMode::Filmstrip`] also draws only `strip_subject`, but through
+/// its own per-cell grid path in `render`, so it is not a caller here and falls
+/// through to the row arm without effect.
+///
+/// Free function (no `&self`) so the row-selection invariant is unit-testable
+/// without a GPU-backed [`Demo`]; [`Demo::render_row`] is the one caller.
+pub(crate) fn render_row_entries<'a>(
+    view_mode: ViewMode,
+    row: &'a [ShapeEntry],
+    strip_subject: &'a ShapeEntry,
+) -> &'a [ShapeEntry] {
+    match view_mode {
+        ViewMode::Single => std::slice::from_ref(strip_subject),
+        ViewMode::Shapes | ViewMode::Filmstrip => row,
+    }
 }
 
 /// How the six regular convex 4-polytopes have their surface rendered.
@@ -90,6 +125,78 @@ impl SurfaceMode {
     }
 }
 
+/// One overlaid layer of the rasterized cross-section: a perimeter-outline
+/// toggle plus a surface-fill alpha that doubles as the layer's on/off switch
+/// (`0.0` draws no fill). The slice geometry is identical for both layers (the
+/// honest drop-w 3-flat cut); the layers differ only in how that geometry maps
+/// to R³ for display. See [`Demo::cross_section`] / [`Demo::projected_cap`].
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) struct SectionLayer {
+    /// Whether this layer's cap-boundary perimeter outline renders. Independent
+    /// of [`Self::surface_alpha`]: a user can show the outline with no fill, or a
+    /// fill with no outline.
+    pub(crate) perimeter: bool,
+    /// Per-fragment fill alpha in `[0, 1]`. `0.0` is the layer's off state (no
+    /// fill submitted); `(0, 1)` renders through the depth-write-disabled
+    /// translucent pipeline so layers behind composite through; `1.0` renders
+    /// opaque with depth-write. See [`Demo::section_faces`] /
+    /// [`Demo::section_faces_translucent`].
+    pub(crate) surface_alpha: f32,
+}
+
+impl SectionLayer {
+    /// Whether the surface fill draws at all (`surface_alpha > 0`). Below this an
+    /// alpha-zero fill is fully transparent, so the layer skips its triangle pass
+    /// entirely rather than submitting an invisible mesh.
+    pub(crate) fn fill_visible(self) -> bool {
+        self.surface_alpha > 0.0
+    }
+}
+
+/// Default surface-fill alpha for the honest cross-section layer: visible but
+/// slightly translucent so the parent wireframe (when enabled) reads through the
+/// cap without a separate `surface alpha` command. "Full-ish" rather than fully
+/// opaque per the layer's default-on role as the always-honest slice.
+const CROSS_SECTION_DEFAULT_ALPHA: f32 = 0.85;
+
+impl SectionLayer {
+    /// The honest cross-section's default: perimeter + fill on at a full-ish
+    /// alpha, so selecting a distorting wireframe projection never silently
+    /// reshapes the slice the user reads as "the cross-section."
+    pub(crate) const CROSS_SECTION_DEFAULT: SectionLayer = SectionLayer {
+        perimeter: true,
+        surface_alpha: CROSS_SECTION_DEFAULT_ALPHA,
+    };
+    /// The projected-cap's default: fully off. It reprojects the slice through
+    /// the active wireframe projection, which is opt-in (the user asks for it to
+    /// sit the cap on a Schlegel / stereographic wireframe).
+    pub(crate) const PROJECTED_CAP_DEFAULT: SectionLayer = SectionLayer {
+        perimeter: false,
+        surface_alpha: 0.0,
+    };
+}
+
+/// The 4D->R³ projection a section layer renders its slice through. The honest
+/// cross-section is ALWAYS drop-w ([`rye_math::Projection::Identity`]) regardless
+/// of the active wireframe projection: the slice IS a 3-flat and drop-w is the
+/// inhabitant's undistorted view of it, the same geometry the SDF raymarch shows.
+/// The projected cap follows the active wireframe `projection`, so it can sit on a
+/// Schlegel / stereographic wireframe.
+///
+/// Free function (no `&Demo`) so the "honest layer ignores the projection,
+/// projected layer follows it" invariant is unit-testable without a GPU-backed
+/// [`Demo`]; the two section render paths in `main.rs` are the callers.
+pub(crate) fn section_layer_projection(
+    is_cross_section: bool,
+    projection: Projection<4>,
+) -> Projection<4> {
+    if is_cross_section {
+        Projection::Identity
+    } else {
+        projection
+    }
+}
+
 /// How the parent wireframe's 4D vertex positions project to R³ for rendering.
 /// Independent of the cross-section's projection (which is always drop-w because the
 /// slice IS a 3-flat and drop-w is the inhabitant's natural view of it).
@@ -108,31 +215,440 @@ pub(crate) enum WireframeProjection {
     /// at the cost of slight distortion on the polytopes that already read well
     /// under drop-w.
     WDepth,
+    /// 4D Schlegel diagram: central projection from a viewpoint just outside the
+    /// chosen boundary cell onto that cell's bounding 3-flat (Coxeter, *Regular
+    /// Polytopes*, ch. 13). The chosen cell becomes the diagram's outer boundary;
+    /// every other cell nests inside it. `cell_index` selects which of the
+    /// polytope's cells is the boundary, in the canonical [`Polytope4::topology`]
+    /// cell order; it is clamped to the polytope's cell count at resolve time.
+    ///
+    /// The variant carries only the index. The `cell_normal` / `cell_offset` /
+    /// `viewpoint_distance` scalars that [`rye_math::Projection::Schlegel`] needs
+    /// are resolved from the *selected polytope's* topology (cell centroids via
+    /// [`Polytope4::face_planes`], the CORRECT path, NOT the buggy dual-vertex
+    /// `cell{120,600}_face_planes`) and cached on [`Demo::schlegel_params`] at
+    /// cell-select time, never inside the per-frame upload. See
+    /// [`resolve_schlegel_params`] and [`Demo::resolved_wireframe_projection`].
+    Schlegel {
+        /// Index of the boundary cell in the polytope's canonical cell order.
+        cell_index: u32,
+    },
+    /// Conformal stereographic projection of the polytope from S³ (where its
+    /// unit-circumradius vertices live) to R³, casting away from a configurable
+    /// pole (default [`STEREOGRAPHIC_DEFAULT_POLE`], a cell-center direction; live
+    /// value is [`Demo::stereographic_pole`]). Angle-preserving, distance-
+    /// distorting: the cell facing the pole balloons to the outer boundary and the
+    /// opposite cell shrinks to the interior, the same nesting Schlegel shows but
+    /// with the round, angle-faithful look that pairs with spherical-space mode.
+    /// The `EuclideanR4` projection normalizes each vertex onto S³ first, so this
+    /// reads correctly for the demo's `BODY_SIZE`-scaled vertices.
+    Stereographic,
+    /// Drop-w projection paired with a demo-side CELL-level w-range cull (the
+    /// `wireframe_hyperslice` filter): the wireframe thins to the edges that
+    /// belong to a cell whose body-local w-range overlaps a slab around
+    /// `w_slice`. The cull is cell-level (not edge-level) so a kept edge agrees
+    /// with the cell-level active-edge coloring and the cross-section: a far-side
+    /// edge of a sliced cell stays because its cell is being cut, even though its
+    /// own endpoints sit outside the slab. The projection itself stays drop-w
+    /// ([`rye_math::Projection::Identity`]); the slicing is done by the cull in
+    /// the wireframe builder, not by the projection (a projection has already
+    /// discarded w and cannot honestly carry a keep/drop signal). Selecting this
+    /// mode turns the cull on; the slab thickness is the existing
+    /// [`Demo::wireframe_hyperslice_thickness`] control.
+    Hyperslice,
 }
+
+/// Resolved canonical (unit-circumradius) Schlegel parameters for one
+/// `(polytope, cell_index)` choice. Cached on [`Demo::schlegel_params`] so the
+/// O(V·D³) `LazyLock` cell-table fit behind [`Polytope4::face_planes`] runs once
+/// per cell selection rather than once per frame.
+///
+/// Stored in CANONICAL coordinates (the polytope's unit-circumradius topology):
+/// the per-frame [`Demo::resolved_wireframe_projection`] scales `cell_offset` and
+/// `viewpoint_distance` by the live [`Demo::effective_body_size`] and rotates
+/// `cell_normal` by the live `rot_state`. Caching canonical (not body-scaled)
+/// params keeps the cache valid across `surface scale` changes and is what lets
+/// the chosen cell stay the outer boundary as the polytope spins.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct SchlegelParams {
+    /// The polytope these params were resolved against. The cache is invalid if
+    /// the selected polytope changes (row edit, different first polychoron).
+    pub(crate) polytope: Polytope4,
+    /// The (already-clamped) boundary cell index.
+    pub(crate) cell_index: u32,
+    /// Outward unit normal of the chosen cell's hyperplane, in CANONICAL coords.
+    /// Per-frame rotated by `rot_state`; rotation preserves unit length.
+    pub(crate) cell_normal: glam::Vec4,
+    /// Signed plane offset in CANONICAL coords (the cell's inradius): the chosen
+    /// cell lies in `{x : dot(cell_normal, x) = cell_offset}`. Per-frame scaled by
+    /// `effective_body_size`.
+    pub(crate) cell_offset: f32,
+    /// Eye distance along `cell_normal` from the origin, in CANONICAL coords. The
+    /// chosen cell's farthest vertex along `+normal` plus a fixed margin, so the
+    /// eye sits just outside the cell for every polytope (a blanket `1.5 *
+    /// cell_offset` crowds the eye against the small-inradius 5-cell). Per-frame
+    /// scaled by `effective_body_size`.
+    pub(crate) viewpoint_distance: f32,
+}
+
+/// Additive eye clearance beyond the chosen cell's far edge, in canonical
+/// (unit-circumradius) units. Fixed and additive rather than a multiple of the
+/// cell offset so the absolute clearance does not collapse for small-inradius
+/// polytopes: the 5-cell's inradius is 0.25, where a `1.5 * cell_offset`
+/// viewpoint leaves the eye only 0.125 clear of the cell and the diagram folds
+/// to a near-degenerate sliver. 0.5 of the unit circumradius keeps the eye a
+/// comfortable, polytope-independent distance outside the boundary cell.
+const SCHLEGEL_EYE_MARGIN: f32 = 0.5;
+
+/// Resolve the canonical Schlegel parameters for the chosen `(polytope,
+/// cell_index)`. `cell_index` is clamped to `[0, cell_count - 1]` so an
+/// out-of-range index never panics or indexes out of bounds.
+///
+/// The cell normal and inradius come from [`Polytope4::face_planes`], which
+/// derives them from cell centroids via topology (Coxeter, *Regular Polytopes*,
+/// ch. 13: a regular polytope's cell centroid lies along the outward face normal
+/// at the inradius). This is the CORRECT path: the dual-vertex
+/// `cell{120,600}_face_planes` helpers in `rye_physics::euclidean_r4` are wrong
+/// for 96 of the 120/600-cell normals (the documented BUG) and are deliberately
+/// NOT used here.
+///
+/// `viewpoint_distance` is the chosen cell's farthest vertex-projection along
+/// `+cell_normal` plus [`SCHLEGEL_EYE_MARGIN`], placing the eye just outside the
+/// boundary cell for any polytope. The result is in canonical coordinates; the
+/// caller scales it by the live body size.
+pub(crate) fn resolve_schlegel_params(polytope: Polytope4, cell_index: u32) -> SchlegelParams {
+    let cell_count = polytope.cell_count() as u32;
+    // `cell_count >= 1` for every polytope, so `cell_count - 1` never underflows.
+    let clamped = cell_index.min(cell_count - 1);
+    let (normals, cell_offset) = polytope.face_planes();
+    let cell_normal = normals[clamped as usize];
+    // Farthest vertex-projection along the outward normal. For the chosen cell
+    // this is its own boundary plane (`= cell_offset`), but compute it over all
+    // vertices so the eye clearance is robust to any topology quirk rather than
+    // assuming the cell vertices are the extreme set.
+    let max_dot = polytope
+        .topology()
+        .vertices
+        .iter()
+        .map(|v| cell_normal.dot(*v))
+        .fold(f32::NEG_INFINITY, f32::max);
+    SchlegelParams {
+        polytope,
+        cell_index: clamped,
+        cell_normal,
+        cell_offset,
+        viewpoint_distance: max_dot + SCHLEGEL_EYE_MARGIN,
+    }
+}
+
+/// Resolve `projection` against the current Schlegel `subject` (the leading
+/// polychoron, or `None` for a row with no polytope), returning the projection
+/// to store plus the cache to attach.
+///
+/// For a `Schlegel` mode with a subject this returns a projection whose
+/// `cell_index` is the SAME clamped value the cache carries: [`resolve_schlegel_params`]
+/// clamps an out-of-range index (a row edit can shrink the subject from a
+/// 600-cell to a 5-cell while the mode still names `cell_index: 300`), and the
+/// returned projection is rewritten to that clamp so the enum, the cache, the UI
+/// cell-index stepper, and the console's "schlegel (cell N)" report never
+/// disagree about which cell is the diagram's boundary. Without the rewrite the
+/// projection rendered correctly (it reads the clamped cache) but the stepper
+/// showed an out-of-range index and the report named a cell the diagram did not
+/// use. Every other mode (and `Schlegel` with no subject) passes the projection
+/// through unchanged and clears the cache.
+///
+/// Pure (no `&mut self`) so the index-sync invariant is unit-testable without a
+/// GPU-backed [`Demo`]; [`Demo::resolve_schlegel_cache`] is the one caller.
+pub(crate) fn synced_schlegel_projection(
+    projection: WireframeProjection,
+    subject: Option<Polytope4>,
+) -> (WireframeProjection, Option<SchlegelParams>) {
+    match (projection, subject) {
+        (WireframeProjection::Schlegel { cell_index }, Some(polytope)) => {
+            let params = resolve_schlegel_params(polytope, cell_index);
+            let synced = WireframeProjection::Schlegel {
+                cell_index: params.cell_index,
+            };
+            (synced, Some(params))
+        }
+        (other, _) => (other, None),
+    }
+}
+
+/// A short educational annotation for the active projection / space-mode
+/// combination: a `title` for the callout window plus a `body` of one to three
+/// sentences explaining what the user is looking at. Surfaced via the
+/// `rye_egui::callout` primitive (see [`Demo::render_mode_annotation`]) so a
+/// reader can understand each non-default mode without opening the source.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ModeAnnotation {
+    /// Callout window title: the mode's short name.
+    pub(crate) title: &'static str,
+    /// One to three sentences. Composed from the projection's own explanation
+    /// plus, when spherical curvature is active, a curvature sentence and (for
+    /// the flat-cap overlap) a disambiguating note.
+    pub(crate) body: String,
+}
+
+/// The `space_blend` argument above this counts as "spherical curvature is on"
+/// for the annotation: any visible bow of the edges toward S³ warrants the
+/// curvature sentence. Matches the wireframe builder's own `blend <= 0.0` flat
+/// fast-path cutoff (the per-edge morph in the demo's `push_blended_edge`), so
+/// the curvature sentence appears for exactly the blend values that bow the
+/// edges. The wireframe-overlay-enabled gate is the caller's responsibility:
+/// `Demo::render_mode_annotation` passes `0.0` here while the overlay is off,
+/// since the bowed edges render only in that overlay, so this threshold is the
+/// last condition rather than the only one.
+const SPHERICAL_ANNOTATION_THRESHOLD: f32 = 0.0;
+
+/// Educational annotation for the active `(projection, space curvature, flat-cap)`
+/// combination, or `None` when the scene is in its plain default state (drop-w
+/// projection AND flat space): there is nothing non-obvious to explain, so no
+/// callout is shown. Every other combination returns `Some` with distinct,
+/// non-empty copy.
+///
+/// `flat_cap_drawn` is `true` when the rasterized cross-section caps are being
+/// drawn (`SurfaceMode::Raster`). It only affects the body text in the THREE-WAY
+/// overlap case (spherical curvature on, with a flat cap and/or Stereographic),
+/// where the cap stays a flat 3-flat slice while the edges bow onto S³; the note
+/// tells the user the flat cap is expected (a curved cross-section is future
+/// work) so a flat cap under curved edges does not read as a bug.
+///
+/// Pure (no `&Demo`) so the `(mode) -> copy` mapping is unit-testable without a
+/// GPU-backed [`Demo`]; [`Demo::render_mode_annotation`] is the one caller.
+///
+/// Projection explanations follow Coxeter, *Regular Polytopes*, ch. 13
+/// (Schlegel diagrams) and the standard conformal stereographic map
+/// `(x, y, z) / (1 - w)` (Wikipedia, "Stereographic projection").
+pub(crate) fn mode_annotation(
+    projection: WireframeProjection,
+    space_blend: f32,
+    flat_cap_drawn: bool,
+) -> Option<ModeAnnotation> {
+    let spherical = space_blend > SPHERICAL_ANNOTATION_THRESHOLD;
+
+    // Per-projection lead sentence. `None` for drop-w, the default projection:
+    // it has no distortion to explain, so a drop-w + flat scene shows nothing.
+    let (title, projection_body): (&'static str, Option<&str>) = match projection {
+        WireframeProjection::DropW => ("Drop-w", None),
+        WireframeProjection::WDepth => (
+            "W-depth perspective",
+            Some(
+                "4D pinhole perspective from a viewer down the w-axis: the +w face \
+                 projects to the outer shape and the -w face to the inner one, the \
+                 classic cube-within-a-cube view of the tesseract.",
+            ),
+        ),
+        WireframeProjection::Schlegel { .. } => (
+            "Schlegel diagram",
+            Some(
+                "Central projection from a viewpoint just outside one chosen cell \
+                 onto that cell's hyperplane (Coxeter, Regular Polytopes, ch. 13): \
+                 the chosen cell becomes the outer boundary and every other cell \
+                 nests inside it.",
+            ),
+        ),
+        WireframeProjection::Stereographic => (
+            "Stereographic projection",
+            Some(
+                "Conformal S^3 -> R^3 map, (x, y, z) / (1 - w): angles are preserved \
+                 but distances are not, so the polytope distorts globally and the \
+                 cell facing the +w pole balloons outward as its vertices approach \
+                 the pole.",
+            ),
+        ),
+        WireframeProjection::Hyperslice => (
+            "Hyperslice",
+            Some(
+                "Shows only the edges of cells the current 4D cut passes through: \
+                 an edge survives when a cell containing it has its w-range within \
+                 the thin slab around the w-slice, so the wireframe thins to the \
+                 cells being sliced.",
+            ),
+        ),
+    };
+
+    // The default scene (drop-w, flat space) has nothing to annotate.
+    let Some(projection_lead) = projection_body else {
+        if !spherical {
+            return None;
+        }
+        // Spherical curvature on but the projection is plain drop-w: the
+        // curvature is the only thing to explain, so the callout is titled for
+        // the space mode rather than the projection.
+        return Some(ModeAnnotation {
+            title: "Spherical space",
+            body: spherical_sentence(flat_cap_drawn, projection).to_string(),
+        });
+    };
+
+    let mut body = projection_lead.to_string();
+    if spherical {
+        body.push(' ');
+        body.push_str(spherical_sentence(flat_cap_drawn, projection));
+    }
+    Some(ModeAnnotation { title, body })
+}
+
+/// The `space_blend` value the annotation should describe, given the raw blend
+/// and whether the wireframe overlay is on. The flat-to-spherical edge morph
+/// lives entirely in the wireframe builder (`push_blended_edge`, reached only
+/// from `Demo::render_wireframe_overlay`), which the frame loop skips while the
+/// overlay is disabled. With the overlay off there is no bowed edge on screen,
+/// so the annotation must not claim curvature: report the blend as `0.0` so
+/// [`mode_annotation`] drops the spherical sentence (or the whole "Spherical
+/// space" callout, for plain drop-w). The projection annotation is unaffected
+/// because the rasterized section caps reproject through the same projection
+/// whether or not the wireframe overlay draws.
+///
+/// Split out so the "no curvature claim without a visible bow" invariant is
+/// unit-testable without a GPU-backed [`Demo`]; [`Demo::render_mode_annotation`]
+/// is the one caller.
+pub(crate) fn annotation_effective_blend(space_blend: f32, wireframe_enabled: bool) -> f32 {
+    if wireframe_enabled {
+        space_blend
+    } else {
+        0.0
+    }
+}
+
+/// The spherical-curvature sentence appended when `space_blend > 0`, plus the
+/// three-way-overlap note when a flat cross-section cap and/or Stereographic is
+/// also in play. The flat cap stays a flat 3-flat slice while the edges bow onto
+/// S^3; the note flags that as expected (curved cross-sections are future work)
+/// so the user does not read the flat cap under curved edges as a bug.
+fn spherical_sentence(flat_cap_drawn: bool, projection: WireframeProjection) -> &'static str {
+    let stereographic = matches!(projection, WireframeProjection::Stereographic);
+    if flat_cap_drawn || stereographic {
+        "Spherical space bows the edges onto S^3 great-circle arcs, so the \
+         polytope curves; the filled cross-section cap stays flat (a flat 3-flat \
+         slice), which is expected here -- a curved cross-section is not yet \
+         implemented."
+    } else {
+        "Spherical space bows the edges onto S^3 great-circle arcs, so the \
+         polytope curves rather than rendering as straight chords."
+    }
+}
+
+/// Default pole for the Stereographic wireframe projection: the unit
+/// direction `(1, 1, 1, 1)/2`, a cell-center direction of the 16-cell (and of
+/// the tesseract and 24-cell). Casting away from a cell center, rather than the
+/// `+w` axis, keeps an *axis-aligned* polytope's vertices off the pole: the
+/// 16-cell's vertices are the `±e_i` axes (Coxeter, *Regular Polytopes*, §8.2),
+/// and a cell centroid lies along the outward face normal between four such
+/// axes, so no 16-cell vertex sits on this pole and a pure `xw` rotation (which
+/// fixes `y, z`) can never sweep one onto it. That removes the common-case
+/// 16-cell pole flicker the `+w` pole exhibits.
+///
+/// Tradeoff, by 16-cell / tesseract duality: this direction *is* a tesseract
+/// vertex direction (the tesseract vertex `(½,½,½,½)`), so under this pole a
+/// tesseract presents a vertex toward the pole at rest, where the `+w` pole
+/// presented a cell. A single pole cannot avoid every polytope's vertices in a
+/// mixed row; this constant trades the tesseract's static look for the
+/// 16-cell's continuous-rotation robustness, and the pole stays configurable
+/// (see [`Demo::stereographic_pole`]). Written as the exact, exactly-unit f32
+/// literal `0.5` per lane so no runtime `normalize` is needed and the constant
+/// is bit-reproducible.
+pub(crate) const STEREOGRAPHIC_DEFAULT_POLE: glam::Vec4 = glam::Vec4::new(0.5, 0.5, 0.5, 0.5);
 
 impl WireframeProjection {
     /// Parse the console-arg spelling. Hyphens because the console grammar lexes on
-    /// whitespace and `drop-w` / `w-depth` read as single tokens.
+    /// whitespace and `drop-w` / `w-depth` read as single tokens. `schlegel` parses
+    /// to `cell_index = 0`; the console handler reads the trailing `<cell-index>`
+    /// token separately (the grammar carries it as its own positional arg).
     pub(crate) fn from_token(token: &str) -> Option<Self> {
         match token {
             "drop-w" => Some(WireframeProjection::DropW),
             "w-depth" => Some(WireframeProjection::WDepth),
+            "schlegel" => Some(WireframeProjection::Schlegel { cell_index: 0 }),
+            "stereographic" => Some(WireframeProjection::Stereographic),
+            "hyperslice" => Some(WireframeProjection::Hyperslice),
             _ => None,
         }
     }
 
-    /// Resolve to a [`rye_math::Projection<4>`]. The focal distance is hardcoded to
-    /// `2.0`, sized to comfortably exceed the unit-circumradius polytope's w-extent
-    /// after the demo's `BODY_SIZE` scaling, so the perspective denominator never
-    /// approaches zero in normal use.
+    /// Cycle order for the bare `wireframe perspective` console command and the
+    /// UI radio: drop-w -> w-depth -> schlegel -> stereographic -> hyperslice ->
+    /// drop-w. Schlegel cycles in at `cell_index = 0`; the cell-index stepper then
+    /// picks the boundary cell.
+    pub(crate) const ALL: [Self; 5] = [
+        WireframeProjection::DropW,
+        WireframeProjection::WDepth,
+        WireframeProjection::Schlegel { cell_index: 0 },
+        WireframeProjection::Stereographic,
+        WireframeProjection::Hyperslice,
+    ];
+
+    /// Display label for the egui projection radio.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            WireframeProjection::DropW => "Drop-w",
+            WireframeProjection::WDepth => "W-depth",
+            WireframeProjection::Schlegel { .. } => "Schlegel",
+            WireframeProjection::Stereographic => "Stereographic",
+            WireframeProjection::Hyperslice => "Hyperslice",
+        }
+    }
+
+    /// Whether two modes are the same VARIANT, ignoring the Schlegel cell index.
+    /// The radio compares modes by variant (a cell-index change must not deselect
+    /// the Schlegel button); `PartialEq` on the enum would treat
+    /// `Schlegel { cell_index: 1 }` as a different button than
+    /// `Schlegel { cell_index: 2 }`.
+    pub(crate) fn same_variant(self, other: Self) -> bool {
+        std::mem::discriminant(&self) == std::mem::discriminant(&other)
+    }
+
+    /// Context-free resolution to a [`rye_math::Projection<4>`]. Handles the modes
+    /// that need no polytope or rotor context:
+    /// - `DropW` -> `Identity` (drop-w),
+    /// - `WDepth` -> `Perspective4D { focal_distance: 2.0 }` (focal sized to clear
+    ///   the unit-circumradius polytope's `BODY_SIZE`-scaled w-extent so the
+    ///   denominator never nears zero),
+    /// - `Stereographic` -> `Stereographic { pole: STEREOGRAPHIC_DEFAULT_POLE }`
+    ///   (a cell-center pole, off every 16-cell vertex; see the constant). The
+    ///   live pole is [`Demo::stereographic_pole`], which
+    ///   [`Demo::resolved_wireframe_projection`] substitutes; this context-free
+    ///   resolution returns the default so a non-render caller still gets the
+    ///   documented pole.
+    /// - `Hyperslice` -> `Identity` (the projection stays drop-w; the demo-side
+    ///   `wireframe_hyperslice` filter does the slicing).
+    ///
+    /// `Schlegel` returns `Identity` here as a SAFE FALLBACK only: the real
+    /// Schlegel projection needs the selected polytope's cached
+    /// [`SchlegelParams`] plus the live `rot_state`, which the context-free enum
+    /// cannot supply. [`Demo::resolved_wireframe_projection`] is the per-frame
+    /// entry point that builds the actual `Schlegel` variant; the four render
+    /// sites call it, not this.
     pub(crate) fn to_projection(self) -> rye_math::Projection<4> {
         match self {
-            WireframeProjection::DropW => rye_math::Projection::Identity,
+            WireframeProjection::DropW | WireframeProjection::Hyperslice => {
+                rye_math::Projection::Identity
+            }
             WireframeProjection::WDepth => rye_math::Projection::Perspective4D {
                 focal_distance: 2.0,
             },
+            // Schlegel needs cached params + rotor (see doc above); fall back to
+            // drop-w until `Demo::resolved_wireframe_projection` resolves it.
+            WireframeProjection::Schlegel { .. } => rye_math::Projection::Identity,
+            WireframeProjection::Stereographic => rye_math::Projection::Stereographic {
+                pole: STEREOGRAPHIC_DEFAULT_POLE,
+            },
         }
     }
+}
+
+/// Whether the wireframe Hyperslice cull is active, given the standalone toggle
+/// and the selected projection mode. The cull runs when EITHER the
+/// [`Demo::wireframe_hyperslice`] toggle is on OR the projection is
+/// [`WireframeProjection::Hyperslice`] (which resolves to drop-w and lets the
+/// cull do the slicing). Both the wireframe builder (the cull's `continue`) and
+/// the Render-modal slab-width control gate on this same predicate, so the
+/// thickness stepper is reachable in exactly the cases where it has an effect:
+/// gating the control on the bare toggle alone left it greyed out under the
+/// Hyperslice projection even though the cull was running.
+pub(crate) fn hyperslice_cull_active(toggle: bool, projection: WireframeProjection) -> bool {
+    toggle || matches!(projection, WireframeProjection::Hyperslice)
 }
 
 /// How the parent-wireframe edges are colored. Orthogonal to the alpha-modulation
@@ -452,11 +968,20 @@ pub(crate) struct Demo {
     /// each moment. When `false`, every edge uses the same uniform dim alpha (the
     /// previous behavior).
     pub(crate) wireframe_nearest_active: bool,
-    /// Whether the cyan section-perimeter outlines render. Independent of the parent
-    /// wireframe edges; turning this off leaves the polytope's full edge graph visible
-    /// but hides the cap-boundary highlight, useful for inspecting the parent structure
-    /// without the slice's cyan trace competing for attention. On by default.
-    pub(crate) wireframe_perimeter: bool,
+    /// The honest cross-section layer: the drop-w slice 3-flat, NEVER reprojected
+    /// through [`Self::wireframe_projection`]. This is the same geometry the SDF
+    /// raymarch shows; the raster version renders it drop-w regardless of the
+    /// active projection so selecting Schlegel / stereographic never silently
+    /// distorts the slice the user reads as "the cross-section." On by default
+    /// (perimeter + a full-ish fill). See [`SectionLayer`].
+    pub(crate) cross_section: SectionLayer,
+    /// The projected-cap layer: the same slice reprojected through the active
+    /// [`Self::wireframe_projection`] (the `cap_vertex_projected_and_world` /
+    /// `perspective_scale_at_w` behavior), so the cap can sit on a Schlegel /
+    /// stereographic wireframe. Off by default; opt-in for inspecting the slice
+    /// in the wireframe's own projected frame. Overlaid in the same viewport as
+    /// [`Self::cross_section`]. See [`SectionLayer`].
+    pub(crate) projected_cap: SectionLayer,
     /// Base RGB for wireframe edges. Orthogonal to [`Self::wireframe_nearest_active`]:
     /// the color mode picks the hue, the nearest-active toggle then modulates alpha on
     /// top.
@@ -465,6 +990,51 @@ pub(crate) struct Demo {
     /// always uses drop-w (mathematically the inhabitant's view of the slice 3-flat);
     /// this toggle only affects the dim wireframe overlay on top.
     pub(crate) wireframe_projection: WireframeProjection,
+    /// Cached canonical Schlegel parameters for the current `(selected polytope,
+    /// cell_index)`. `Some` only while `wireframe_projection` is `Schlegel` and the
+    /// row has a polychoron to project; `None` otherwise. Resolved at cell-select
+    /// time via [`Demo::resolve_schlegel_cache`] (console + UI both call it), never
+    /// inside the per-frame upload: [`Polytope4::face_planes`] runs a `LazyLock`
+    /// O(V·D³) cell-table fit on first access that must not land on the hot path.
+    /// The per-frame [`Demo::resolved_wireframe_projection`] only rotates the
+    /// cached normal and scales the offsets.
+    pub(crate) schlegel_params: Option<SchlegelParams>,
+    /// Live pole for the Stereographic wireframe projection, the unit `Vec4` the
+    /// conformal map casts away from. Defaults to [`STEREOGRAPHIC_DEFAULT_POLE`]
+    /// (a cell-center direction, off every 16-cell vertex; see the constant for
+    /// why and the tesseract tradeoff). Kept as a field rather than baked into the
+    /// payload-free [`WireframeProjection::Stereographic`] variant so the enum
+    /// stays a plain marker across `ALL` / `from_token` / `same_variant` / the UI
+    /// radio; [`Self::resolved_wireframe_projection`] substitutes it per frame.
+    /// Console-settable via the `wireframe` command.
+    pub(crate) stereographic_pole: glam::Vec4,
+    /// Wireframe Hyperslice toggle. When `true`, the parent wireframe is culled
+    /// to only the edges belonging to a cell whose body-local 4D w-range
+    /// intersects a slab of width [`Self::wireframe_hyperslice_thickness`]
+    /// centered on `w_slice`, so the graph thins to "the edges of the cells the
+    /// current 4D cut passes through." Off by default; the demo's identity is the
+    /// full wireframe + cross-section composition. This is a CPU-side cell-level
+    /// filter in the wireframe builder (cell-level so it agrees with the
+    /// active-edge coloring and the cross-section), independent of (and
+    /// composable with) the SDF raymarch's own w-slice and the cyan section
+    /// perimeter; all three slice against the same `w_slice`.
+    pub(crate) wireframe_hyperslice: bool,
+    /// Full width of the wireframe Hyperslice slab (see
+    /// [`Self::wireframe_hyperslice`]). An edge survives iff a cell containing
+    /// both its endpoints has a w-range intersecting `[w_slice - t/2, w_slice +
+    /// t/2]`. Floored at [`crate::consts::HYPERSLICE_MIN_THICKNESS`] at the test
+    /// site so a 0 here degrades to "only edges of cells straddling `w_slice`
+    /// survive" rather than an exact-equality test that never fires. Default
+    /// [`crate::consts::HYPERSLICE_DEFAULT_THICKNESS`].
+    pub(crate) wireframe_hyperslice_thickness: f32,
+    /// Wireframe-edge geometry morph in `[0, 1]`: `0.0` draws straight chords
+    /// in R⁴ (flat, `EuclideanR4` lerp); `1.0` draws great-circle arcs on S³
+    /// (`SphericalS3Embedded` slerp); values between linearly blend the two
+    /// per tessellation sample. The polytope's unit-circumradius vertices
+    /// already lie on S³, so only the edge interiors move; endpoints are
+    /// shared. Set via the `space` console command. At exactly `0.0` the
+    /// wireframe takes a one-segment-per-edge fast path (no tessellation).
+    pub(crate) space_blend: f32,
     /// Pixel width of parent-wireframe edges. Tuneable via `wireframe width <N>`
     /// for thicker lines on screenshots. Default bumped from 1.2 px to 1.8 px
     /// after side-by-side comparison: 1.2 px was too fine to read clearly
@@ -493,14 +1063,6 @@ pub(crate) struct Demo {
     /// (0, 10] are accepted; the upper bound exists to keep the SDF
     /// marcher's bounded-w-slice assumption intact.
     pub(crate) surface_scale: f32,
-    /// Per-fragment alpha for the rasterized section-faces (filled cross-
-    /// section cell-caps). Default 1.0 (fully opaque); `surface alpha <N>`
-    /// lowers it so the parent wireframe shows through. Independent of
-    /// `wireframe_nearest_active` (which only modulates wireframe-edge
-    /// alpha, not the surface). Accepted range `(0, 1]`; the lower bound
-    /// is open since 0.0 would just hide the surface entirely (use
-    /// `surface off` for that).
-    pub(crate) surface_alpha: f32,
     /// `y = 0` hyperplane floor visibility (the gridded ground). On by
     /// default; toggled via the `floor` console command. Gated at the
     /// kernel via `u.params[0]` so the toggle is zero-cost: when off, the
@@ -514,10 +1076,14 @@ pub(crate) struct Demo {
     /// here instead. Per-body solid color + face-normal Lambert in the fragment shader.
     pub(crate) section_faces: rye_render::TriangleRasterNode,
     /// Translucent variant of [`Self::section_faces`] with depth-write
-    /// disabled. Used in place of `section_faces` when `surface_alpha`
-    /// drops below 1.0 so the parent wireframe can show through caps.
-    /// Same vertex/fragment shaders + blend state; the only delta is the
-    /// `DepthMode::ReadOnly` pipeline-bake.
+    /// disabled. Used in place of `section_faces` when a section layer's
+    /// `surface_alpha` drops below 1.0 so the parent wireframe (and any
+    /// layer drawn behind) can show through caps. Same vertex/fragment
+    /// shaders + blend state; the only delta is the `DepthMode::ReadOnly`
+    /// pipeline-bake. Both section layers (honest cross-section + projected
+    /// cap) route through this pair of nodes, picking opaque vs translucent
+    /// per layer alpha; each layer's pass is a self-contained submit, so the
+    /// two nodes are reused across the two layers within one frame.
     pub(crate) section_faces_translucent: rye_render::TriangleRasterNode,
     /// Antialiased point-disc rasterizer for vertex markers and cell-center sprites.
     /// Constructed once during demo setup; uploaded with the combined point mesh each
@@ -558,7 +1124,29 @@ pub(crate) struct Demo {
     /// the start of each invocation; capacity grows monotonically with the largest
     /// polychoron's vertex / triangle count seen so far.
     pub(crate) section_world_vertices_scratch: Vec<glam::Vec4>,
+    /// Combined-mesh scratch for the honest drop-w cross-section layer.
     pub(crate) section_faces_mesh_scratch: rye_shape::TriangleMesh<3>,
+    /// Combined-mesh scratch for the projected-cap layer. Separate from
+    /// [`Self::section_faces_mesh_scratch`] so both section layers can be built
+    /// in one pass over the row (the body-local 4D vertices are shared) without
+    /// either layer's mesh clobbering the other's reused allocation.
+    pub(crate) section_faces_projected_scratch: rye_shape::TriangleMesh<3>,
+    /// Per-vertex body-local projected points for the cap-fill near-pole clip,
+    /// reused across frames + bodies inside `build_section_layer_meshes` to avoid
+    /// a per-body allocation. Holds the pre-translate projected point of each
+    /// freshly-appended cap vertex so the triangle-granularity Stereographic drop
+    /// (drop a fill triangle when any of its three projected vertices is past the
+    /// clip radius) reuses the same `sample_in_radius` predicate the wireframe and
+    /// cap-perimeter outline use, keeping fill and outline culling in lockstep.
+    pub(crate) section_clip_projected_scratch: Vec<glam::Vec3>,
+    /// Reused buffer for per-frame body-uniform uploads (see
+    /// `upload_render_row_bodies`); kept to avoid a per-frame allocation on
+    /// the steady-state spin path.
+    pub(crate) body_uniform_scratch: Vec<BodyUniform>,
+    /// Reused great-circle sampling buffer for `push_blended_edge`; taken via
+    /// `mem::take` during the wireframe-overlay build and put back after, so the
+    /// curved-mode (`space_blend > 0`) path does not allocate per frame.
+    pub(crate) slerp_scratch: Vec<glam::Vec4>,
     /// Selects how the six regular convex 4-polytopes are rendered. Smooth-surface shapes
     /// (Clifford torus, duocylinder, etc.) ignore this and always render via the SDF since
     /// they have no polytope topology to section.
@@ -627,6 +1215,16 @@ pub(crate) struct Demo {
     /// overlays in the playground will instantiate additional `CalloutState`s
     /// the same way.
     pub(crate) example_callout: rye_egui::CalloutState,
+
+    /// Persistent state for the per-mode educational annotation callout: a short
+    /// floating explanation of the active projection / space mode, anchored to
+    /// the leading polychoron. Its text is the pure [`mode_annotation`] mapping
+    /// reprojected each frame; the callout only draws when that mapping returns
+    /// `Some` (a non-default projection or spherical curvature is active) AND
+    /// this flag is on. On by default so a first-time user who switches to
+    /// Schlegel / Stereographic / Hyperslice or turns up Curvature immediately
+    /// sees what the mode does; toggle via `View > Mode annotation`.
+    pub(crate) mode_annotation_open: rye_egui::CalloutState,
 
     /// Whether the top-right rotation-formula popup is rendered. Off by default; the
     /// formula is dense for newcomers; the expanded section has a checkbox to turn it on
@@ -798,8 +1396,13 @@ impl Demo {
     ///
     /// Smooth-surface shapes (Clifford torus, etc.) ignore the surface mode and always
     /// produce a live SDF body; they have no rasterizer path.
-    fn sdf_body_for_slot(&self, slot: usize, n: usize, rotor: Rotor4) -> BodyUniform {
-        let entry = &self.row[slot];
+    fn sdf_body_for_slot(
+        &self,
+        entry: &ShapeEntry,
+        slot: usize,
+        n: usize,
+        rotor: Rotor4,
+    ) -> BodyUniform {
         if !self.surface_mode.uses_sdf_for_polychora() && entry.shape.polytope4().is_some() {
             return BodyUniform::default();
         }
@@ -828,8 +1431,19 @@ impl Demo {
     /// WebGPU shader budget (Chrome crashed the tab on first attempt).
     /// The console `surface sdf` command and the UI radio gate on this
     /// to keep the demo crash-free.
+    ///
+    /// Tests the RENDERED row (see [`Self::render_row`]), not the stored
+    /// `self.row`: the SDF kernel only ever uploads what `write_all` /
+    /// `rebuild_bodies` emit, which in [`ViewMode::Single`] is the lone
+    /// `strip_subject`, independent of the multi-shape row. Gating on
+    /// `self.row` would both falsely block SDF on a light Single subject
+    /// (because a hidden row member is heavy) and, worse, falsely ALLOW it
+    /// for a heavy Single subject sitting over an all-light row, which would
+    /// hand the crash-prone 120/600-cell SDF straight to the kernel. This
+    /// matches the heavy-shape warning `render_single_body` already shows
+    /// against `strip_subject`.
     pub(crate) fn sdf_blocked_by_heavy_polychora(&self) -> bool {
-        row_blocks_sdf(&self.row)
+        row_blocks_sdf(self.render_row())
     }
 
     /// Effective `w` slider half-range after [`Self::surface_scale`]. The
@@ -842,27 +1456,136 @@ impl Demo {
         crate::consts::W_RANGE * self.surface_scale
     }
 
-    /// Drive every body in the row with the same rotor, lets the user directly compare
-    /// slice signatures under identical 4D motion.
-    pub(crate) fn write_all(&mut self, rotor: Rotor4) {
-        let n = self.row.len();
-        for slot in 0..n {
-            let body = self.sdf_body_for_slot(slot, n, rotor);
-            self.node.set_body(slot, body);
+    /// The slice of [`ShapeEntry`]s the scene renders this frame. In
+    /// [`ViewMode::Single`] this is exactly the `strip_subject`; otherwise the
+    /// full `row`. Every per-body render path (section faces, wireframe overlay,
+    /// points) and the SDF body upload (`write_all` / `rebuild_bodies`) reads
+    /// this, so Single mode draws one body without disturbing the user's row.
+    /// See [`render_row_entries`].
+    pub(crate) fn render_row(&self) -> &[ShapeEntry] {
+        render_row_entries(self.view_mode, &self.row, &self.strip_subject)
+    }
+
+    /// The polytope a Schlegel cell index refers to: the first polychoron in the
+    /// rendered row, the same "representative shape" convention the example
+    /// callout anchors to. A Schlegel cell index has no single meaning across a
+    /// row of different polytopes (a 5-cell has 5 cells, a 600-cell has 600), so
+    /// the diagram picks the leading polychoron and projects through its chosen
+    /// cell's frame. In [`ViewMode::Single`] the rendered row is exactly the
+    /// `strip_subject`, so the cell-index bound is that subject's cell count
+    /// (the unambiguous selection Schlegel needs).
+    pub(crate) fn schlegel_subject(&self) -> Option<Polytope4> {
+        self.render_row().iter().find_map(|e| e.shape.polytope4())
+    }
+
+    /// Resolve and cache the canonical Schlegel parameters for the current
+    /// projection mode + selected polytope. Call this at every cell-SELECT point
+    /// (console `wireframe perspective schlegel <n>`, the UI cell-index stepper,
+    /// switching the projection radio to Schlegel, and any row edit that changes
+    /// the leading polychoron) so the per-frame path never re-runs the
+    /// `LazyLock`-backed [`Polytope4::face_planes`] fit.
+    ///
+    /// Clears the cache (`None`) when the mode is not Schlegel or the row has no
+    /// polychoron to project. Idempotent: re-resolving the same `(polytope,
+    /// cell_index)` recomputes bit-identical params (the fit is deterministic), so
+    /// callers may invoke it unconditionally.
+    ///
+    /// When the leading polychoron has fewer cells than the carried
+    /// `cell_index` (a row edit can swap a 600-cell out for a 5-cell while the
+    /// mode stays `Schlegel { cell_index: 300 }`), [`resolve_schlegel_params`]
+    /// clamps the index for the cache. The clamped value is written back into
+    /// `wireframe_projection` so the enum, the cache, the UI cell-index stepper,
+    /// and the console's "schlegel (cell N)" report all name the same cell the
+    /// projection actually renders, rather than the stepper showing an
+    /// out-of-range index and the report lying about the boundary cell.
+    pub(crate) fn resolve_schlegel_cache(&mut self) {
+        let (projection, cache) =
+            synced_schlegel_projection(self.wireframe_projection, self.schlegel_subject());
+        self.wireframe_projection = projection;
+        self.schlegel_params = cache;
+    }
+
+    /// The live [`rye_math::Projection<4>`] for the wireframe overlay this frame.
+    /// For Schlegel it builds the engine projection from the cached canonical
+    /// [`SchlegelParams`]: the canonical normal is rotated by the current
+    /// `rot_state` (one rotor apply; rotation preserves unit length) so the chosen
+    /// cell stays the outer boundary as the body spins, and the canonical offset +
+    /// viewpoint distance are scaled by [`Self::effective_body_size`] to match the
+    /// body-scaled vertices the wireframe feeds the projection. No allocation, no
+    /// `face_planes` call: this is the hot-path-safe counterpart to
+    /// [`Self::resolve_schlegel_cache`]. Every other mode delegates to the
+    /// context-free [`WireframeProjection::to_projection`].
+    pub(crate) fn resolved_wireframe_projection(&self) -> Projection<4> {
+        match self.wireframe_projection {
+            WireframeProjection::Schlegel { .. } => match self.schlegel_params {
+                Some(p) => {
+                    let body_size = self.effective_body_size();
+                    Projection::Schlegel {
+                        cell_normal: self.rot_state.apply(p.cell_normal),
+                        cell_offset: p.cell_offset * body_size,
+                        viewpoint_distance: p.viewpoint_distance * body_size,
+                    }
+                }
+                // Unresolved (no polychoron in row): drop-w fallback. The cache is
+                // resolved at every select point, so this only fires for a row with
+                // no polytope, where the wireframe draws nothing anyway.
+                None => Projection::Identity,
+            },
+            // Substitute the live pole. The context-free `to_projection` returns
+            // the default pole; the per-frame path honors the configurable field.
+            WireframeProjection::Stereographic => Projection::Stereographic {
+                pole: self.stereographic_pole,
+            },
+            other => other.to_projection(),
         }
     }
 
-    /// Re-emit every body's uniform from the current row + rotor state. Called after row
-    /// mutations (add/remove/reorder), rotor changes during spin, and surface-mode changes
-    /// (any time the polychora switch between SDF-live and SDF-inert, which happens at
-    /// every transition involving SDF mode).
+    /// Whether the wireframe Hyperslice cull should run this frame. Single source
+    /// for both the cull's per-edge `continue` in `render_wireframe_overlay` and
+    /// the Render-modal slab-width enable-gate, so the thickness control is live
+    /// in exactly the frames the cull is. See [`hyperslice_cull_active`].
+    pub(crate) fn hyperslice_cull_active(&self) -> bool {
+        hyperslice_cull_active(self.wireframe_hyperslice, self.wireframe_projection)
+    }
+
+    /// Drive every body in the RENDERED row (see [`Self::render_row`]) with the
+    /// same rotor, letting the user directly compare slice signatures under
+    /// identical 4D motion. In [`ViewMode::Single`] the rendered row is the lone
+    /// `strip_subject`, so this uploads exactly one body and rewrites the active
+    /// `body_count` accordingly (via `set_bodies`, not slot-wise patching, so a
+    /// stale row of bodies from a previous mode can't keep rendering).
+    pub(crate) fn write_all(&mut self, rotor: Rotor4) {
+        self.upload_render_row_bodies(rotor);
+    }
+
+    /// Re-emit every rendered body's uniform from the current row + rotor state.
+    /// Called after row mutations (add/remove/reorder), rotor changes during
+    /// spin, view-mode changes (the rendered row swaps between the full row and
+    /// the single subject), and surface-mode changes (any time the polychora
+    /// switch between SDF-live and SDF-inert).
     pub(crate) fn rebuild_bodies(&mut self) {
-        let n = self.row.len();
-        let rotor = self.rot_state;
-        let bodies: Vec<BodyUniform> = (0..n)
-            .map(|slot| self.sdf_body_for_slot(slot, n, rotor))
-            .collect();
-        self.node.set_bodies(&bodies);
+        self.upload_render_row_bodies(self.rot_state);
+    }
+
+    /// Build each rendered body's SDF uniform from the current row + rotor and
+    /// upload them via `set_bodies`, which also sets the kernel's active
+    /// `body_count`. Shared by [`Self::write_all`] and [`Self::rebuild_bodies`].
+    ///
+    /// The uniforms are filled into `body_uniform_scratch`, taken out of `self`
+    /// for the duration so the build can borrow `&self` (for `render_row` and
+    /// `sdf_body_for_slot`) while writing an owned buffer, then put back. The
+    /// buffer keeps its capacity across frames, so the steady-state spin upload
+    /// does not allocate.
+    fn upload_render_row_bodies(&mut self, rotor: Rotor4) {
+        let mut scratch = std::mem::take(&mut self.body_uniform_scratch);
+        scratch.clear();
+        let n = self.render_row().len();
+        for slot in 0..n {
+            let entry = &self.render_row()[slot];
+            scratch.push(self.sdf_body_for_slot(entry, slot, n, rotor));
+        }
+        self.node.set_bodies(&scratch);
+        self.body_uniform_scratch = scratch;
     }
 
     /// Render a compact `exp(B · 0.30·t)` form for whichever mode drives the spin. `B`
@@ -904,6 +1627,12 @@ impl Demo {
         self.rot_state = Rotor4::IDENTITY;
         self.rot_time = 0.0;
         self.t_slider_max = T_SLIDER_INITIAL;
+        self.space_blend = 0.0;
+        // Restore the honest-slice default: the drop-w cross-section visible,
+        // the reprojected cap off, so a reset always returns to the "slice that
+        // never distorts under a projection change" baseline.
+        self.cross_section = SectionLayer::CROSS_SECTION_DEFAULT;
+        self.projected_cap = SectionLayer::PROJECTED_CAP_DEFAULT;
         self.draft.clear();
         self.write_all(Rotor4::IDENTITY);
     }
@@ -911,11 +1640,18 @@ impl Demo {
 
 #[cfg(test)]
 mod tests {
-    use super::{active_plane_angle, compose_active_rotor, row_blocks_sdf, BASE_ROTATION_RATE};
+    use super::{
+        active_plane_angle, annotation_effective_blend, compose_active_rotor,
+        hyperslice_cull_active, mode_annotation, render_row_entries, resolve_schlegel_params,
+        row_blocks_sdf, section_layer_projection, synced_schlegel_projection, SectionLayer,
+        ViewMode, WireframeProjection, BASE_ROTATION_RATE, STEREOGRAPHIC_DEFAULT_POLE,
+    };
     use crate::catalog::ShapeEntry;
-    use rye_math::{Bivector, Plane4, Rotor4};
+    use glam::Vec4;
+    use rye_math::{Bivector, Plane4, Projection, Rotor, Rotor4};
     use rye_physics::polytope::Polytope4;
     use rye_render::raymarch::RaymarchShape;
+    use std::collections::HashSet;
 
     fn entry(shape: RaymarchShape) -> ShapeEntry {
         ShapeEntry {
@@ -950,6 +1686,42 @@ mod tests {
         );
         // t = 0 collapses to the baseline even when active.
         assert_eq!(active_plane_angle(0.5, true, 0.0), 0.5);
+    }
+
+    #[test]
+    fn toggling_active_preserves_displayed_angle() {
+        // The Active-mode checkbox is decoupled from the live orientation:
+        // flipping `active` adds or removes the spin term `t * RATE`, and the
+        // cell re-solves `base` so the displayed angle is continuous across
+        // the toggle (no teleport). This pins that re-solve, which the UI
+        // performs inline as `base = displayed_before - spin(active_after)`.
+        let t = 7.5_f32;
+        let resolve = |base_old: f32, active_before: bool| {
+            let displayed_before = active_plane_angle(base_old, active_before, t);
+            let active_after = !active_before;
+            let spin_after = if active_after {
+                t * BASE_ROTATION_RATE
+            } else {
+                0.0
+            };
+            let base_new = displayed_before - spin_after;
+            // The new displayed angle must equal the pre-toggle one.
+            active_plane_angle(base_new, active_after, t)
+        };
+        // Switching ON: the inactive baseline must survive unchanged.
+        let base_off = 0.42_f32;
+        let displayed_off = active_plane_angle(base_off, false, t);
+        assert!(
+            (resolve(base_off, false) - displayed_off).abs() < 1e-6,
+            "toggle on changed the displayed angle"
+        );
+        // Switching OFF: the accumulated spin must freeze into the baseline.
+        let base_on = -1.1_f32;
+        let displayed_on = active_plane_angle(base_on, true, t);
+        assert!(
+            (resolve(base_on, true) - displayed_on).abs() < 1e-6,
+            "toggle off changed the displayed angle"
+        );
     }
 
     #[test]
@@ -1029,5 +1801,692 @@ mod tests {
         // A 600-cell does too.
         let with_600 = [entry(RaymarchShape::Polytope(Polytope4::Cell600))];
         assert!(row_blocks_sdf(&with_600));
+    }
+
+    /// A curvature value set while the wireframe overlay is OFF must not produce a
+    /// spherical annotation: the flat-to-spherical edge bow renders only in the
+    /// wireframe overlay, so with the overlay off there is no curved geometry on
+    /// screen and the callout would describe something the user cannot see. The
+    /// caller routes `space_blend` through [`annotation_effective_blend`], which
+    /// reports flat (`0.0`) while the overlay is off, so:
+    ///  - drop-w + curvature-but-overlay-off collapses to the default no-op
+    ///    (`None`), exactly as plain flat drop-w does; and
+    ///  - a non-default projection keeps its projection annotation (the caps
+    ///    reproject without the wireframe) but drops the spherical sentence.
+    ///
+    /// With the overlay on, the raw blend passes through unchanged.
+    #[test]
+    fn curvature_annotation_requires_visible_wireframe() {
+        // Overlay off: the gate reports flat regardless of the raw blend.
+        assert_eq!(annotation_effective_blend(1.0, false), 0.0);
+        assert_eq!(annotation_effective_blend(0.5, false), 0.0);
+        // Overlay on: the raw blend passes through untouched.
+        assert_eq!(annotation_effective_blend(1.0, true), 1.0);
+        assert_eq!(annotation_effective_blend(0.0, true), 0.0);
+
+        // Drop-w with curvature set but the overlay off is indistinguishable from
+        // the plain flat default scene: no annotation.
+        let blend_off = annotation_effective_blend(1.0, false);
+        assert!(
+            mode_annotation(WireframeProjection::DropW, blend_off, false).is_none(),
+            "spherical-over-drop-w must not annotate while the wireframe is off"
+        );
+        // Turning the overlay on resurrects the spherical-space callout.
+        let blend_on = annotation_effective_blend(1.0, true);
+        assert!(
+            mode_annotation(WireframeProjection::DropW, blend_on, false).is_some(),
+            "spherical-over-drop-w must annotate once the wireframe is on"
+        );
+
+        // A non-default projection keeps its projection annotation with the
+        // overlay off, but the body must NOT mention the S^3 edge bow, since no
+        // bowed edge is drawn. The projection lead (caps reproject regardless) is
+        // still present.
+        let stereo_off = mode_annotation(WireframeProjection::Stereographic, blend_off, false)
+            .expect("stereographic still annotates its projection with the overlay off");
+        assert!(
+            !stereo_off.body.contains("S^3 great-circle arcs"),
+            "no spherical sentence without a visible wireframe bow: {}",
+            stereo_off.body
+        );
+        assert!(
+            stereo_off.body.contains("Conformal S^3 -> R^3"),
+            "the stereographic projection lead must still be present: {}",
+            stereo_off.body
+        );
+    }
+
+    /// The educational-annotation mapping pins three invariants the UI relies on:
+    /// (1) the plain default scene (drop-w projection, flat space) yields no
+    /// annotation, so nothing floats over an undistorted view; (2) every
+    /// non-default projection and the spherical-space-over-drop-w case yields a
+    /// non-empty body; and (3) the bodies are pairwise DISTINCT across the
+    /// non-default modes, so each mode reads as its own explanation rather than a
+    /// shared placeholder. Pins the `(mode) -> copy` mapping, not the egui render.
+    #[test]
+    fn annotation_text_present_per_mode() {
+        // Default scene: drop-w + flat space + (cap state irrelevant) -> nothing.
+        assert!(
+            mode_annotation(WireframeProjection::DropW, 0.0, true).is_none(),
+            "drop-w + flat space must not annotate the default view"
+        );
+        assert!(
+            mode_annotation(WireframeProjection::DropW, 0.0, false).is_none(),
+            "cap state must not resurrect the default-scene annotation"
+        );
+
+        // Each distinct mode case the UI can surface. `space_blend` and the
+        // flat-cap flag are chosen to exercise both the plain projection body and
+        // the spherical/overlap branches.
+        let cases: &[(WireframeProjection, f32, bool)] = &[
+            (WireframeProjection::WDepth, 0.0, true),
+            (WireframeProjection::Schlegel { cell_index: 0 }, 0.0, true),
+            (WireframeProjection::Stereographic, 0.0, true),
+            (WireframeProjection::Hyperslice, 0.0, true),
+            // Spherical curvature over plain drop-w: the space mode is the only
+            // thing to explain, so this is its own distinct annotation.
+            (WireframeProjection::DropW, 1.0, true),
+        ];
+
+        let mut bodies = HashSet::new();
+        for &(projection, blend, flat_cap) in cases {
+            let annotation = mode_annotation(projection, blend, flat_cap)
+                .unwrap_or_else(|| panic!("{projection:?} blend={blend} must annotate"));
+            assert!(
+                !annotation.title.is_empty(),
+                "{projection:?} blend={blend}: title must be non-empty"
+            );
+            assert!(
+                !annotation.body.is_empty(),
+                "{projection:?} blend={blend}: body must be non-empty"
+            );
+            assert!(
+                bodies.insert(annotation.body.clone()),
+                "{projection:?} blend={blend}: body duplicates another mode's copy"
+            );
+        }
+
+        // The three-way overlap note is conditional: spherical curvature with a
+        // flat cap (or Stereographic) must mention the flat cross-section, and the
+        // no-flat-cap / non-stereographic case must NOT, so the user is only warned
+        // about the flat cap when one is actually drawn under curved edges.
+        let with_cap = mode_annotation(WireframeProjection::WDepth, 1.0, true)
+            .expect("wdepth + spherical annotates");
+        assert!(
+            with_cap.body.contains("cross-section cap stays flat"),
+            "spherical + flat cap must flag the flat cross-section: {}",
+            with_cap.body
+        );
+        let no_cap = mode_annotation(WireframeProjection::WDepth, 1.0, false)
+            .expect("wdepth + spherical annotates");
+        assert!(
+            !no_cap.body.contains("cross-section cap stays flat"),
+            "spherical without a flat cap must not mention the cap: {}",
+            no_cap.body
+        );
+        // Stereographic forces the overlap note even with no raster cap, because
+        // its own R^3 image is a flat conformal map under the curved edges.
+        let stereo_no_cap = mode_annotation(WireframeProjection::Stereographic, 1.0, false)
+            .expect("stereographic + spherical annotates");
+        assert!(
+            stereo_no_cap.body.contains("cross-section cap stays flat"),
+            "stereographic + spherical must flag the flat slice even without a cap: {}",
+            stereo_no_cap.body
+        );
+    }
+
+    /// The SDF crash-safety gate keys off the RENDERED row, not the stored
+    /// `self.row`. `Demo::sdf_blocked_by_heavy_polychora` is
+    /// `row_blocks_sdf(self.render_row())`; in [`ViewMode::Single`] the rendered
+    /// row is exactly the `strip_subject`, so the gate must follow the subject
+    /// and ignore the multi-shape row entirely. Both failure directions matter:
+    /// a heavy subject over a light row must still BLOCK (else the 120/600-cell
+    /// SDF reaches the kernel and crashes the tab), and a light subject under a
+    /// heavy row must NOT block (else SDF is needlessly disabled on a safe body).
+    /// This pins the same `render_row()`-keyed contract the method now uses,
+    /// which the row-only `row_blocks_sdf_only_for_heavy_polychora` test could
+    /// not catch.
+    #[test]
+    fn sdf_gate_follows_single_subject_not_row() {
+        let heavy = entry(RaymarchShape::Polytope(Polytope4::Cell600));
+        let light = entry(RaymarchShape::Polytope(Polytope4::Tesseract));
+
+        // Heavy subject, all-light row: blocked, because Single renders the
+        // 600-cell. Reading the row alone here would WRONGLY allow SDF.
+        let light_row = [light, entry(RaymarchShape::Polytope(Polytope4::Cell24))];
+        assert!(
+            row_blocks_sdf(render_row_entries(ViewMode::Single, &light_row, &heavy)),
+            "heavy Single subject blocks SDF even over an all-light row",
+        );
+        // Light subject, heavy row: NOT blocked, because Single renders the
+        // tesseract. Reading the row alone here would WRONGLY block SDF.
+        let heavy_row = [entry(RaymarchShape::Polytope(Polytope4::Cell120))];
+        assert!(
+            !row_blocks_sdf(render_row_entries(ViewMode::Single, &heavy_row, &light)),
+            "light Single subject keeps SDF available even over a heavy row",
+        );
+        // Shapes mode keeps the row-wide gate: the same heavy row blocks SDF
+        // regardless of the (unrendered, in this mode) subject.
+        assert!(
+            row_blocks_sdf(render_row_entries(ViewMode::Shapes, &heavy_row, &light)),
+            "Shapes mode blocks SDF on a heavy row member",
+        );
+    }
+
+    /// Every token in the five-mode set parses to its `WireframeProjection`
+    /// variant, and the context-free `to_projection` produces the matching engine
+    /// `Projection<4>` variant or the documented `Identity` fallback. The fallback
+    /// modes are `Hyperslice` (a demo-side w-cull, drop-w projection) and
+    /// `Schlegel` (resolved Demo-side from the cached face-plane params + rotor,
+    /// which the context-free enum cannot supply). `ALL` is the single cycle
+    /// source the bare console command and the UI radio share, so a variant added
+    /// to the enum but omitted from `ALL`/`from_token` fails here.
+    #[test]
+    fn wireframe_projection_from_token_round_trips() {
+        // Pin the count so an enum addition that skips `ALL` is loud.
+        assert_eq!(
+            WireframeProjection::ALL.len(),
+            5,
+            "ALL must list every selectable projection mode"
+        );
+        for mode in WireframeProjection::ALL {
+            let token = match mode {
+                WireframeProjection::DropW => "drop-w",
+                WireframeProjection::WDepth => "w-depth",
+                WireframeProjection::Schlegel { .. } => "schlegel",
+                WireframeProjection::Stereographic => "stereographic",
+                WireframeProjection::Hyperslice => "hyperslice",
+            };
+            assert_eq!(
+                WireframeProjection::from_token(token),
+                Some(mode),
+                "token `{token}` must parse back to {mode:?}"
+            );
+        }
+        // Context-free engine projections per the documented contract.
+        assert_eq!(
+            WireframeProjection::DropW.to_projection(),
+            Projection::Identity
+        );
+        assert_eq!(
+            WireframeProjection::WDepth.to_projection(),
+            Projection::Perspective4D {
+                focal_distance: 2.0
+            }
+        );
+        assert_eq!(
+            WireframeProjection::Stereographic.to_projection(),
+            Projection::Stereographic {
+                pole: STEREOGRAPHIC_DEFAULT_POLE
+            }
+        );
+        // Hyperslice: drop-w projection, the cull does the slicing.
+        assert_eq!(
+            WireframeProjection::Hyperslice.to_projection(),
+            Projection::Identity
+        );
+        // Schlegel context-free fallback is Identity; the real Schlegel comes
+        // from `Demo::resolved_wireframe_projection` with the cached params.
+        assert_eq!(
+            WireframeProjection::Schlegel { cell_index: 0 }.to_projection(),
+            Projection::Identity
+        );
+    }
+
+    /// The default Stereographic pole is the unit direction `(1, 1, 1, 1)/2` and
+    /// equals (to f32 epsilon) the normalized centroid of a 16-cell cell, tying
+    /// the literal constant to the polytope's topology rather than a bare number.
+    /// If the cell-centroid derivation ever drifts from the recorded literal this
+    /// fails loudly.
+    #[test]
+    fn stereographic_default_pole_is_unit_cell_center() {
+        // Exactly unit by construction: 4 * 0.5^2 = 1.
+        assert_eq!(
+            STEREOGRAPHIC_DEFAULT_POLE.length_squared(),
+            1.0,
+            "default pole must be exactly unit"
+        );
+        // The 16-cell cell centroids are the (±½, ±½, ±½, ±½) directions; the
+        // all-positive one, normalized, is the default pole. `cell_centers`
+        // returns centroids at the inradius, so normalize before comparing.
+        let centers = Polytope4::Cell16.cell_centers();
+        let matches_a_centroid = centers
+            .iter()
+            .any(|c| (c.normalize() - STEREOGRAPHIC_DEFAULT_POLE).length() < 1e-6);
+        assert!(
+            matches_a_centroid,
+            "default pole must be a normalized 16-cell cell centroid"
+        );
+    }
+
+    /// No 16-cell vertex sits on the default pole: every vertex direction is
+    /// strictly outside the pole-clamp band (`dot(v, pole) < 1 - eps`), so the
+    /// stereographic denominator never reaches the clamp for an axis-aligned
+    /// 16-cell at rest. Also pins the common-case sweep: a pure `xw` rotation
+    /// leaves each vertex's `y, z` fixed, and the pole has `y = z = ½`, so no
+    /// 16-cell vertex (whose `y, z` are each `0` or `±1`) can ever rotate onto it.
+    #[test]
+    fn stereographic_default_pole_is_never_a_16cell_vertex() {
+        let eps = rye_math::STEREOGRAPHIC_POLE_EPSILON;
+        let pole = STEREOGRAPHIC_DEFAULT_POLE;
+        for v in Polytope4::Cell16.topology().vertices {
+            // Vertices are unit `±e_i`; dot with the pole is exactly ±½.
+            let d = v.normalize().dot(pole);
+            assert!(
+                d < 1.0 - eps,
+                "16-cell vertex {v:?} has dot {d} with the default pole, inside \
+                 the pole-clamp band"
+            );
+        }
+        // The common-case xw sweep: rotate +x through the xw plane and confirm
+        // the pole's fixed y = z = ½ keeps dot bounded away from 1 the whole way.
+        for step in 0..360 {
+            let theta = (step as f32).to_radians();
+            // xw rotation of +x: (cos, 0, 0, sin). y and z stay 0.
+            let rotated = Vec4::new(theta.cos(), 0.0, 0.0, theta.sin());
+            let d = rotated.dot(pole);
+            // Max over the sweep is cos*½ + sin*½ <= sqrt(2)/2 ~ 0.707 < 1 - eps.
+            assert!(
+                d < 1.0 - eps,
+                "xw-rotated +x at {step} deg has dot {d}, inside the clamp band"
+            );
+        }
+    }
+
+    /// The Hyperslice cull runs when EITHER the standalone toggle is on OR the
+    /// projection mode is `Hyperslice`. This is the single predicate the wireframe
+    /// builder's per-edge `continue` and the Render-modal slab-width enable-gate
+    /// both consume, so the thickness control is reachable in exactly the frames
+    /// the cull is active. The bug this pins: the projection-mode arm must turn the
+    /// cull on by itself, with EVERY other projection leaving it off unless the
+    /// toggle is set.
+    #[test]
+    fn hyperslice_cull_active_fires_for_toggle_or_projection() {
+        // Projection mode alone activates the cull, toggle off.
+        assert!(hyperslice_cull_active(
+            false,
+            WireframeProjection::Hyperslice
+        ));
+        // Toggle alone activates it under any other projection.
+        for mode in WireframeProjection::ALL {
+            assert!(
+                hyperslice_cull_active(true, mode),
+                "toggle on must activate the cull under {mode:?}"
+            );
+        }
+        // Neither set: only the Hyperslice projection mode keeps it on.
+        for mode in WireframeProjection::ALL {
+            let expected = matches!(mode, WireframeProjection::Hyperslice);
+            assert_eq!(
+                hyperslice_cull_active(false, mode),
+                expected,
+                "with the toggle off, only the Hyperslice projection activates the cull ({mode:?})"
+            );
+        }
+    }
+
+    /// The Schlegel `cell_normal` `resolve_schlegel_params` feeds the projection is
+    /// the topology-derived `Polytope4::face_planes` direction, NOT the buggy
+    /// dual-vertex `cell{120,600}_face_planes`. For the 600-cell the dual helper
+    /// returns the 120-cell's 120 vertices as "face normals", which are wrong for
+    /// the 96 golden-ratio cell orbits. Pin that the resolved normal (a) equals the
+    /// `face_planes` direction exactly and (b) is, for at least one cell, more than
+    /// 1e-3 from EVERY dual normal: the only way that holds is if the dual path is
+    /// not the source.
+    #[test]
+    fn schlegel_params_from_face_planes_not_dual() {
+        use rye_physics::euclidean_r4::cell600_face_planes;
+        let polytope = Polytope4::Cell600;
+        let (topo_normals, _) = polytope.face_planes();
+        let (dual_normals, _) = cell600_face_planes();
+        // Find a cell whose topology normal is far from every dual normal. The 96
+        // golden-ratio orbits guarantee at least one exists; the dual set has only
+        // 120 entries for a 600-faced polytope, so most topology faces have no dual
+        // counterpart at all.
+        let divergent = (0..topo_normals.len() as u32).find(|&i| {
+            let n = topo_normals[i as usize];
+            dual_normals
+                .iter()
+                .all(|d| (n - *d).length() > 1e-3 && (n + *d).length() > 1e-3)
+        });
+        let cell_index = divergent.expect(
+            "the 600-cell must have a golden-ratio face that diverges from the dual-vertex set",
+        );
+        let params = resolve_schlegel_params(polytope, cell_index);
+        // (a) The resolved normal is exactly the topology face-plane direction.
+        assert_eq!(params.cell_normal, topo_normals[cell_index as usize]);
+        // (b) It is far from every dual normal (the buggy path is not the source).
+        for d in &dual_normals {
+            let n = params.cell_normal;
+            assert!(
+                (n - *d).length() > 1e-3 && (n + *d).length() > 1e-3,
+                "resolved Schlegel normal must not coincide with any dual-vertex normal"
+            );
+        }
+    }
+
+    /// An out-of-range `cell_index` clamps to `[0, cell_count - 1]`: it never
+    /// panics, never indexes the face-plane slice out of bounds, and resolves to
+    /// the last cell rather than wrapping or saturating past the end.
+    #[test]
+    fn schlegel_cell_index_clamped_to_cell_count() {
+        let polytope = Polytope4::Pentatope; // 5 cells.
+        let last = polytope.cell_count() as u32 - 1;
+        // Way past the end clamps to the last cell, no panic.
+        let params = resolve_schlegel_params(polytope, 9999);
+        assert_eq!(params.cell_index, last);
+        // The clamped resolution equals an explicit last-cell request.
+        let at_last = resolve_schlegel_params(polytope, last);
+        assert_eq!(params, at_last);
+    }
+
+    /// Resolving a Schlegel selection whose `cell_index` overruns the leading
+    /// polytope's cell count writes the CLAMPED index back into the projection,
+    /// so the carried `WireframeProjection::Schlegel { cell_index }` names the
+    /// exact cell the cache (and therefore the rendered diagram) uses. This is
+    /// the row-shrink desync the cache-clamp alone left open: a 600-cell ->
+    /// 5-cell row edit clamps the cache to cell 4 but, before the writeback, left
+    /// the enum (and thus the UI stepper + console "schlegel (cell N)" report)
+    /// naming cell 300. Pin that the returned projection's index equals the
+    /// cache's index and is in range, and that re-resolving is a fixed point.
+    #[test]
+    fn schlegel_resolve_syncs_carried_index_to_clamp() {
+        let polytope = Polytope4::Pentatope; // 5 cells; indices 0..=4.
+        let last = polytope.cell_count() as u32 - 1;
+        let overrun = WireframeProjection::Schlegel { cell_index: 300 };
+        let (projection, cache) = synced_schlegel_projection(overrun, Some(polytope));
+        let cache = cache.expect("a Schlegel mode with a subject must produce a cache");
+        // The carried index now equals the cache's clamped index (no desync).
+        match projection {
+            WireframeProjection::Schlegel { cell_index } => {
+                assert_eq!(
+                    cell_index, cache.cell_index,
+                    "carried index must match cache"
+                );
+                assert_eq!(cell_index, last, "overrun must clamp to the last cell");
+            }
+            other => panic!("Schlegel input must stay Schlegel, got {other:?}"),
+        }
+        // Idempotent: feeding the synced projection back yields the same index.
+        let (again, _) = synced_schlegel_projection(projection, Some(polytope));
+        assert_eq!(again, projection, "re-resolve must be a fixed point");
+    }
+
+    /// A non-Schlegel mode passes through unchanged and clears the cache, and a
+    /// Schlegel mode with no polychoron in the row (`subject == None`) keeps its
+    /// carried index verbatim (no polytope to clamp against) with a `None` cache.
+    /// Pins that the index-sync only fires where a subject can actually clamp it.
+    #[test]
+    fn synced_schlegel_passes_through_non_schlegel_and_subjectless() {
+        // Non-Schlegel: unchanged projection, no cache.
+        let (proj, cache) =
+            synced_schlegel_projection(WireframeProjection::Stereographic, Some(Polytope4::Cell24));
+        assert_eq!(proj, WireframeProjection::Stereographic);
+        assert!(cache.is_none(), "non-Schlegel mode must clear the cache");
+        // Schlegel with no subject: index untouched, no cache (the wireframe
+        // draws nothing for an empty / non-polychoral row anyway).
+        let schlegel = WireframeProjection::Schlegel { cell_index: 7 };
+        let (proj, cache) = synced_schlegel_projection(schlegel, None);
+        assert_eq!(proj, schlegel, "no subject means no clamp, index stays put");
+        assert!(cache.is_none(), "no subject means no cache");
+    }
+
+    /// Resolving the canonical params for a fixed `(polytope, cell_index)` twice
+    /// yields BIT-identical f32 (not merely approximately equal). The face-plane
+    /// fit is deterministic, so the Schlegel cache can be rebuilt on any select
+    /// without introducing frame-to-frame jitter in the projection.
+    #[test]
+    fn schlegel_resolution_is_bit_deterministic() {
+        for polytope in Polytope4::ALL {
+            let cell_index = (polytope.cell_count() / 2) as u32;
+            let a = resolve_schlegel_params(polytope, cell_index);
+            let b = resolve_schlegel_params(polytope, cell_index);
+            assert_eq!(a.cell_normal, b.cell_normal, "{polytope:?} normal");
+            assert_eq!(a.cell_offset, b.cell_offset, "{polytope:?} offset");
+            assert_eq!(
+                a.viewpoint_distance, b.viewpoint_distance,
+                "{polytope:?} viewpoint"
+            );
+        }
+    }
+
+    /// With a non-identity `rot_state`, the effective Schlegel boundary normal is
+    /// the canonical normal rotated by that same rotor: `rot_state.apply(canonical)`.
+    /// This is the determinism hazard the plan flags. `face_planes` returns
+    /// CANONICAL unrotated normals, but the wireframe vertices are `rot_state`-
+    /// rotated before projection, so the chosen cell only stays the outer boundary
+    /// if its normal rotates with the body. Verified at the math level (the rotor
+    /// apply) since `Demo::resolved_wireframe_projection` needs a GPU-backed `Demo`.
+    #[test]
+    fn schlegel_normal_rotates_with_body() {
+        let polytope = Polytope4::Tesseract;
+        let cell_index = 0;
+        let params = resolve_schlegel_params(polytope, cell_index);
+        // A non-trivial xw rotation. The canonical normal must not already be the
+        // rotated one, else the test proves nothing.
+        let rot = (Plane4::Xw.unit_bivector() * 0.7).exp().normalize();
+        let rotated = rot.apply(params.cell_normal);
+        assert!(
+            (rotated - params.cell_normal).length() > 1e-3,
+            "rotation must actually move the normal for this test to bite"
+        );
+        // Rotation preserves unit length, so the rotated normal is still a valid
+        // outward unit normal for the engine `Projection::Schlegel`.
+        assert!((rotated.length() - 1.0).abs() < 1e-5);
+        // And it equals the body's own rotation of every chosen-cell vertex's
+        // direction: a chosen-cell vertex `v` has `dot(canonical_normal, v) =
+        // cell_offset`; after rotating both, `dot(rotated_normal, rot.apply(v))`
+        // must still equal `cell_offset` (the cell stays on its hyperplane).
+        let topo = polytope.topology();
+        let cell = topo.cells[cell_index as usize];
+        for &vi in cell {
+            let v = topo.vertices[vi as usize];
+            let lhs = rotated.dot(rot.apply(v));
+            assert!(
+                (lhs - params.cell_offset).abs() < 1e-4,
+                "rotated cell vertex must stay on the rotated boundary hyperplane: {lhs} vs {}",
+                params.cell_offset
+            );
+        }
+    }
+
+    /// In [`ViewMode::Single`] the rendered row is EXACTLY the `strip_subject`,
+    /// not the multi-shape row. Every per-body render path (wireframe overlay,
+    /// section faces, points) and the SDF body upload iterate the slice
+    /// `render_row_entries` returns, so this pins that those passes build
+    /// geometry for the single subject alone, independent of how many shapes the
+    /// row holds. Shapes / Filmstrip keep returning the full row.
+    #[test]
+    fn single_mode_renders_one_subject() {
+        let subject = entry(RaymarchShape::Polytope(Polytope4::Cell600));
+        let row = [
+            entry(RaymarchShape::Polytope(Polytope4::Tesseract)),
+            entry(RaymarchShape::Polytope(Polytope4::Cell24)),
+            entry(RaymarchShape::Polytope(Polytope4::Pentatope)),
+        ];
+        // Single: exactly one body, and it is the subject (not any row member).
+        let single = render_row_entries(ViewMode::Single, &row, &subject);
+        assert_eq!(single.len(), 1, "Single renders exactly one body");
+        assert_eq!(single[0], subject, "the single body is the strip_subject");
+        // The subject is deliberately absent from the row, so a length-1 result
+        // alone cannot accidentally pass by aliasing a row entry.
+        assert!(
+            !row.contains(&subject),
+            "test setup: subject must differ from every row entry",
+        );
+        // Shapes / Filmstrip render the whole row verbatim (same pointer + len).
+        for mode in [ViewMode::Shapes, ViewMode::Filmstrip] {
+            let full = render_row_entries(mode, &row, &subject);
+            assert_eq!(full, &row[..], "{mode:?} renders the full row");
+        }
+    }
+
+    /// The Schlegel cell-index upper bound in Single mode is the
+    /// `strip_subject`'s cell count, NOT any row member's. The bound is derived
+    /// from the leading polychoron of the rendered row (the same path
+    /// `Demo::schlegel_subject` walks: `render_row().find_map(polytope4)`), so in
+    /// Single mode it must resolve to the subject's polytope and therefore its
+    /// `cell_count()`. This is the unambiguous single-polytope selection a
+    /// boundary-cell index needs (a 5-cell has 5 cells, a 600-cell has 600), and
+    /// the whole reason Single mode unblocks the Schlegel cell-index control.
+    #[test]
+    fn single_mode_schlegel_cell_bound_from_subject() {
+        let subject = entry(RaymarchShape::Polytope(Polytope4::Cell600));
+        // A row whose leading polychoron has a DIFFERENT cell count, so reading
+        // the row instead of the subject would give the wrong bound.
+        let row = [
+            entry(RaymarchShape::Polytope(Polytope4::Pentatope)), // 5 cells
+            entry(RaymarchShape::Polytope(Polytope4::Cell24)),
+        ];
+        // Mirror `Demo::schlegel_subject`: first polychoron of the rendered row.
+        let subject_poly = render_row_entries(ViewMode::Single, &row, &subject)
+            .iter()
+            .find_map(|e| e.shape.polytope4())
+            .expect("the single subject is a polychoron");
+        assert_eq!(subject_poly, Polytope4::Cell600);
+        assert_eq!(
+            subject_poly.cell_count(),
+            Polytope4::Cell600.cell_count(),
+            "the cell-index bound is the subject's cell count (600), not the row's leading 5",
+        );
+        // And in Shapes mode the same walk yields the ROW's leading polychoron
+        // (the 5-cell), confirming the two modes resolve different subjects.
+        let row_poly = render_row_entries(ViewMode::Shapes, &row, &subject)
+            .iter()
+            .find_map(|e| e.shape.polytope4())
+            .expect("the row has a polychoron");
+        assert_eq!(row_poly, Polytope4::Pentatope);
+        assert_ne!(
+            subject_poly.cell_count(),
+            row_poly.cell_count(),
+            "test setup: subject and row-leader must differ in cell count",
+        );
+    }
+
+    /// Each `ViewMode` variant round-trips through the tab's stage-then-apply
+    /// shape: staging a different value into `pending_view_mode` and applying it
+    /// lands `view_mode` on that variant, and the rendered row then matches the
+    /// applied mode (Single -> subject, Shapes/Filmstrip -> row). Re-staging the
+    /// SAME mode is a no-op (the UI only stages on `staged != view_mode`), so the
+    /// pending slot stays `None`. This pins the `render_view_tab_row` ->
+    /// `render_overlay` deferred-apply contract without a GPU-backed `Demo`.
+    #[test]
+    fn view_mode_tab_round_trips() {
+        let subject = entry(RaymarchShape::Polytope(Polytope4::Cell24));
+        let row = [entry(RaymarchShape::Polytope(Polytope4::Tesseract))];
+
+        // Replicate the tab's stage rule: stage iff the clicked value differs.
+        let stage = |current: ViewMode, clicked: ViewMode| -> Option<ViewMode> {
+            (clicked != current).then_some(clicked)
+        };
+
+        for &target in &[ViewMode::Shapes, ViewMode::Single, ViewMode::Filmstrip] {
+            // Start from a mode that is guaranteed different from `target` so the
+            // stage fires; Single <-> Shapes covers both directions.
+            let start = if target == ViewMode::Shapes {
+                ViewMode::Single
+            } else {
+                ViewMode::Shapes
+            };
+            let pending = stage(start, target);
+            assert_eq!(pending, Some(target), "clicking {target:?} stages it");
+            // Apply (the `pending_view_mode.take()` arm in render_overlay).
+            let applied = pending.unwrap_or(start);
+            assert_eq!(applied, target, "applying the pending mode lands on it");
+            // The rendered row reflects the applied mode.
+            let rendered = render_row_entries(applied, &row, &subject);
+            match applied {
+                ViewMode::Single => assert_eq!(rendered, std::slice::from_ref(&subject)),
+                ViewMode::Shapes | ViewMode::Filmstrip => assert_eq!(rendered, &row[..]),
+            }
+            // Re-staging the same mode is a no-op: nothing to apply.
+            assert_eq!(
+                stage(target, target),
+                None,
+                "{target:?} re-stage is a no-op"
+            );
+        }
+    }
+
+    // ---- Section layers (cross-section + projected cap) ------------------
+
+    /// The headline invariant of the two-layer split: the honest cross-section
+    /// ALWAYS resolves to drop-w (`Identity`) regardless of the active wireframe
+    /// projection, while the projected cap follows whatever projection is active.
+    /// This is what guarantees that selecting Schlegel / stereographic never
+    /// silently distorts the slice the user reads as "the cross-section": the
+    /// honest layer is pinned to the SDF's own drop-w view.
+    #[test]
+    fn section_layer_projection_honest_ignores_projected_follows() {
+        let actives = [
+            Projection::Identity,
+            Projection::Perspective4D {
+                focal_distance: 2.0,
+            },
+            Projection::Stereographic { pole: Vec4::W },
+            Projection::Schlegel {
+                cell_normal: Vec4::W,
+                cell_offset: 0.5,
+                viewpoint_distance: 0.75,
+            },
+        ];
+        for active in actives {
+            // Honest layer: drop-w no matter what the active projection is.
+            assert_eq!(
+                section_layer_projection(true, active),
+                Projection::Identity,
+                "honest cross-section must stay drop-w under active {active:?}"
+            );
+            // Projected cap: exactly the active projection, passed through.
+            assert_eq!(
+                section_layer_projection(false, active),
+                active,
+                "projected cap must follow the active projection {active:?}"
+            );
+        }
+    }
+
+    /// `fill_visible` is the layer's on/off switch: any positive alpha draws a
+    /// fill, `0` (or below) skips the pass. Pins the boundary so a layer set to
+    /// alpha 0 never submits an invisible mesh and a faint positive alpha still
+    /// draws.
+    #[test]
+    fn section_layer_fill_visible_at_positive_alpha_only() {
+        assert!(!SectionLayer {
+            perimeter: true,
+            surface_alpha: 0.0
+        }
+        .fill_visible());
+        assert!(SectionLayer {
+            perimeter: false,
+            surface_alpha: 0.01
+        }
+        .fill_visible());
+        assert!(SectionLayer {
+            perimeter: false,
+            surface_alpha: 1.0
+        }
+        .fill_visible());
+    }
+
+    /// The defaults encode the spec's "honest slice visible, reprojected cap off"
+    /// baseline: the cross-section's perimeter + fill are on (the fill at a
+    /// full-ish, sub-opaque alpha so the wireframe reads through), and the
+    /// projected cap is fully off. This is the state that makes a projection
+    /// change non-destructive to the slice.
+    #[test]
+    fn section_layer_defaults_match_spec() {
+        let cross = SectionLayer::CROSS_SECTION_DEFAULT;
+        assert!(cross.perimeter, "honest perimeter on by default");
+        assert!(cross.fill_visible(), "honest fill on by default");
+        assert!(
+            cross.surface_alpha > 0.5 && cross.surface_alpha <= 1.0,
+            "honest default alpha should be full-ish, got {}",
+            cross.surface_alpha
+        );
+
+        let cap = SectionLayer::PROJECTED_CAP_DEFAULT;
+        assert!(!cap.perimeter, "projected-cap perimeter off by default");
+        assert!(!cap.fill_visible(), "projected-cap fill off by default");
     }
 }

--- a/crates/polytope_playground/src/state.rs
+++ b/crates/polytope_playground/src/state.rs
@@ -153,16 +153,14 @@ impl SectionLayer {
     }
 }
 
-/// Default surface-fill alpha for the honest cross-section layer: visible but
-/// slightly translucent so the parent wireframe (when enabled) reads through the
-/// cap without a separate `surface alpha` command. "Full-ish" rather than fully
-/// opaque per the layer's default-on role as the always-honest slice.
-const CROSS_SECTION_DEFAULT_ALPHA: f32 = 0.85;
+/// Default surface-fill alpha for the honest cross-section layer: fully opaque
+/// by default so the always-honest slice reads as solid surface geometry.
+const CROSS_SECTION_DEFAULT_ALPHA: f32 = 1.0;
 
 impl SectionLayer {
-    /// The honest cross-section's default: perimeter + fill on at a full-ish
-    /// alpha, so selecting a distorting wireframe projection never silently
-    /// reshapes the slice the user reads as "the cross-section."
+    /// The honest cross-section's default: perimeter + opaque fill on, so
+    /// selecting a distorting wireframe projection never silently reshapes the
+    /// slice the user reads as "the cross-section."
     pub(crate) const CROSS_SECTION_DEFAULT: SectionLayer = SectionLayer {
         perimeter: true,
         surface_alpha: CROSS_SECTION_DEFAULT_ALPHA,
@@ -202,19 +200,23 @@ pub(crate) fn section_layer_projection(
 /// slice IS a 3-flat and drop-w is the inhabitant's natural view of it).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub(crate) enum WireframeProjection {
-    /// Axis-aligned drop-w: `(x, y, z, w) -> (x, y, z)`. The default. Collapses every
-    /// pair of w-opposite vertices to the same R³ point, so axis-aligned polytopes
-    /// (especially the tesseract) render as visually degenerate "flat" shapes; the
-    /// 5-cell and 24-cell read more naturally because their cells aren't w-aligned.
+    /// Shadow: the orthographic drop-w projection `(x, y, z, w) -> (x, y, z)`, the
+    /// 4D object's shadow cast by parallel light down the w-axis. The default.
+    /// Collapses every pair of w-opposite vertices to the same R³ point, so
+    /// axis-aligned polytopes (especially the tesseract) render as visually
+    /// degenerate "flat" shapes; the 5-cell and 24-cell read more naturally
+    /// because their cells aren't w-aligned.
     #[default]
-    DropW,
-    /// 4D pinhole perspective from a viewer at `(0, 0, 0, focal_distance)` looking
-    /// in -w. Produces the classical "cube within a cube" tesseract view: +w face
-    /// renders as the outer (larger) shape, -w face as the inner (smaller) shape,
-    /// connecting edges as the frustum lines. Brings axis-aligned polytopes to life
-    /// at the cost of slight distortion on the polytopes that already read well
-    /// under drop-w.
-    WDepth,
+    Shadow,
+    /// W-pinhole: a 4D pinhole camera with its eye at `(0, 0, 0, focal_distance)`
+    /// on the w-axis, projecting the polytope onto the `w = 0` image 3-flat
+    /// (rays through one center, foreshortening by `focal / (focal - w)`).
+    /// Produces the classical "cube within a cube" tesseract view: the +w face
+    /// renders as the outer (larger) shape, the -w face as the inner (smaller)
+    /// shape, connecting edges as the frustum lines. Brings axis-aligned polytopes
+    /// to life at the cost of slight distortion on the polytopes that already read
+    /// well under Shadow.
+    WPinhole,
     /// 4D Schlegel diagram: central projection from a viewpoint just outside the
     /// chosen boundary cell onto that cell's bounding 3-flat (Coxeter, *Regular
     /// Polytopes*, ch. 13). The chosen cell becomes the diagram's outer boundary;
@@ -222,9 +224,9 @@ pub(crate) enum WireframeProjection {
     /// polytope's cells is the boundary, in the canonical [`Polytope4::topology`]
     /// cell order; it is clamped to the polytope's cell count at resolve time.
     ///
-    /// The variant carries only the index. The `cell_normal` / `cell_offset` /
-    /// `viewpoint_distance` scalars that [`rye_math::Projection::Schlegel`] needs
-    /// are resolved from the *selected polytope's* topology (cell centroids via
+    /// The variant carries only the index. The `cell_normal`, cell basis, and
+    /// distance scalars that [`rye_math::Projection::Schlegel`] needs are
+    /// resolved from the *selected polytope's* topology (cell centroids via
     /// [`Polytope4::face_planes`], the CORRECT path, NOT the buggy dual-vertex
     /// `cell{120,600}_face_planes`) and cached on [`Demo::schlegel_params`] at
     /// cell-select time, never inside the per-frame upload. See
@@ -235,16 +237,17 @@ pub(crate) enum WireframeProjection {
     },
     /// Conformal stereographic projection of the polytope from S³ (where its
     /// unit-circumradius vertices live) to R³, casting away from a configurable
-    /// pole (default [`STEREOGRAPHIC_DEFAULT_POLE`], a cell-center direction; live
-    /// value is [`Demo::stereographic_pole`]). Angle-preserving, distance-
-    /// distorting: the cell facing the pole balloons to the outer boundary and the
-    /// opposite cell shrinks to the interior, the same nesting Schlegel shows but
-    /// with the round, angle-faithful look that pairs with spherical-space mode.
+    /// pole (default [`STEREOGRAPHIC_DEFAULT_POLE`], the `+w` axis aligned with
+    /// the w-slice; live value is [`Demo::stereographic_pole`]). Edges always
+    /// render as S³ great-circle arcs (see [`default_edge_blend`]). Angle-
+    /// preserving, distance-distorting: the cell facing the pole balloons to the
+    /// outer boundary and the opposite cell shrinks to the interior, the same
+    /// nesting Schlegel shows but with the round, angle-faithful conformal look.
     /// The `EuclideanR4` projection normalizes each vertex onto S³ first, so this
     /// reads correctly for the demo's `BODY_SIZE`-scaled vertices.
     Stereographic,
-    /// Drop-w projection paired with a demo-side CELL-level w-range cull (the
-    /// `wireframe_hyperslice` filter): the wireframe thins to the edges that
+    /// Shadow (drop-w) projection paired with a demo-side CELL-level w-range cull
+    /// (the `wireframe_hyperslice` filter): the wireframe thins to the edges that
     /// belong to a cell whose body-local w-range overlaps a slab around
     /// `w_slice`. The cull is cell-level (not edge-level) so a kept edge agrees
     /// with the cell-level active-edge coloring and the cross-section: a far-side
@@ -266,9 +269,9 @@ pub(crate) enum WireframeProjection {
 /// Stored in CANONICAL coordinates (the polytope's unit-circumradius topology):
 /// the per-frame [`Demo::resolved_wireframe_projection`] scales `cell_offset` and
 /// `viewpoint_distance` by the live [`Demo::effective_body_size`] and rotates
-/// `cell_normal` by the live `rot_state`. Caching canonical (not body-scaled)
-/// params keeps the cache valid across `surface scale` changes and is what lets
-/// the chosen cell stay the outer boundary as the polytope spins.
+/// `cell_normal` / `cell_basis` by the live `rot_state`. Caching canonical (not
+/// body-scaled) params keeps the cache valid across `surface scale` changes and
+/// lets the chosen cell stay the outer boundary as the polytope spins.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct SchlegelParams {
     /// The polytope these params were resolved against. The cache is invalid if
@@ -279,6 +282,9 @@ pub(crate) struct SchlegelParams {
     /// Outward unit normal of the chosen cell's hyperplane, in CANONICAL coords.
     /// Per-frame rotated by `rot_state`; rotation preserves unit length.
     pub(crate) cell_normal: glam::Vec4,
+    /// Orthonormal readout basis spanning the chosen cell, in CANONICAL coords.
+    /// Per-frame rotated by `rot_state` so its gauge cannot snap while spinning.
+    pub(crate) cell_basis: [glam::Vec4; 3],
     /// Signed plane offset in CANONICAL coords (the cell's inradius): the chosen
     /// cell lies in `{x : dot(cell_normal, x) = cell_offset}`. Per-frame scaled by
     /// `effective_body_size`.
@@ -289,6 +295,61 @@ pub(crate) struct SchlegelParams {
     /// cell_offset` crowds the eye against the small-inradius 5-cell). Per-frame
     /// scaled by `effective_body_size`.
     pub(crate) viewpoint_distance: f32,
+}
+
+const SCHLEGEL_BASIS_EPSILON: f32 = 1e-6;
+
+fn push_schlegel_basis_vector(
+    candidate: glam::Vec4,
+    cell_normal: glam::Vec4,
+    basis: &mut [glam::Vec4; 3],
+    count: &mut usize,
+) {
+    if *count == basis.len() {
+        return;
+    }
+    let mut v = candidate - candidate.dot(cell_normal) * cell_normal;
+    for b in basis.iter().take(*count) {
+        v -= v.dot(*b) * *b;
+    }
+    let len = v.length();
+    if len > SCHLEGEL_BASIS_EPSILON {
+        basis[*count] = v / len;
+        *count += 1;
+    }
+}
+
+fn resolve_schlegel_cell_basis(
+    polytope: Polytope4,
+    cell_index: usize,
+    cell_normal: glam::Vec4,
+) -> [glam::Vec4; 3] {
+    let topo = polytope.topology();
+    let cell = topo.cells[cell_index];
+    let anchor = topo.vertices[cell[0] as usize];
+    let mut basis = [glam::Vec4::ZERO; 3];
+    let mut count = 0usize;
+
+    for &vi in cell.iter().skip(1) {
+        push_schlegel_basis_vector(
+            topo.vertices[vi as usize] - anchor,
+            cell_normal,
+            &mut basis,
+            &mut count,
+        );
+        if count == 3 {
+            return basis;
+        }
+    }
+
+    debug_assert_eq!(count, 3, "Schlegel boundary cell must span a 3-flat");
+    for seed in [glam::Vec4::X, glam::Vec4::Y, glam::Vec4::Z, glam::Vec4::W] {
+        push_schlegel_basis_vector(seed, cell_normal, &mut basis, &mut count);
+        if count == 3 {
+            break;
+        }
+    }
+    basis
 }
 
 /// Additive eye clearance beyond the chosen cell's far edge, in canonical
@@ -322,6 +383,7 @@ pub(crate) fn resolve_schlegel_params(polytope: Polytope4, cell_index: u32) -> S
     let clamped = cell_index.min(cell_count - 1);
     let (normals, cell_offset) = polytope.face_planes();
     let cell_normal = normals[clamped as usize];
+    let cell_basis = resolve_schlegel_cell_basis(polytope, clamped as usize, cell_normal);
     // Farthest vertex-projection along the outward normal. For the chosen cell
     // this is its own boundary plane (`= cell_offset`), but compute it over all
     // vertices so the eye clearance is robust to any topology quirk rather than
@@ -336,6 +398,7 @@ pub(crate) fn resolve_schlegel_params(polytope: Polytope4, cell_index: u32) -> S
         polytope,
         cell_index: clamped,
         cell_normal,
+        cell_basis,
         cell_offset,
         viewpoint_distance: max_dot + SCHLEGEL_EYE_MARGIN,
     }
@@ -375,6 +438,34 @@ pub(crate) fn synced_schlegel_projection(
     }
 }
 
+/// The edge geometry an honest render of `projection` uses: the S3 great-circle
+/// arc (`blend == 1`) for Stereographic, flat R4 chords (`blend == 0`) for every
+/// other projection. Under the conformal map a polytope edge is a circular arc,
+/// not a straight chord, so Stereographic always draws arcs; the affine
+/// projections draw chords. Read per frame by the wireframe builder
+/// ([`Demo::render_wireframe_overlay`]); edge geometry is derived from the
+/// projection, not a separate control, so it can never disagree with the map.
+pub(crate) fn default_edge_blend(projection: WireframeProjection) -> f32 {
+    match projection {
+        WireframeProjection::Stereographic => 1.0,
+        _ => 0.0,
+    }
+}
+
+/// Apply secondary state changes implied by selecting a wireframe projection.
+///
+/// Stereographic only shows anything in the wireframe overlay (its S3 arcs are
+/// drawn there), so selecting it turns the overlay on. Edge geometry itself is
+/// derived from the projection ([`default_edge_blend`]), not set here.
+pub(crate) fn apply_projection_selection_defaults(
+    projection: WireframeProjection,
+    wireframe_enabled: &mut bool,
+) {
+    if matches!(projection, WireframeProjection::Stereographic) {
+        *wireframe_enabled = true;
+    }
+}
+
 /// A short educational annotation for the active projection / space-mode
 /// combination: a `title` for the callout window plus a `body` of one to three
 /// sentences explaining what the user is looking at. Surfaced via the
@@ -384,35 +475,13 @@ pub(crate) fn synced_schlegel_projection(
 pub(crate) struct ModeAnnotation {
     /// Callout window title: the mode's short name.
     pub(crate) title: &'static str,
-    /// One to three sentences. Composed from the projection's own explanation
-    /// plus, when spherical curvature is active, a curvature sentence and (for
-    /// the flat-cap overlap) a disambiguating note.
+    /// One to three sentences explaining the active projection.
     pub(crate) body: String,
 }
 
-/// The `space_blend` argument above this counts as "spherical curvature is on"
-/// for the annotation: any visible bow of the edges toward S³ warrants the
-/// curvature sentence. Matches the wireframe builder's own `blend <= 0.0` flat
-/// fast-path cutoff (the per-edge morph in the demo's `push_blended_edge`), so
-/// the curvature sentence appears for exactly the blend values that bow the
-/// edges. The wireframe-overlay-enabled gate is the caller's responsibility:
-/// `Demo::render_mode_annotation` passes `0.0` here while the overlay is off,
-/// since the bowed edges render only in that overlay, so this threshold is the
-/// last condition rather than the only one.
-const SPHERICAL_ANNOTATION_THRESHOLD: f32 = 0.0;
-
-/// Educational annotation for the active `(projection, space curvature, flat-cap)`
-/// combination, or `None` when the scene is in its plain default state (drop-w
-/// projection AND flat space): there is nothing non-obvious to explain, so no
-/// callout is shown. Every other combination returns `Some` with distinct,
-/// non-empty copy.
-///
-/// `flat_cap_drawn` is `true` when the rasterized cross-section caps are being
-/// drawn (`SurfaceMode::Raster`). It only affects the body text in the THREE-WAY
-/// overlap case (spherical curvature on, with a flat cap and/or Stereographic),
-/// where the cap stays a flat 3-flat slice while the edges bow onto S³; the note
-/// tells the user the flat cap is expected (a curved cross-section is future
-/// work) so a flat cap under curved edges does not read as a bug.
+/// Educational annotation for the active `projection`, or `None` for the plain
+/// default (drop-w): there is nothing non-obvious to explain, so no callout is
+/// shown. Every other projection returns `Some` with distinct, non-empty copy.
 ///
 /// Pure (no `&Demo`) so the `(mode) -> copy` mapping is unit-testable without a
 /// GPU-backed [`Demo`]; [`Demo::render_mode_annotation`] is the one caller.
@@ -420,21 +489,15 @@ const SPHERICAL_ANNOTATION_THRESHOLD: f32 = 0.0;
 /// Projection explanations follow Coxeter, *Regular Polytopes*, ch. 13
 /// (Schlegel diagrams) and the standard conformal stereographic map
 /// `(x, y, z) / (1 - w)` (Wikipedia, "Stereographic projection").
-pub(crate) fn mode_annotation(
-    projection: WireframeProjection,
-    space_blend: f32,
-    flat_cap_drawn: bool,
-) -> Option<ModeAnnotation> {
-    let spherical = space_blend > SPHERICAL_ANNOTATION_THRESHOLD;
-
-    // Per-projection lead sentence. `None` for drop-w, the default projection:
-    // it has no distortion to explain, so a drop-w + flat scene shows nothing.
+pub(crate) fn mode_annotation(projection: WireframeProjection) -> Option<ModeAnnotation> {
+    // `None` for drop-w, the default projection: it has no distortion to
+    // explain, so a drop-w scene shows nothing.
     let (title, projection_body): (&'static str, Option<&str>) = match projection {
-        WireframeProjection::DropW => ("Drop-w", None),
-        WireframeProjection::WDepth => (
-            "W-depth perspective",
+        WireframeProjection::Shadow => ("Shadow", None),
+        WireframeProjection::WPinhole => (
+            "W-pinhole",
             Some(
-                "4D pinhole perspective from a viewer down the w-axis: the +w face \
+                "4D pinhole camera with its eye down the w-axis: the +w face \
                  projects to the outer shape and the -w face to the inner one, the \
                  classic cube-within-a-cube view of the tesseract.",
             ),
@@ -451,10 +514,10 @@ pub(crate) fn mode_annotation(
         WireframeProjection::Stereographic => (
             "Stereographic projection",
             Some(
-                "Conformal S^3 -> R^3 map, (x, y, z) / (1 - w): angles are preserved \
-                 but distances are not, so the polytope distorts globally and the \
-                 cell facing the +w pole balloons outward as its vertices approach \
-                 the pole.",
+                "Conformal S^3 -> R^3 map, (x, y, z) / (1 - w): the polytope is \
+                 cast onto S^3 and its edges render as great-circle arcs. Angles \
+                 are preserved but distances are not, so the cell facing the +w \
+                 pole balloons outward as its vertices approach the pole.",
             ),
         ),
         WireframeProjection::Hyperslice => (
@@ -468,98 +531,43 @@ pub(crate) fn mode_annotation(
         ),
     };
 
-    // The default scene (drop-w, flat space) has nothing to annotate.
-    let Some(projection_lead) = projection_body else {
-        if !spherical {
-            return None;
-        }
-        // Spherical curvature on but the projection is plain drop-w: the
-        // curvature is the only thing to explain, so the callout is titled for
-        // the space mode rather than the projection.
-        return Some(ModeAnnotation {
-            title: "Spherical space",
-            body: spherical_sentence(flat_cap_drawn, projection).to_string(),
-        });
-    };
-
-    let mut body = projection_lead.to_string();
-    if spherical {
-        body.push(' ');
-        body.push_str(spherical_sentence(flat_cap_drawn, projection));
-    }
-    Some(ModeAnnotation { title, body })
+    let projection_lead = projection_body?;
+    Some(ModeAnnotation {
+        title,
+        body: projection_lead.to_string(),
+    })
 }
 
-/// The `space_blend` value the annotation should describe, given the raw blend
-/// and whether the wireframe overlay is on. The flat-to-spherical edge morph
-/// lives entirely in the wireframe builder (`push_blended_edge`, reached only
-/// from `Demo::render_wireframe_overlay`), which the frame loop skips while the
-/// overlay is disabled. With the overlay off there is no bowed edge on screen,
-/// so the annotation must not claim curvature: report the blend as `0.0` so
-/// [`mode_annotation`] drops the spherical sentence (or the whole "Spherical
-/// space" callout, for plain drop-w). The projection annotation is unaffected
-/// because the rasterized section caps reproject through the same projection
-/// whether or not the wireframe overlay draws.
+/// Default pole for the Stereographic wireframe projection: the `+w` axis
+/// `(0, 0, 0, 1)`, casting away from `+w` toward the `-w` antipode at the R^3
+/// origin. The pole is deliberately aligned with the w-slice axis: the
+/// cross-section selects cells by their w-coordinate, and under a `+w` pole the
+/// conformal scale `1 / (1 - dot(p, pole)) = 1 / (1 - p.w)` depends only on `w`,
+/// so every cell sharing the slice's w maps to one CENTERED radial shell. An
+/// off-axis pole (e.g. a cell center `(½,½,½,½)`) makes the scale depend on
+/// `x + y + z + w`, which spreads a single w-slice asymmetrically and pulls the
+/// active cells off-center.
 ///
-/// Split out so the "no curvature claim without a visible bow" invariant is
-/// unit-testable without a GPU-backed [`Demo`]; [`Demo::render_mode_annotation`]
-/// is the one caller.
-pub(crate) fn annotation_effective_blend(space_blend: f32, wireframe_enabled: bool) -> f32 {
-    if wireframe_enabled {
-        space_blend
-    } else {
-        0.0
-    }
-}
-
-/// The spherical-curvature sentence appended when `space_blend > 0`, plus the
-/// three-way-overlap note when a flat cross-section cap and/or Stereographic is
-/// also in play. The flat cap stays a flat 3-flat slice while the edges bow onto
-/// S^3; the note flags that as expected (curved cross-sections are future work)
-/// so the user does not read the flat cap under curved edges as a bug.
-fn spherical_sentence(flat_cap_drawn: bool, projection: WireframeProjection) -> &'static str {
-    let stereographic = matches!(projection, WireframeProjection::Stereographic);
-    if flat_cap_drawn || stereographic {
-        "Spherical space bows the edges onto S^3 great-circle arcs, so the \
-         polytope curves; the filled cross-section cap stays flat (a flat 3-flat \
-         slice), which is expected here -- a curved cross-section is not yet \
-         implemented."
-    } else {
-        "Spherical space bows the edges onto S^3 great-circle arcs, so the \
-         polytope curves rather than rendering as straight chords."
-    }
-}
-
-/// Default pole for the Stereographic wireframe projection: the unit
-/// direction `(1, 1, 1, 1)/2`, a cell-center direction of the 16-cell (and of
-/// the tesseract and 24-cell). Casting away from a cell center, rather than the
-/// `+w` axis, keeps an *axis-aligned* polytope's vertices off the pole: the
-/// 16-cell's vertices are the `±e_i` axes (Coxeter, *Regular Polytopes*, §8.2),
-/// and a cell centroid lies along the outward face normal between four such
-/// axes, so no 16-cell vertex sits on this pole and a pure `xw` rotation (which
-/// fixes `y, z`) can never sweep one onto it. That removes the common-case
-/// 16-cell pole flicker the `+w` pole exhibits.
-///
-/// Tradeoff, by 16-cell / tesseract duality: this direction *is* a tesseract
-/// vertex direction (the tesseract vertex `(½,½,½,½)`), so under this pole a
-/// tesseract presents a vertex toward the pole at rest, where the `+w` pole
-/// presented a cell. A single pole cannot avoid every polytope's vertices in a
-/// mixed row; this constant trades the tesseract's static look for the
-/// 16-cell's continuous-rotation robustness, and the pole stays configurable
-/// (see [`Demo::stereographic_pole`]). Written as the exact, exactly-unit f32
-/// literal `0.5` per lane so no runtime `normalize` is needed and the constant
-/// is bit-reproducible.
-pub(crate) const STEREOGRAPHIC_DEFAULT_POLE: glam::Vec4 = glam::Vec4::new(0.5, 0.5, 0.5, 0.5);
+/// Tradeoff: `+w` is a vertex direction of the axis-aligned polytopes (the
+/// 16-cell vertex `+e_w`, Coxeter, *Regular Polytopes*, §8.2), so a vertex can
+/// sweep through the pole under an `xw` rotation and flick to infinity at the
+/// crossing instant. This is the standard stereographic point-at-infinity
+/// singularity, accepted here in exchange for the centered, slice-aligned image
+/// (a pole that dodges the vertices instead skews every slice). The pole stays
+/// configurable (see [`Demo::stereographic_pole`]). `(0, 0, 0, 1)` is exactly
+/// unit, so no runtime `normalize` is needed and the constant is
+/// bit-reproducible.
+pub(crate) const STEREOGRAPHIC_DEFAULT_POLE: glam::Vec4 = glam::Vec4::new(0.0, 0.0, 0.0, 1.0);
 
 impl WireframeProjection {
     /// Parse the console-arg spelling. Hyphens because the console grammar lexes on
-    /// whitespace and `drop-w` / `w-depth` read as single tokens. `schlegel` parses
+    /// whitespace and `w-pinhole` reads as a single token. `schlegel` parses
     /// to `cell_index = 0`; the console handler reads the trailing `<cell-index>`
     /// token separately (the grammar carries it as its own positional arg).
     pub(crate) fn from_token(token: &str) -> Option<Self> {
         match token {
-            "drop-w" => Some(WireframeProjection::DropW),
-            "w-depth" => Some(WireframeProjection::WDepth),
+            "shadow" => Some(WireframeProjection::Shadow),
+            "w-pinhole" => Some(WireframeProjection::WPinhole),
             "schlegel" => Some(WireframeProjection::Schlegel { cell_index: 0 }),
             "stereographic" => Some(WireframeProjection::Stereographic),
             "hyperslice" => Some(WireframeProjection::Hyperslice),
@@ -568,12 +576,12 @@ impl WireframeProjection {
     }
 
     /// Cycle order for the bare `wireframe perspective` console command and the
-    /// UI radio: drop-w -> w-depth -> schlegel -> stereographic -> hyperslice ->
-    /// drop-w. Schlegel cycles in at `cell_index = 0`; the cell-index stepper then
+    /// UI radio: shadow -> w-pinhole -> schlegel -> stereographic -> hyperslice ->
+    /// shadow. Schlegel cycles in at `cell_index = 0`; the cell-index stepper then
     /// picks the boundary cell.
     pub(crate) const ALL: [Self; 5] = [
-        WireframeProjection::DropW,
-        WireframeProjection::WDepth,
+        WireframeProjection::Shadow,
+        WireframeProjection::WPinhole,
         WireframeProjection::Schlegel { cell_index: 0 },
         WireframeProjection::Stereographic,
         WireframeProjection::Hyperslice,
@@ -582,8 +590,8 @@ impl WireframeProjection {
     /// Display label for the egui projection radio.
     pub(crate) fn label(self) -> &'static str {
         match self {
-            WireframeProjection::DropW => "Drop-w",
-            WireframeProjection::WDepth => "W-depth",
+            WireframeProjection::Shadow => "Shadow",
+            WireframeProjection::WPinhole => "W-pinhole",
             WireframeProjection::Schlegel { .. } => "Schlegel",
             WireframeProjection::Stereographic => "Stereographic",
             WireframeProjection::Hyperslice => "Hyperslice",
@@ -601,12 +609,12 @@ impl WireframeProjection {
 
     /// Context-free resolution to a [`rye_math::Projection<4>`]. Handles the modes
     /// that need no polytope or rotor context:
-    /// - `DropW` -> `Identity` (drop-w),
-    /// - `WDepth` -> `Perspective4D { focal_distance: 2.0 }` (focal sized to clear
+    /// - `Shadow` -> `Identity` (orthographic drop-w),
+    /// - `WPinhole` -> `Perspective4D { focal_distance: 2.0 }` (focal sized to clear
     ///   the unit-circumradius polytope's `BODY_SIZE`-scaled w-extent so the
     ///   denominator never nears zero),
     /// - `Stereographic` -> `Stereographic { pole: STEREOGRAPHIC_DEFAULT_POLE }`
-    ///   (a cell-center pole, off every 16-cell vertex; see the constant). The
+    ///   (the `+w` pole aligned with the w-slice; see the constant). The
     ///   live pole is [`Demo::stereographic_pole`], which
     ///   [`Demo::resolved_wireframe_projection`] substitutes; this context-free
     ///   resolution returns the default so a non-render caller still gets the
@@ -622,14 +630,14 @@ impl WireframeProjection {
     /// sites call it, not this.
     pub(crate) fn to_projection(self) -> rye_math::Projection<4> {
         match self {
-            WireframeProjection::DropW | WireframeProjection::Hyperslice => {
+            WireframeProjection::Shadow | WireframeProjection::Hyperslice => {
                 rye_math::Projection::Identity
             }
-            WireframeProjection::WDepth => rye_math::Projection::Perspective4D {
+            WireframeProjection::WPinhole => rye_math::Projection::Perspective4D {
                 focal_distance: 2.0,
             },
             // Schlegel needs cached params + rotor (see doc above); fall back to
-            // drop-w until `Demo::resolved_wireframe_projection` resolves it.
+            // Shadow (drop-w) until `Demo::resolved_wireframe_projection` resolves it.
             WireframeProjection::Schlegel { .. } => rye_math::Projection::Identity,
             WireframeProjection::Stereographic => rye_math::Projection::Stereographic {
                 pole: STEREOGRAPHIC_DEFAULT_POLE,
@@ -1001,8 +1009,8 @@ pub(crate) struct Demo {
     pub(crate) schlegel_params: Option<SchlegelParams>,
     /// Live pole for the Stereographic wireframe projection, the unit `Vec4` the
     /// conformal map casts away from. Defaults to [`STEREOGRAPHIC_DEFAULT_POLE`]
-    /// (a cell-center direction, off every 16-cell vertex; see the constant for
-    /// why and the tesseract tradeoff). Kept as a field rather than baked into the
+    /// (the `+w` axis, aligned with the w-slice; see the constant for why and the
+    /// 16-cell flicker tradeoff). Kept as a field rather than baked into the
     /// payload-free [`WireframeProjection::Stereographic`] variant so the enum
     /// stays a plain marker across `ALL` / `from_token` / `same_variant` / the UI
     /// radio; [`Self::resolved_wireframe_projection`] substitutes it per frame.
@@ -1027,14 +1035,6 @@ pub(crate) struct Demo {
     /// survive" rather than an exact-equality test that never fires. Default
     /// [`crate::consts::HYPERSLICE_DEFAULT_THICKNESS`].
     pub(crate) wireframe_hyperslice_thickness: f32,
-    /// Wireframe-edge geometry morph in `[0, 1]`: `0.0` draws straight chords
-    /// in R⁴ (flat, `EuclideanR4` lerp); `1.0` draws great-circle arcs on S³
-    /// (`SphericalS3Embedded` slerp); values between linearly blend the two
-    /// per tessellation sample. The polytope's unit-circumradius vertices
-    /// already lie on S³, so only the edge interiors move; endpoints are
-    /// shared. Set via the `space` console command. At exactly `0.0` the
-    /// wireframe takes a one-segment-per-edge fast path (no tessellation).
-    pub(crate) space_blend: f32,
     /// Pixel width of parent-wireframe edges. Tuneable via `wireframe width <N>`
     /// for thicker lines on screenshots. Default bumped from 1.2 px to 1.8 px
     /// after side-by-side comparison: 1.2 px was too fine to read clearly
@@ -1145,7 +1145,7 @@ pub(crate) struct Demo {
     pub(crate) body_uniform_scratch: Vec<BodyUniform>,
     /// Reused great-circle sampling buffer for `push_blended_edge`; taken via
     /// `mem::take` during the wireframe-overlay build and put back after, so the
-    /// curved-mode (`space_blend > 0`) path does not allocate per frame.
+    /// arc-edge (Stereographic) path does not allocate per frame.
     pub(crate) slerp_scratch: Vec<glam::Vec4>,
     /// Selects how the six regular convex 4-polytopes are rendered. Smooth-surface shapes
     /// (Clifford torus, duocylinder, etc.) ignore this and always render via the SDF since
@@ -1217,13 +1217,12 @@ pub(crate) struct Demo {
     pub(crate) example_callout: rye_egui::CalloutState,
 
     /// Persistent state for the per-mode educational annotation callout: a short
-    /// floating explanation of the active projection / space mode, anchored to
-    /// the leading polychoron. Its text is the pure [`mode_annotation`] mapping
-    /// reprojected each frame; the callout only draws when that mapping returns
-    /// `Some` (a non-default projection or spherical curvature is active) AND
-    /// this flag is on. On by default so a first-time user who switches to
-    /// Schlegel / Stereographic / Hyperslice or turns up Curvature immediately
-    /// sees what the mode does; toggle via `View > Mode annotation`.
+    /// floating explanation of the active projection, anchored to the leading
+    /// polychoron. Its text is the pure [`mode_annotation`] mapping reprojected
+    /// each frame; the callout only draws when that mapping returns `Some` (a
+    /// non-default projection is active) AND this flag is on. On by default so a
+    /// first-time user who switches to Schlegel / Stereographic / Hyperslice
+    /// immediately sees what the mode does; toggle via `View > Mode annotation`.
     pub(crate) mode_annotation_open: rye_egui::CalloutState,
 
     /// Whether the top-right rotation-formula popup is rendered. Off by default; the
@@ -1507,9 +1506,9 @@ impl Demo {
 
     /// The live [`rye_math::Projection<4>`] for the wireframe overlay this frame.
     /// For Schlegel it builds the engine projection from the cached canonical
-    /// [`SchlegelParams`]: the canonical normal is rotated by the current
-    /// `rot_state` (one rotor apply; rotation preserves unit length) so the chosen
-    /// cell stays the outer boundary as the body spins, and the canonical offset +
+    /// [`SchlegelParams`]: the canonical normal and basis rotate by the current
+    /// `rot_state` so the chosen cell stays the outer boundary as the body spins,
+    /// and its in-flat orientation stays continuous. The canonical offset and
     /// viewpoint distance are scaled by [`Self::effective_body_size`] to match the
     /// body-scaled vertices the wireframe feeds the projection. No allocation, no
     /// `face_planes` call: this is the hot-path-safe counterpart to
@@ -1520,11 +1519,14 @@ impl Demo {
             WireframeProjection::Schlegel { .. } => match self.schlegel_params {
                 Some(p) => {
                     let body_size = self.effective_body_size();
-                    Projection::Schlegel {
-                        cell_normal: self.rot_state.apply(p.cell_normal),
-                        cell_offset: p.cell_offset * body_size,
-                        viewpoint_distance: p.viewpoint_distance * body_size,
-                    }
+                    let cell_normal = self.rot_state.apply(p.cell_normal);
+                    let basis = p.cell_basis.map(|axis| self.rot_state.apply(axis));
+                    Projection::schlegel_with_basis(
+                        cell_normal,
+                        p.cell_offset * body_size,
+                        p.viewpoint_distance * body_size,
+                        basis,
+                    )
                 }
                 // Unresolved (no polychoron in row): drop-w fallback. The cache is
                 // resolved at every select point, so this only fires for a row with
@@ -1627,7 +1629,6 @@ impl Demo {
         self.rot_state = Rotor4::IDENTITY;
         self.rot_time = 0.0;
         self.t_slider_max = T_SLIDER_INITIAL;
-        self.space_blend = 0.0;
         // Restore the honest-slice default: the drop-w cross-section visible,
         // the reprojected cap off, so a reset always returns to the "slice that
         // never distorts under a projection change" baseline.
@@ -1641,10 +1642,11 @@ impl Demo {
 #[cfg(test)]
 mod tests {
     use super::{
-        active_plane_angle, annotation_effective_blend, compose_active_rotor,
-        hyperslice_cull_active, mode_annotation, render_row_entries, resolve_schlegel_params,
-        row_blocks_sdf, section_layer_projection, synced_schlegel_projection, SectionLayer,
-        ViewMode, WireframeProjection, BASE_ROTATION_RATE, STEREOGRAPHIC_DEFAULT_POLE,
+        active_plane_angle, apply_projection_selection_defaults, compose_active_rotor,
+        default_edge_blend, hyperslice_cull_active, mode_annotation, render_row_entries,
+        resolve_schlegel_params, row_blocks_sdf, section_layer_projection,
+        synced_schlegel_projection, SectionLayer, ViewMode, WireframeProjection,
+        BASE_ROTATION_RATE, STEREOGRAPHIC_DEFAULT_POLE,
     };
     use crate::catalog::ShapeEntry;
     use glam::Vec4;
@@ -1803,136 +1805,42 @@ mod tests {
         assert!(row_blocks_sdf(&with_600));
     }
 
-    /// A curvature value set while the wireframe overlay is OFF must not produce a
-    /// spherical annotation: the flat-to-spherical edge bow renders only in the
-    /// wireframe overlay, so with the overlay off there is no curved geometry on
-    /// screen and the callout would describe something the user cannot see. The
-    /// caller routes `space_blend` through [`annotation_effective_blend`], which
-    /// reports flat (`0.0`) while the overlay is off, so:
-    ///  - drop-w + curvature-but-overlay-off collapses to the default no-op
-    ///    (`None`), exactly as plain flat drop-w does; and
-    ///  - a non-default projection keeps its projection annotation (the caps
-    ///    reproject without the wireframe) but drops the spherical sentence.
-    ///
-    /// With the overlay on, the raw blend passes through unchanged.
-    #[test]
-    fn curvature_annotation_requires_visible_wireframe() {
-        // Overlay off: the gate reports flat regardless of the raw blend.
-        assert_eq!(annotation_effective_blend(1.0, false), 0.0);
-        assert_eq!(annotation_effective_blend(0.5, false), 0.0);
-        // Overlay on: the raw blend passes through untouched.
-        assert_eq!(annotation_effective_blend(1.0, true), 1.0);
-        assert_eq!(annotation_effective_blend(0.0, true), 0.0);
-
-        // Drop-w with curvature set but the overlay off is indistinguishable from
-        // the plain flat default scene: no annotation.
-        let blend_off = annotation_effective_blend(1.0, false);
-        assert!(
-            mode_annotation(WireframeProjection::DropW, blend_off, false).is_none(),
-            "spherical-over-drop-w must not annotate while the wireframe is off"
-        );
-        // Turning the overlay on resurrects the spherical-space callout.
-        let blend_on = annotation_effective_blend(1.0, true);
-        assert!(
-            mode_annotation(WireframeProjection::DropW, blend_on, false).is_some(),
-            "spherical-over-drop-w must annotate once the wireframe is on"
-        );
-
-        // A non-default projection keeps its projection annotation with the
-        // overlay off, but the body must NOT mention the S^3 edge bow, since no
-        // bowed edge is drawn. The projection lead (caps reproject regardless) is
-        // still present.
-        let stereo_off = mode_annotation(WireframeProjection::Stereographic, blend_off, false)
-            .expect("stereographic still annotates its projection with the overlay off");
-        assert!(
-            !stereo_off.body.contains("S^3 great-circle arcs"),
-            "no spherical sentence without a visible wireframe bow: {}",
-            stereo_off.body
-        );
-        assert!(
-            stereo_off.body.contains("Conformal S^3 -> R^3"),
-            "the stereographic projection lead must still be present: {}",
-            stereo_off.body
-        );
-    }
-
     /// The educational-annotation mapping pins three invariants the UI relies on:
-    /// (1) the plain default scene (drop-w projection, flat space) yields no
-    /// annotation, so nothing floats over an undistorted view; (2) every
-    /// non-default projection and the spherical-space-over-drop-w case yields a
-    /// non-empty body; and (3) the bodies are pairwise DISTINCT across the
-    /// non-default modes, so each mode reads as its own explanation rather than a
-    /// shared placeholder. Pins the `(mode) -> copy` mapping, not the egui render.
+    /// (1) the plain default (drop-w) projection yields no annotation, so nothing
+    /// floats over the undistorted default view; (2) every non-default projection
+    /// yields a non-empty title and body; and (3) the bodies are pairwise DISTINCT,
+    /// so each mode reads as its own explanation rather than a shared placeholder.
+    /// Pins the `(projection) -> copy` mapping, not the egui render.
     #[test]
     fn annotation_text_present_per_mode() {
-        // Default scene: drop-w + flat space + (cap state irrelevant) -> nothing.
         assert!(
-            mode_annotation(WireframeProjection::DropW, 0.0, true).is_none(),
-            "drop-w + flat space must not annotate the default view"
-        );
-        assert!(
-            mode_annotation(WireframeProjection::DropW, 0.0, false).is_none(),
-            "cap state must not resurrect the default-scene annotation"
+            mode_annotation(WireframeProjection::Shadow).is_none(),
+            "drop-w must not annotate the default view"
         );
 
-        // Each distinct mode case the UI can surface. `space_blend` and the
-        // flat-cap flag are chosen to exercise both the plain projection body and
-        // the spherical/overlap branches.
-        let cases: &[(WireframeProjection, f32, bool)] = &[
-            (WireframeProjection::WDepth, 0.0, true),
-            (WireframeProjection::Schlegel { cell_index: 0 }, 0.0, true),
-            (WireframeProjection::Stereographic, 0.0, true),
-            (WireframeProjection::Hyperslice, 0.0, true),
-            // Spherical curvature over plain drop-w: the space mode is the only
-            // thing to explain, so this is its own distinct annotation.
-            (WireframeProjection::DropW, 1.0, true),
+        let cases = [
+            WireframeProjection::WPinhole,
+            WireframeProjection::Schlegel { cell_index: 0 },
+            WireframeProjection::Stereographic,
+            WireframeProjection::Hyperslice,
         ];
-
         let mut bodies = HashSet::new();
-        for &(projection, blend, flat_cap) in cases {
-            let annotation = mode_annotation(projection, blend, flat_cap)
-                .unwrap_or_else(|| panic!("{projection:?} blend={blend} must annotate"));
+        for projection in cases {
+            let annotation = mode_annotation(projection)
+                .unwrap_or_else(|| panic!("{projection:?} must annotate"));
             assert!(
                 !annotation.title.is_empty(),
-                "{projection:?} blend={blend}: title must be non-empty"
+                "{projection:?}: title must be non-empty"
             );
             assert!(
                 !annotation.body.is_empty(),
-                "{projection:?} blend={blend}: body must be non-empty"
+                "{projection:?}: body must be non-empty"
             );
             assert!(
                 bodies.insert(annotation.body.clone()),
-                "{projection:?} blend={blend}: body duplicates another mode's copy"
+                "{projection:?}: body duplicates another mode's copy"
             );
         }
-
-        // The three-way overlap note is conditional: spherical curvature with a
-        // flat cap (or Stereographic) must mention the flat cross-section, and the
-        // no-flat-cap / non-stereographic case must NOT, so the user is only warned
-        // about the flat cap when one is actually drawn under curved edges.
-        let with_cap = mode_annotation(WireframeProjection::WDepth, 1.0, true)
-            .expect("wdepth + spherical annotates");
-        assert!(
-            with_cap.body.contains("cross-section cap stays flat"),
-            "spherical + flat cap must flag the flat cross-section: {}",
-            with_cap.body
-        );
-        let no_cap = mode_annotation(WireframeProjection::WDepth, 1.0, false)
-            .expect("wdepth + spherical annotates");
-        assert!(
-            !no_cap.body.contains("cross-section cap stays flat"),
-            "spherical without a flat cap must not mention the cap: {}",
-            no_cap.body
-        );
-        // Stereographic forces the overlap note even with no raster cap, because
-        // its own R^3 image is a flat conformal map under the curved edges.
-        let stereo_no_cap = mode_annotation(WireframeProjection::Stereographic, 1.0, false)
-            .expect("stereographic + spherical annotates");
-        assert!(
-            stereo_no_cap.body.contains("cross-section cap stays flat"),
-            "stereographic + spherical must flag the flat slice even without a cap: {}",
-            stereo_no_cap.body
-        );
     }
 
     /// The SDF crash-safety gate keys off the RENDERED row, not the stored
@@ -1991,8 +1899,8 @@ mod tests {
         );
         for mode in WireframeProjection::ALL {
             let token = match mode {
-                WireframeProjection::DropW => "drop-w",
-                WireframeProjection::WDepth => "w-depth",
+                WireframeProjection::Shadow => "shadow",
+                WireframeProjection::WPinhole => "w-pinhole",
                 WireframeProjection::Schlegel { .. } => "schlegel",
                 WireframeProjection::Stereographic => "stereographic",
                 WireframeProjection::Hyperslice => "hyperslice",
@@ -2005,11 +1913,11 @@ mod tests {
         }
         // Context-free engine projections per the documented contract.
         assert_eq!(
-            WireframeProjection::DropW.to_projection(),
+            WireframeProjection::Shadow.to_projection(),
             Projection::Identity
         );
         assert_eq!(
-            WireframeProjection::WDepth.to_projection(),
+            WireframeProjection::WPinhole.to_projection(),
             Projection::Perspective4D {
                 focal_distance: 2.0
             }
@@ -2033,64 +1941,103 @@ mod tests {
         );
     }
 
-    /// The default Stereographic pole is the unit direction `(1, 1, 1, 1)/2` and
-    /// equals (to f32 epsilon) the normalized centroid of a 16-cell cell, tying
-    /// the literal constant to the polytope's topology rather than a bare number.
-    /// If the cell-centroid derivation ever drifts from the recorded literal this
-    /// fails loudly.
+    /// Edge geometry is derived from the projection, not a control: Stereographic
+    /// always renders S3 great-circle arcs (`blend == 1`), every affine projection
+    /// renders flat R4 chords (`blend == 0`). Because the wireframe builder reads
+    /// `default_edge_blend` per frame, this can never disagree with the map, and a
+    /// reset (which touches no edge-geometry state) cannot flatten the arcs.
     #[test]
-    fn stereographic_default_pole_is_unit_cell_center() {
-        // Exactly unit by construction: 4 * 0.5^2 = 1.
+    fn edge_geometry_is_derived_from_projection() {
+        assert_eq!(default_edge_blend(WireframeProjection::Stereographic), 1.0);
+        for p in [
+            WireframeProjection::Shadow,
+            WireframeProjection::WPinhole,
+            WireframeProjection::Hyperslice,
+        ] {
+            assert_eq!(default_edge_blend(p), 0.0, "{p:?} should draw chords");
+        }
+    }
+
+    /// Selecting Stereographic turns the wireframe overlay on (its arcs are drawn
+    /// only there); every other projection leaves the toggle alone.
+    #[test]
+    fn stereographic_selection_enables_wireframe() {
+        let mut wireframe = false;
+        apply_projection_selection_defaults(WireframeProjection::Stereographic, &mut wireframe);
+        assert!(
+            wireframe,
+            "stereographic arcs require the wireframe overlay"
+        );
+
+        let mut wireframe = false;
+        apply_projection_selection_defaults(WireframeProjection::WPinhole, &mut wireframe);
+        assert!(
+            !wireframe,
+            "non-stereographic selection must not force the overlay"
+        );
+    }
+
+    /// The default Stereographic pole is the `+w` axis `(0, 0, 0, 1)`, exactly
+    /// unit. Aligning the pole with the w-slice axis is what centers the active
+    /// cells (see [`stereographic_plus_w_pole_scale_depends_only_on_w`]).
+    #[test]
+    fn stereographic_default_pole_is_plus_w() {
+        assert_eq!(STEREOGRAPHIC_DEFAULT_POLE, Vec4::W);
         assert_eq!(
             STEREOGRAPHIC_DEFAULT_POLE.length_squared(),
             1.0,
             "default pole must be exactly unit"
         );
-        // The 16-cell cell centroids are the (±½, ±½, ±½, ±½) directions; the
-        // all-positive one, normalized, is the default pole. `cell_centers`
-        // returns centroids at the inradius, so normalize before comparing.
-        let centers = Polytope4::Cell16.cell_centers();
-        let matches_a_centroid = centers
-            .iter()
-            .any(|c| (c.normalize() - STEREOGRAPHIC_DEFAULT_POLE).length() < 1e-6);
+    }
+
+    /// The centering property the `+w` pole is chosen for: the conformal scale
+    /// `1 / (1 - dot(p, pole))` reduces to `1 / (1 - p.w)`, so it depends ONLY on
+    /// `w`. Every cell sharing the cross-section's w-coordinate therefore maps to
+    /// one centered radial shell, instead of the asymmetric spread an off-w pole
+    /// (whose scale depends on `x + y + z + w`) produces. Pins that two points at
+    /// equal `w` but different `x, y, z` share an identical stereographic
+    /// denominator under the default pole, and that an off-w pole does NOT.
+    #[test]
+    fn stereographic_plus_w_pole_scale_depends_only_on_w() {
+        let pole = STEREOGRAPHIC_DEFAULT_POLE;
+        // Two unit directions at the same w = 0.6 but different x + y + z
+        // (0.8 vs 1.12), so an off-w pole can tell them apart while +w cannot.
+        // Both are exactly unit: 0.8^2 + 0.6^2 = 1 and 0.48^2 + 0.64^2 + 0.6^2 = 1.
+        let p = Vec4::new(0.8, 0.0, 0.0, 0.6);
+        let q = Vec4::new(0.0, 0.48, 0.64, 0.6);
+        assert!((p.w - q.w).abs() < 1e-6, "fixture points must share w");
+        let denom_p = 1.0 - p.dot(pole);
+        let denom_q = 1.0 - q.dot(pole);
         assert!(
-            matches_a_centroid,
-            "default pole must be a normalized 16-cell cell centroid"
+            (denom_p - denom_q).abs() < 1e-6,
+            "+w pole must give equal scale at equal w ({denom_p} vs {denom_q})"
+        );
+        // An off-w pole (a cell center) breaks the equal-w invariant, which is
+        // exactly the off-center pull the +w pole was reverted to avoid.
+        let off_w = Vec4::splat(0.5);
+        assert!(
+            (1.0 - p.dot(off_w) - (1.0 - q.dot(off_w))).abs() > 1e-3,
+            "off-w pole must spread a single w-slice (the skew we reverted)"
         );
     }
 
-    /// No 16-cell vertex sits on the default pole: every vertex direction is
-    /// strictly outside the pole-clamp band (`dot(v, pole) < 1 - eps`), so the
-    /// stereographic denominator never reaches the clamp for an axis-aligned
-    /// 16-cell at rest. Also pins the common-case sweep: a pure `xw` rotation
-    /// leaves each vertex's `y, z` fixed, and the pole has `y = z = ½`, so no
-    /// 16-cell vertex (whose `y, z` are each `0` or `±1`) can ever rotate onto it.
+    /// The accepted tradeoff: `+w` IS a 16-cell vertex (`+e_w`), so under an `xw`
+    /// rotation a vertex sweeps through the pole and flicks to infinity. Pinned
+    /// so the streak is a documented, deliberate consequence of the slice-aligned
+    /// pole, not a regression: a future "dodge the vertices" pole change would
+    /// reintroduce the off-center pull and must fail here.
     #[test]
-    fn stereographic_default_pole_is_never_a_16cell_vertex() {
-        let eps = rye_math::STEREOGRAPHIC_POLE_EPSILON;
+    fn stereographic_default_pole_is_a_16cell_vertex_by_design() {
         let pole = STEREOGRAPHIC_DEFAULT_POLE;
-        for v in Polytope4::Cell16.topology().vertices {
-            // Vertices are unit `±e_i`; dot with the pole is exactly ±½.
-            let d = v.normalize().dot(pole);
-            assert!(
-                d < 1.0 - eps,
-                "16-cell vertex {v:?} has dot {d} with the default pole, inside \
-                 the pole-clamp band"
-            );
-        }
-        // The common-case xw sweep: rotate +x through the xw plane and confirm
-        // the pole's fixed y = z = ½ keeps dot bounded away from 1 the whole way.
-        for step in 0..360 {
-            let theta = (step as f32).to_radians();
-            // xw rotation of +x: (cos, 0, 0, sin). y and z stay 0.
-            let rotated = Vec4::new(theta.cos(), 0.0, 0.0, theta.sin());
-            let d = rotated.dot(pole);
-            // Max over the sweep is cos*½ + sin*½ <= sqrt(2)/2 ~ 0.707 < 1 - eps.
-            assert!(
-                d < 1.0 - eps,
-                "xw-rotated +x at {step} deg has dot {d}, inside the clamp band"
-            );
-        }
+        let on_a_vertex = Polytope4::Cell16
+            .topology()
+            .vertices
+            .iter()
+            .any(|v| (v.normalize() - pole).length() < 1e-6);
+        assert!(
+            on_a_vertex,
+            "the slice-aligned +w pole sits on a 16-cell vertex by design"
+        );
     }
 
     /// The Hyperslice cull runs when EITHER the standalone toggle is on OR the
@@ -2242,11 +2189,58 @@ mod tests {
             let a = resolve_schlegel_params(polytope, cell_index);
             let b = resolve_schlegel_params(polytope, cell_index);
             assert_eq!(a.cell_normal, b.cell_normal, "{polytope:?} normal");
+            assert_eq!(a.cell_basis, b.cell_basis, "{polytope:?} basis");
             assert_eq!(a.cell_offset, b.cell_offset, "{polytope:?} offset");
             assert_eq!(
                 a.viewpoint_distance, b.viewpoint_distance,
                 "{polytope:?} viewpoint"
             );
+        }
+    }
+
+    /// The cached Schlegel basis is an orthonormal frame of the selected cell's
+    /// own 3-flat. This is the no-snap invariant: the frame is derived once in
+    /// canonical cell coordinates, not guessed later from a live rotated normal.
+    #[test]
+    fn schlegel_cell_basis_spans_chosen_cell() {
+        for polytope in Polytope4::ALL {
+            let cell_index = (polytope.cell_count() / 2) as u32;
+            let params = resolve_schlegel_params(polytope, cell_index);
+
+            for (i, axis) in params.cell_basis.iter().enumerate() {
+                assert!(
+                    (axis.length() - 1.0).abs() < 1e-5,
+                    "{polytope:?} basis axis {i} must be unit"
+                );
+                assert!(
+                    axis.dot(params.cell_normal).abs() < 1e-5,
+                    "{polytope:?} basis axis {i} must be in the cell plane"
+                );
+            }
+            for i in 0..3 {
+                for j in (i + 1)..3 {
+                    assert!(
+                        params.cell_basis[i].dot(params.cell_basis[j]).abs() < 1e-5,
+                        "{polytope:?} basis axes {i}/{j} must be orthogonal"
+                    );
+                }
+            }
+
+            let topo = polytope.topology();
+            let cell = topo.cells[params.cell_index as usize];
+            let anchor = topo.vertices[cell[0] as usize];
+            for &vi in cell {
+                let delta = topo.vertices[vi as usize] - anchor;
+                let reconstructed = params
+                    .cell_basis
+                    .iter()
+                    .fold(Vec4::ZERO, |acc, &axis| acc + delta.dot(axis) * axis);
+                let residual = delta - reconstructed;
+                assert!(
+                    residual.length() < 5e-4,
+                    "{polytope:?} cell vertex {vi} must reconstruct in the basis"
+                );
+            }
         }
     }
 
@@ -2258,7 +2252,7 @@ mod tests {
     /// if its normal rotates with the body. Verified at the math level (the rotor
     /// apply) since `Demo::resolved_wireframe_projection` needs a GPU-backed `Demo`.
     #[test]
-    fn schlegel_normal_rotates_with_body() {
+    fn schlegel_frame_rotates_with_body() {
         let polytope = Polytope4::Tesseract;
         let cell_index = 0;
         let params = resolve_schlegel_params(polytope, cell_index);
@@ -2273,12 +2267,22 @@ mod tests {
         // Rotation preserves unit length, so the rotated normal is still a valid
         // outward unit normal for the engine `Projection::Schlegel`.
         assert!((rotated.length() - 1.0).abs() < 1e-5);
+        let rotated_basis = params.cell_basis.map(|axis| rot.apply(axis));
+        for (i, axis) in rotated_basis.iter().enumerate() {
+            assert!((axis.length() - 1.0).abs() < 1e-5, "axis {i} unit");
+            assert!(
+                axis.dot(rotated).abs() < 1e-5,
+                "axis {i} remains perpendicular to the rotated normal"
+            );
+        }
         // And it equals the body's own rotation of every chosen-cell vertex's
         // direction: a chosen-cell vertex `v` has `dot(canonical_normal, v) =
         // cell_offset`; after rotating both, `dot(rotated_normal, rot.apply(v))`
         // must still equal `cell_offset` (the cell stays on its hyperplane).
         let topo = polytope.topology();
         let cell = topo.cells[cell_index as usize];
+        let anchor = topo.vertices[cell[0] as usize];
+        let rotated_anchor = rot.apply(anchor);
         for &vi in cell {
             let v = topo.vertices[vi as usize];
             let lhs = rotated.dot(rot.apply(v));
@@ -2287,6 +2291,16 @@ mod tests {
                 "rotated cell vertex must stay on the rotated boundary hyperplane: {lhs} vs {}",
                 params.cell_offset
             );
+            let delta = v - anchor;
+            let rotated_delta = rot.apply(v) - rotated_anchor;
+            for (axis, rotated_axis) in params.cell_basis.iter().zip(rotated_basis) {
+                let want = delta.dot(*axis);
+                let got = rotated_delta.dot(rotated_axis);
+                assert!(
+                    (got - want).abs() < 1e-5,
+                    "rotated basis coordinates must match canonical coordinates"
+                );
+            }
         }
     }
 
@@ -2424,11 +2438,7 @@ mod tests {
                 focal_distance: 2.0,
             },
             Projection::Stereographic { pole: Vec4::W },
-            Projection::Schlegel {
-                cell_normal: Vec4::W,
-                cell_offset: 0.5,
-                viewpoint_distance: 0.75,
-            },
+            Projection::schlegel(Vec4::W, 0.5, 0.75),
         ];
         for active in actives {
             // Honest layer: drop-w no matter what the active projection is.

--- a/crates/polytope_playground/src/ui.rs
+++ b/crates/polytope_playground/src/ui.rs
@@ -17,17 +17,57 @@ use rye_math::Rotor4;
 
 use crate::consts::{CONTROL_H, CONTROL_W, PLAY_PAUSE_W};
 use crate::state::{
-    DeferredAction, Demo, RotationMode, RotorTerm, SurfaceMode, ViewMode, WireframeColorMode,
-    WireframeProjection,
+    hyperslice_cull_active, DeferredAction, Demo, RotationMode, RotorTerm, SectionLayer,
+    SurfaceMode, ViewMode, WireframeColorMode, WireframeProjection,
 };
+
+/// Render one [`SectionLayer`]'s controls: a perimeter-outline checkbox and a
+/// fill-alpha slider whose `0` end is the layer's off state. `title` names the
+/// layer; `tooltip` explains what it shows. The perimeter outline only draws in
+/// the wireframe overlay, so its checkbox tooltip says so and notes that the
+/// overlay must be on (the fill draws in Raster mode regardless).
+///
+/// Free function (not an `impl Demo` method) so it can take a `&mut SectionLayer`
+/// destructured out of `Demo` in the render-panel closure without re-borrowing
+/// the whole `Demo`.
+fn section_layer_controls(
+    ui: &mut egui::Ui,
+    title: &str,
+    tooltip: &str,
+    layer: &mut SectionLayer,
+    wireframe_enabled: bool,
+) {
+    ui.label(egui::RichText::new(title).italics())
+        .on_hover_text(tooltip);
+    let perimeter_resp = ui
+        .checkbox(&mut layer.perimeter, "Perimeter outline")
+        .on_hover_text(
+            "Cap-boundary outline. Draws in the wireframe overlay, so enable Wireframe to see it.",
+        );
+    if layer.perimeter && !wireframe_enabled {
+        perimeter_resp
+            .on_hover_text("Wireframe overlay is off, so the outline is not currently drawn.");
+    }
+    ui.horizontal(|ui| {
+        ui.label("Fill alpha");
+        // 0 is the off state; the slider spans the full [0, 1] so the user can
+        // drag a layer off or to any visible opacity. The fill draws in Raster
+        // surface mode; below 1.0 it composites through the no-depth-write
+        // pipeline so layers behind show through.
+        ui.add(egui::Slider::new(&mut layer.surface_alpha, 0.0..=1.0).fixed_decimals(2))
+            .on_hover_text("0 = off; below 1.0 composites translucently over the layers behind");
+    });
+}
 
 impl Demo {
     /// Expanded section of the bottom overlay. Two tab rows
     /// stacked vertically:
     ///
-    /// 1. **View tabs** (Shapes / Filmstrip): top-level visual
-    ///    demo. Shapes shows the multi-shape row; Filmstrip
-    ///    shows one shape across N w-slices.
+    /// 1. **View tabs** (Shapes / Single / Filmstrip): top-level
+    ///    visual demo. Shapes shows the multi-shape row; Single
+    ///    shows one subject with the full projection stack (the
+    ///    mode Schlegel's cell-index needs); Filmstrip shows one
+    ///    shape across N w-slices.
     /// 2. **Rotation tabs** (Active set / Composer): how the
     ///    rotor evolves. Independent of view mode.
     ///
@@ -37,6 +77,7 @@ impl Demo {
         self.render_view_tab_row(ui);
         match self.view_mode {
             ViewMode::Shapes => self.render_shapes_section(ui),
+            ViewMode::Single => self.render_single_body(ui),
             ViewMode::Filmstrip => self.render_filmstrip_body(ui),
         }
         ui.separator();
@@ -49,15 +90,22 @@ impl Demo {
     }
 
     /// Top tab row of the expanded body: visual demo selector.
-    /// Shapes (multi-shape side-by-side row) vs Filmstrip (one
-    /// shape across multiple w-slices). Tab change is staged
-    /// into `pending_view_mode` for the same `BottomOverlay`
-    /// two-pass reason as `pending_mode`.
+    /// Shapes (multi-shape side-by-side row), Single (one subject
+    /// with the full projection stack), Filmstrip (one shape
+    /// across multiple w-slices). Tab change is staged into
+    /// `pending_view_mode` for the same `BottomOverlay` two-pass
+    /// reason as `pending_mode`.
     pub(crate) fn render_view_tab_row(&mut self, ui: &mut egui::Ui) {
         let mut staged = self.view_mode;
         ui.horizontal(|ui| {
             ui.selectable_value(&mut staged, ViewMode::Shapes, "Shapes")
                 .on_hover_text("Side-by-side row of shapes at one w-slice");
+            ui.selectable_value(&mut staged, ViewMode::Single, "Single")
+                .on_hover_text(
+                    "One subject (the picker below) at one w-slice with the full \
+                     surface / wireframe / projection stack. Schlegel's boundary-cell \
+                     selection needs this unambiguous single shape.",
+                );
             ui.selectable_value(&mut staged, ViewMode::Filmstrip, "Filmstrip")
                 .on_hover_text(
                     "One shape rendered N times across w-slices fanning out by \
@@ -118,6 +166,12 @@ impl Demo {
                     ui.checkbox(&mut self.show_controls, "Rotation controls (H)");
                     ui.checkbox(&mut self.show_formula, "Formula popup");
                     ui.checkbox(&mut self.example_callout.open, "Example callout");
+                    ui.checkbox(&mut self.mode_annotation_open.open, "Mode annotation")
+                        .on_hover_text(
+                            "Floating note explaining the active projection / space \
+                             mode. Appears only for a non-default projection or with \
+                             Curvature turned up.",
+                        );
                     ui.separator();
                     // One-shot action: opens the About window and the menu should fold
                     // away. `Popup::close_all(ctx)` cooperates with the sticky-popup
@@ -146,20 +200,32 @@ impl Demo {
         // inside the closure would need `&mut self` while `&mut self.show_render_panel`
         // is still active.
         let prev_surface = self.surface_mode;
+        // Snapshot the projection so we can detect a Schlegel select / cell-index
+        // change after the panel's borrow ends and re-resolve the cache (the same
+        // deferred-mutation shape `prev_surface` uses for `rebuild_bodies`).
+        let prev_projection = self.wireframe_projection;
         // Computed BEFORE the destructure so the closure can read it as a captured value
         // (the destructure exclusively borrows `self.row`).
         let sdf_disabled = self.sdf_blocked_by_heavy_polychora();
+        // Cell count of the polytope a Schlegel cell index refers to (the leading
+        // polychoron). Captured for the cell-index DragValue's clamp. `None` when
+        // the row has no polychoron, in which case the stepper is disabled.
+        let schlegel_cell_count = self.schlegel_subject().map(|p| p.cell_count() as u32);
         // Destructure-borrow the fields the panel writes so the closure doesn't capture
         // a whole `&mut self`. This sidesteps the borrow conflict with `show_render_panel`
         // and lets the closure remain a plain `FnOnce(&mut Ui)`.
         let Self {
             show_render_panel,
             surface_mode,
+            cross_section,
+            projected_cap,
             wireframe_enabled,
-            wireframe_perimeter,
             wireframe_nearest_active,
             wireframe_color_mode,
             wireframe_projection,
+            wireframe_hyperslice,
+            wireframe_hyperslice_thickness,
+            space_blend,
             points_enabled,
             points_show_vertices,
             points_show_cell_centers,
@@ -191,10 +257,37 @@ impl Demo {
                 ui.radio_value(surface_mode, SurfaceMode::Off, "Off");
                 ui.separator();
 
+                // Cross-section layers. The slice renders as two overlaid layers
+                // in one viewport: the HONEST cross-section (drop-w, never
+                // reprojected; what the SDF shows) and the PROJECTED cap (the
+                // slice reprojected through the active wireframe projection). Each
+                // has its own perimeter outline + fill alpha. Fills draw in Raster
+                // mode; perimeter outlines draw in the wireframe overlay, so they
+                // gate on `wireframe_enabled` and the tooltips say so.
+                ui.label(egui::RichText::new("Cross-section").strong());
+                section_layer_controls(
+                    ui,
+                    "Honest (drop-w)",
+                    "The drop-w slice, never reprojected: the geometry the SDF \
+                     shows. On by default so a projection change never distorts \
+                     the slice.",
+                    cross_section,
+                    *wireframe_enabled,
+                );
+                section_layer_controls(
+                    ui,
+                    "Projected cap",
+                    "The same slice reprojected through the active wireframe \
+                     projection, so it can sit on a Schlegel / stereographic \
+                     wireframe. Off by default.",
+                    projected_cap,
+                    *wireframe_enabled,
+                );
+                ui.separator();
+
                 ui.label(egui::RichText::new("Wireframe").strong());
                 ui.checkbox(wireframe_enabled, "Enabled");
                 ui.add_enabled_ui(*wireframe_enabled, |ui| {
-                    ui.checkbox(wireframe_perimeter, "Section perimeter (cyan)");
                     ui.checkbox(wireframe_nearest_active, "Nearest-active gradient");
                     ui.horizontal(|ui| {
                         ui.label("Color");
@@ -204,13 +297,102 @@ impl Demo {
                     });
                     ui.horizontal(|ui| {
                         ui.label("Projection");
-                        ui.radio_value(wireframe_projection, WireframeProjection::DropW, "Drop-w");
-                        ui.radio_value(
-                            wireframe_projection,
-                            WireframeProjection::WDepth,
-                            "W-depth",
-                        );
+                        for mode in WireframeProjection::ALL {
+                            // Compare by VARIANT, not full `PartialEq`: a Schlegel
+                            // cell-index change must keep the Schlegel button
+                            // selected. Selecting Schlegel preserves the current
+                            // cell index (the contextual stepper below owns it).
+                            let selected = wireframe_projection.same_variant(mode);
+                            if ui.radio(selected, mode.label()).clicked() && !selected {
+                                *wireframe_projection = match (mode, *wireframe_projection) {
+                                    (
+                                        WireframeProjection::Schlegel { .. },
+                                        WireframeProjection::Schlegel { cell_index },
+                                    ) => WireframeProjection::Schlegel { cell_index },
+                                    (m, _) => m,
+                                };
+                            }
+                        }
                     });
+                    // Contextual parameter row: only the active mode's knob shows.
+                    // Schlegel -> cell-index stepper (clamped to the leading
+                    // polytope's cell count). Other modes need no contextual
+                    // param; Hyperslice's slab width lives with the cull toggle
+                    // below, so it is not duplicated here.
+                    if let WireframeProjection::Schlegel { cell_index } = wireframe_projection {
+                        ui.horizontal(|ui| {
+                            ui.label("Boundary cell");
+                            match schlegel_cell_count {
+                                Some(count) => {
+                                    ui.add(
+                                        egui::DragValue::new(cell_index)
+                                            .range(0..=count - 1)
+                                            .speed(0.25),
+                                    );
+                                    ui.label(format!("of {count}"));
+                                }
+                                None => {
+                                    ui.add_enabled(false, egui::DragValue::new(cell_index))
+                                        .on_disabled_hover_text(
+                                            "No polychoron in the row to project",
+                                        );
+                                }
+                            }
+                        });
+                    }
+                    // Hyperslice cull: thin the edge graph to a w-slab around the
+                    // current slice. The thickness stepper is enabled whenever the
+                    // cull is running, which includes the Hyperslice PROJECTION
+                    // mode (it resolves to drop-w and turns the cull on without the
+                    // standalone toggle). Gating on the toggle alone left the slab
+                    // width greyed out under that projection even though the cull
+                    // was active.
+                    ui.checkbox(wireframe_hyperslice, "Hyperslice cull (w-slab)");
+                    let cull_active =
+                        hyperslice_cull_active(*wireframe_hyperslice, *wireframe_projection);
+                    ui.add_enabled_ui(cull_active, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Slab width");
+                            ui.add(
+                                egui::DragValue::new(wireframe_hyperslice_thickness)
+                                    .range(
+                                        crate::consts::HYPERSLICE_MIN_THICKNESS
+                                            ..=2.0 * crate::consts::W_RANGE,
+                                    )
+                                    .speed(0.01),
+                            );
+                        });
+                    });
+                });
+                // Curvature is a DIFFERENT axis from Projection above. The
+                // Projection radio picks the 4D->R³ map (where a vertex lands
+                // on screen); Curvature morphs the EDGE GEOMETRY between a flat
+                // R⁴ chord and an S³ great-circle arc (whether the line between
+                // two landed vertices is straight or bowed). They compose, but
+                // conflating them confuses, so the slider sits in its own
+                // separator-delimited group below the projection knob. Writes
+                // the same `space_blend` field the `wireframe space` /
+                // top-level `space` console command drives, clamped to [0, 1].
+                //
+                // Deliberately OUTSIDE the `wireframe_enabled` enable-gate the
+                // other wireframe controls sit in: the morph is only visible in
+                // the wireframe layer, but gating the slider behind that toggle
+                // is the same dead-end the bare `space spherical` command had
+                // (mutate a field nothing draws). A user reaching for the
+                // Curvature slider IS asking to see curved edges, so dragging it
+                // above zero auto-enables the wireframe, mirroring the console
+                // handler. Holding it at zero never flips the overlay on.
+                ui.separator();
+                ui.label(egui::RichText::new("Curvature (flat <-> spherical)").strong());
+                ui.horizontal(|ui| {
+                    ui.label("Blend");
+                    if ui
+                        .add(egui::Slider::new(space_blend, 0.0..=1.0).fixed_decimals(2))
+                        .changed()
+                        && *space_blend > 0.0
+                    {
+                        *wireframe_enabled = true;
+                    }
                 });
                 ui.separator();
 
@@ -236,6 +418,14 @@ impl Demo {
         // stays in sync with the new mode (`BodyKind::Invalid` for inert polychora).
         if self.surface_mode != prev_surface {
             self.rebuild_bodies();
+        }
+        // Re-resolve the cached Schlegel face-plane params if the user changed the
+        // projection mode or dragged the cell-index stepper through the panel.
+        // Deferred to here (same shape as the surface-mode rebuild) because the
+        // resolve runs the LazyLock cell-table fit on first access and must not be
+        // called inside the destructure-borrowed closure (it needs `&mut self`).
+        if self.wireframe_projection != prev_projection {
+            self.resolve_schlegel_cache();
         }
     }
 
@@ -368,6 +558,13 @@ impl Demo {
 
         let default_bottom_centre = egui::pos2(screen.center().x, screen.bottom() - pad);
 
+        // Snapshot the single-view subject so a change made through the Single
+        // body's picker this frame can trigger the same body-rebuild + Schlegel
+        // re-resolve a row edit does (the subject IS the rendered row in Single
+        // mode, so changing it changes which polychoron the diagram projects
+        // through and its cell count). Compared after the deferred-apply block.
+        let prev_strip_subject = self.strip_subject;
+
         egui::Window::new("polytope-playground-overlay")
             .id(egui::Id::new("polytope-playground-overlay"))
             .title_bar(false)
@@ -397,6 +594,15 @@ impl Demo {
         }
         if let Some(new_view) = self.pending_view_mode.take() {
             self.view_mode = new_view;
+            // The rendered row changes with the view mode (full row in Shapes,
+            // the lone `strip_subject` in Single), so re-emit the SDF body slots
+            // and re-resolve the Schlegel cache: the leading polychoron (and its
+            // cell count) the diagram projects through can differ between the row
+            // and the single subject. Filmstrip re-uploads its own per-cell
+            // bodies during render and restores the row after, so this rebuild is
+            // harmless there too.
+            self.rebuild_bodies();
+            self.resolve_schlegel_cache();
         }
         for action in std::mem::take(&mut self.pending_actions) {
             match action {
@@ -413,6 +619,14 @@ impl Demo {
                 DeferredAction::DraftClear => self.draft.clear(),
                 DeferredAction::SeqPushTerm(term) => self.seq.push(term),
             }
+        }
+        // A Single-view subject change is a render-row change: re-emit the SDF
+        // body slots and re-resolve the Schlegel cache against the new subject's
+        // topology. Gated on `Single` so picking a filmstrip subject (which does
+        // not change the Schlegel-relevant row) skips the work.
+        if self.view_mode == ViewMode::Single && self.strip_subject != prev_strip_subject {
+            self.rebuild_bodies();
+            self.resolve_schlegel_cache();
         }
     }
 

--- a/crates/polytope_playground/src/ui.rs
+++ b/crates/polytope_playground/src/ui.rs
@@ -17,8 +17,9 @@ use rye_math::Rotor4;
 
 use crate::consts::{CONTROL_H, CONTROL_W, PLAY_PAUSE_W};
 use crate::state::{
-    hyperslice_cull_active, DeferredAction, Demo, RotationMode, RotorTerm, SectionLayer,
-    SurfaceMode, ViewMode, WireframeColorMode, WireframeProjection,
+    apply_projection_selection_defaults, hyperslice_cull_active, DeferredAction, Demo,
+    RotationMode, RotorTerm, SectionLayer, SurfaceMode, ViewMode, WireframeColorMode,
+    WireframeProjection,
 };
 
 /// Render one [`SectionLayer`]'s controls: a perimeter-outline checkbox and a
@@ -168,9 +169,8 @@ impl Demo {
                     ui.checkbox(&mut self.example_callout.open, "Example callout");
                     ui.checkbox(&mut self.mode_annotation_open.open, "Mode annotation")
                         .on_hover_text(
-                            "Floating note explaining the active projection / space \
-                             mode. Appears only for a non-default projection or with \
-                             Curvature turned up.",
+                            "Floating note explaining the active projection. Appears \
+                             only for a non-default projection.",
                         );
                     ui.separator();
                     // One-shot action: opens the About window and the menu should fold
@@ -225,7 +225,6 @@ impl Demo {
             wireframe_projection,
             wireframe_hyperslice,
             wireframe_hyperslice_thickness,
-            space_blend,
             points_enabled,
             points_show_vertices,
             points_show_cell_centers,
@@ -304,13 +303,15 @@ impl Demo {
                             // cell index (the contextual stepper below owns it).
                             let selected = wireframe_projection.same_variant(mode);
                             if ui.radio(selected, mode.label()).clicked() && !selected {
-                                *wireframe_projection = match (mode, *wireframe_projection) {
+                                let next = match (mode, *wireframe_projection) {
                                     (
                                         WireframeProjection::Schlegel { .. },
                                         WireframeProjection::Schlegel { cell_index },
                                     ) => WireframeProjection::Schlegel { cell_index },
                                     (m, _) => m,
                                 };
+                                *wireframe_projection = next;
+                                apply_projection_selection_defaults(next, wireframe_enabled);
                             }
                         }
                     });
@@ -363,36 +364,6 @@ impl Demo {
                             );
                         });
                     });
-                });
-                // Curvature is a DIFFERENT axis from Projection above. The
-                // Projection radio picks the 4D->R³ map (where a vertex lands
-                // on screen); Curvature morphs the EDGE GEOMETRY between a flat
-                // R⁴ chord and an S³ great-circle arc (whether the line between
-                // two landed vertices is straight or bowed). They compose, but
-                // conflating them confuses, so the slider sits in its own
-                // separator-delimited group below the projection knob. Writes
-                // the same `space_blend` field the `wireframe space` /
-                // top-level `space` console command drives, clamped to [0, 1].
-                //
-                // Deliberately OUTSIDE the `wireframe_enabled` enable-gate the
-                // other wireframe controls sit in: the morph is only visible in
-                // the wireframe layer, but gating the slider behind that toggle
-                // is the same dead-end the bare `space spherical` command had
-                // (mutate a field nothing draws). A user reaching for the
-                // Curvature slider IS asking to see curved edges, so dragging it
-                // above zero auto-enables the wireframe, mirroring the console
-                // handler. Holding it at zero never flips the overlay on.
-                ui.separator();
-                ui.label(egui::RichText::new("Curvature (flat <-> spherical)").strong());
-                ui.horizontal(|ui| {
-                    ui.label("Blend");
-                    if ui
-                        .add(egui::Slider::new(space_blend, 0.0..=1.0).fixed_decimals(2))
-                        .changed()
-                        && *space_blend > 0.0
-                    {
-                        *wireframe_enabled = true;
-                    }
                 });
                 ui.separator();
 

--- a/crates/rye-camera/src/controller.rs
+++ b/crates/rye-camera/src/controller.rs
@@ -21,7 +21,11 @@ use crate::Camera;
 const ORBIT_RADIANS_PER_PIXEL: f32 = 0.006;
 const ZOOM_LOG_STEP: f32 = 0.12;
 const MIN_DISTANCE: f32 = 1.5;
-const MAX_DISTANCE: f32 = 8.0;
+// Zoom-out ceiling, raised from the original 8 so a caller can pull back to
+// frame a larger 4D shape (e.g. the polytope_playground 120-cell). Held at 20
+// rather than further out because the scene fog washes out geometry beyond
+// roughly that range, so additional zoom buys nothing.
+const MAX_DISTANCE: f32 = 20.0;
 const INITIAL_HEIGHT: f32 = 0.6;
 const INITIAL_RADIUS: f32 = 3.5;
 const MIN_ORBIT_PITCH: f32 = -1.45;

--- a/crates/rye-egui/src/console/mod.rs
+++ b/crates/rye-egui/src/console/mod.rs
@@ -154,7 +154,11 @@ pub struct ConsoleWriter {
 }
 
 impl ConsoleWriter {
-    fn new() -> Self {
+    /// An empty writer. The console builds one per `execute` and drains it into
+    /// scrollback; exposed `pub` so command handlers can be unit-tested in
+    /// isolation (run the handler against a fresh writer, inspect the field it
+    /// mutated) without standing up a full `Console` and `Ctx`.
+    pub fn new() -> Self {
         Self { lines: Vec::new() }
     }
 
@@ -167,6 +171,12 @@ impl ConsoleWriter {
     /// bubble unrecoverable errors via `Result` instead.
     pub fn error(&mut self, text: impl Into<String>) {
         self.lines.push(HistoryLine::error(text));
+    }
+}
+
+impl Default for ConsoleWriter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/rye-math/src/lib.rs
+++ b/crates/rye-math/src/lib.rs
@@ -33,6 +33,7 @@ pub mod rasterizable;
 pub mod sectionable;
 pub mod space;
 pub mod spherical;
+pub mod spherical_embedded;
 pub mod tangent;
 
 pub use bivector::{
@@ -43,10 +44,11 @@ pub use euclidean::{EuclideanR3, Iso3};
 pub use euclidean_r2::{EuclideanR2, Iso2};
 pub use euclidean_r4::{EuclideanR4, Iso4Flat};
 pub use hyperbolic::{HyperbolicH3, Iso3H};
-pub use rasterizable::{Projection, RasterizableSpace};
+pub use rasterizable::{Projection, RasterizableSpace, STEREOGRAPHIC_POLE_EPSILON};
 pub use sectionable::{
     SectionableSpace, WPlane, EDGE_PARALLEL_EPSILON, SLICE_PERTURBATION_EPSILON,
 };
 pub use space::{Space, WgslSpace};
 pub use spherical::{Iso4, SphericalS3};
+pub use spherical_embedded::SphericalS3Embedded;
 pub use tangent::Tangent;

--- a/crates/rye-math/src/rasterizable.rs
+++ b/crates/rye-math/src/rasterizable.rs
@@ -249,19 +249,11 @@ pub enum Projection<const N: usize> {
     /// `result = E + t * (p - E)`.
     ///
     /// `result` lands in the 3-flat perpendicular to `cell_normal`; the readout expresses it
-    /// in an orthonormal basis of that 3-flat (Gram-Schmidt against `n`), not by dropping the
-    /// w-coordinate. A naive w-drop is exact only for a w-aligned `n`; for any other cell
-    /// normal it is an oblique projection that flattens the chosen boundary cell (its `+n`
-    /// vertex collapses toward the origin) and breaks the nesting, so the 5-cell, 16-cell,
-    /// 24-cell, 120-cell, and 600-cell would all render as degenerate diagrams. The frame is a
-    /// function of `n` alone, so it is identical across the polytope's vertices within one
-    /// Schlegel projection, but [`RasterizableSpace::project_point`] rebuilds it on every call,
-    /// which is once per vertex (per tessellation sample) in the upload path. The rebuild is a
-    /// few f32 ops with no allocation; it is left in the per-vertex path until Schlegel is
-    /// wired into the demo and the redundancy is measured, at which point the frame should be
-    /// resolved once per projection (see `perp_frame`). The frame's in-3-flat orientation
-    /// (which way is "up" in the diagram) is arbitrary but deterministic in `n`, which is all a
-    /// wireframe needs.
+    /// in the supplied orthonormal `basis` for that 3-flat, not by dropping the w-coordinate.
+    /// A naive w-drop is exact only for a w-aligned `n`; for any other cell normal it is an
+    /// oblique projection that flattens the chosen boundary cell. The basis is part of the
+    /// projection because its in-flat gauge is visible: a basis rebuilt from the live normal
+    /// can snap during rotation when a "drop one axis" construction crosses a tie.
     ///
     /// **Precondition: `cell_normal` is the *outward* unit normal and
     /// `viewpoint_distance > cell_offset`.** With the inward normal the diagram fails to nest
@@ -283,6 +275,8 @@ pub enum Projection<const N: usize> {
         /// Eye distance along `cell_normal` from the origin; must exceed `cell_offset` so the
         /// viewpoint sits just outside the chosen cell.
         viewpoint_distance: f32,
+        /// Orthonormal readout basis spanning the chosen cell's 3-flat.
+        basis: [Vec4; 3],
     },
 
     /// Stereographic projection of the unit 3-sphere S³ onto R³ from a chosen `pole` (a unit
@@ -335,6 +329,29 @@ pub enum Projection<const N: usize> {
         /// actually selects lives in the demo layer (this map stays pole-agnostic).
         pole: Vec4,
     },
+}
+
+impl Projection<4> {
+    /// Build a Schlegel projection with the deterministic normal-only basis.
+    pub fn schlegel(cell_normal: Vec4, cell_offset: f32, viewpoint_distance: f32) -> Projection<4> {
+        let (e1, e2, e3) = perp_frame(cell_normal);
+        Self::schlegel_with_basis(cell_normal, cell_offset, viewpoint_distance, [e1, e2, e3])
+    }
+
+    /// Build a Schlegel projection with an explicit 3-flat readout basis.
+    pub fn schlegel_with_basis(
+        cell_normal: Vec4,
+        cell_offset: f32,
+        viewpoint_distance: f32,
+        basis: [Vec4; 3],
+    ) -> Projection<4> {
+        Projection::Schlegel {
+            cell_normal,
+            cell_offset,
+            viewpoint_distance,
+            basis,
+        }
+    }
 }
 
 /// A flat or curved space that can drive the rasterizer pipeline: provides projection from its
@@ -447,6 +464,7 @@ impl RasterizableSpace<4> for EuclideanR4 {
                 cell_normal,
                 cell_offset,
                 viewpoint_distance,
+                basis,
             } => {
                 // Central projection from the eye `E = viewpoint_distance * n` through the
                 // vertex `point` onto the chosen cell's 3-flat `{x : dot(n, x) = cell_offset}`
@@ -470,20 +488,15 @@ impl RasterizableSpace<4> for EuclideanR4 {
                 };
                 let t = (*cell_offset - n_dot_eye) / denom;
                 let result = eye + t * (point - eye);
-                // Read `result` out in an orthonormal frame of the cell's 3-flat (perpendicular
-                // to `n`), not by dropping the w-coordinate. The drop-w shortcut is exact only
-                // for a w-aligned `n`; for any other cell normal it obliquely flattens the
-                // chosen boundary cell (its `+n` vertex collapses toward the origin) and the
-                // diagram stops nesting. The frame depends on `n` alone and is rebuilt per call
-                // (per vertex); see `perp_frame` for why that recompute is left un-hoisted.
-                let (e1, e2, e3) = perp_frame(n);
+                // Read in the caller-supplied frame so interactive Schlegel diagrams keep a
+                // stable in-flat orientation while the body rotates.
+                let [e1, e2, e3] = *basis;
                 Vec3::new(result.dot(e1), result.dot(e2), result.dot(e3))
             }
             Projection::Stereographic { pole } => {
-                // Stereographic is only defined on the unit sphere, but vertices fed through the
-                // demo are `body_size`-scaled rather than unit, so normalize onto S³ first; the
-                // normalize is the precondition guard. `stereographic_to_r3` then applies the
-                // conformal map with the pole-denominator clamp.
+                // Stereographic is only defined on the unit sphere, but demo
+                // vertices are body-scaled. Normalize onto S3 first, then apply
+                // the conformal map with the pole-denominator clamp.
                 stereographic_to_r3(point.normalize(), *pole)
             }
         }
@@ -505,13 +518,13 @@ mod tests {
     use crate::SphericalS3Embedded;
     use approx::assert_relative_eq;
 
-    /// Golden Vec3 for `stereographic_frame_is_deterministic_under_tie`. Hand-derived from the
-    /// deterministic `perp_frame` construction for the pole `(0,0,1,1)/√2` and the unit input
-    /// `(0.5, 0.5, -0.5, 0.5)`: the z/w max-magnitude tie resolves to dropping z (the earlier
-    /// index in the `==` ladder), giving the frame `(X, Y, (0,0,-1,1)/√2)`; with `dot(p, pole)
-    /// = 0` the readout is `(0.5, 0.5, 1/√2)`. A future change to the tie-break or Gram-Schmidt
-    /// order that flips the gauge changes this value and the test catches it.
-    /// `1/√2` is the `FRAC_1_SQRT_2` constant, not a bare literal.
+    /// Golden Vec3 for `stereographic_frame_is_deterministic_under_tie`.
+    /// Hand-derived from `perp_frame` for pole `(0,0,1,1)/sqrt(2)` and input
+    /// `(0.5, 0.5, -0.5, 0.5)`: the z/w tie drops z, giving the frame
+    /// `(X, Y, (0,0,-1,1)/sqrt(2))`. With `dot(p, pole) = 0`, the readout is
+    /// `(0.5, 0.5, 1/sqrt(2))`. A future tie-break or Gram-Schmidt change that
+    /// flips the gauge changes this value and the test catches it.
+    /// `1/sqrt(2)` is `FRAC_1_SQRT_2`, not a bare literal.
     const GOLDEN_TIE_FRAME: Vec3 = Vec3::new(0.5, 0.5, std::f32::consts::FRAC_1_SQRT_2);
 
     /// `point_to_array` is the inverse of `array_to_point` on `EuclideanR3` for any input.
@@ -696,8 +709,9 @@ mod tests {
         let far = Vec4::new(0.5, 0.5, 0.5, -0.5);
         let pn = <EuclideanR4 as RasterizableSpace<4>>::project_point(near, &proj);
         let pf = <EuclideanR4 as RasterizableSpace<4>>::project_point(far, &proj);
-        // Scale at w=+0.5 is `2 / (2 - 0.5) = 4/3`; at w=-0.5 is `2 / 2.5 = 4/5`. Each R³
-        // component scales by the same factor, so the ratio of magnitudes is `(4/3)/(4/5) = 5/3`.
+        // Scale at w=+0.5 is `2 / (2 - 0.5) = 4/3`; at w=-0.5 it is
+        // `2 / 2.5 = 4/5`. Each R3 component scales by the same factor, so
+        // the magnitude ratio is `(4/3)/(4/5) = 5/3`.
         let r_near = (pn.length() / 0.5_f32.mul_add(3.0_f32.sqrt(), 0.0)).abs(); // |near|/|input|
         let r_far = (pf.length() / 0.5_f32.mul_add(3.0_f32.sqrt(), 0.0)).abs();
         assert!((r_near - 4.0 / 3.0).abs() < 1e-5, "near scale {r_near}");
@@ -770,11 +784,7 @@ mod tests {
     #[test]
     fn schlegel_chosen_cell_renders_undistorted() {
         let cell_offset = 0.5;
-        let proj = Projection::Schlegel {
-            cell_normal: Vec4::W,
-            cell_offset,
-            viewpoint_distance: 1.5 * cell_offset,
-        };
+        let proj = Projection::schlegel(Vec4::W, cell_offset, 1.5 * cell_offset);
         // The eight vertices of the `w = +0.5` cell (the first half of TESSERACT_VERTS).
         let cell: Vec<Vec4> = TESSERACT_VERTS.iter().take(8).copied().collect();
         let projected: Vec<Vec3> = cell
@@ -819,11 +829,7 @@ mod tests {
         let centroid = (Vec4::X + Vec4::Y + Vec4::Z + Vec4::W) / 4.0;
         let cell_offset = centroid.length();
         let cell_normal = centroid / cell_offset;
-        let proj = Projection::Schlegel {
-            cell_normal,
-            cell_offset,
-            viewpoint_distance: 1.5 * cell_offset,
-        };
+        let proj = Projection::schlegel(cell_normal, cell_offset, 1.5 * cell_offset);
         // The four chosen-cell vertices (the +axes) are the boundary; the four -axes nest.
         let boundary = [Vec4::X, Vec4::Y, Vec4::Z, Vec4::W];
         let inner = [-Vec4::X, -Vec4::Y, -Vec4::Z, -Vec4::W];
@@ -847,10 +853,10 @@ mod tests {
                 "every nested vertex must sit inside the boundary, inner {inner_r:?} vs {r0}"
             );
         }
-        // Directly pin the oblique-normal isometry (the case this divergence from spec exists
-        // to fix): the four boundary +axes are mutually equidistant at `sqrt(2)`, and each lies
-        // on the cell hyperplane (`t = 1`, projects to itself), so the orthonormal-frame readout
-        // must preserve every pairwise distance. A naive oblique drop-w would not.
+        // Directly pin the oblique-normal isometry. The four boundary +axes are
+        // mutually equidistant at `sqrt(2)`, and each lies on the cell hyperplane
+        // (`t = 1`, projects to itself), so the orthonormal-frame readout must
+        // preserve every pairwise distance. A naive oblique drop-w would not.
         let proj_boundary: Vec<Vec3> = boundary.iter().map(|&v| proj_pt(v)).collect();
         let edge_len = 2.0_f32.sqrt();
         for i in 0..proj_boundary.len() {
@@ -882,6 +888,22 @@ mod tests {
         }
     }
 
+    /// Schlegel readout uses the supplied basis, not a rebuilt normal-only frame.
+    /// The point lies on the chosen boundary cell, so central projection returns
+    /// it unchanged and only the basis ordering can affect the R3 coordinates.
+    #[test]
+    fn schlegel_uses_supplied_basis_for_readout() {
+        let p = Vec4::new(0.5, -0.25, 0.125, 0.5);
+        let xyz = Projection::schlegel_with_basis(Vec4::W, 0.5, 0.75, [Vec4::X, Vec4::Y, Vec4::Z]);
+        let yxz = Projection::schlegel_with_basis(Vec4::W, 0.5, 0.75, [Vec4::Y, Vec4::X, Vec4::Z]);
+
+        let a = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &xyz);
+        let b = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &yxz);
+
+        assert_eq!(a, Vec3::new(0.5, -0.25, 0.125));
+        assert_eq!(b, Vec3::new(-0.25, 0.5, 0.125));
+    }
+
     /// Every tesseract vertex projects to an all-finite R³ point under the default viewpoint
     /// (`viewpoint_distance = 1.5 * cell_offset`). The viewpoint clears the chosen cell, so no
     /// vertex sits on the viewer 3-flat and the denominator clamp never engages on this input;
@@ -890,11 +912,7 @@ mod tests {
     #[test]
     fn schlegel_projection_is_always_finite() {
         let cell_offset = 0.5;
-        let proj = Projection::Schlegel {
-            cell_normal: Vec4::W,
-            cell_offset,
-            viewpoint_distance: 1.5 * cell_offset,
-        };
+        let proj = Projection::schlegel(Vec4::W, cell_offset, 1.5 * cell_offset);
         for v in TESSERACT_VERTS {
             let got = <EuclideanR4 as RasterizableSpace<4>>::project_point(v, &proj);
             for c in [got.x, got.y, got.z] {
@@ -913,11 +931,7 @@ mod tests {
     #[test]
     fn schlegel_zero_denominator_clamps_finite() {
         let viewpoint_distance = 0.75;
-        let proj = Projection::Schlegel {
-            cell_normal: Vec4::W,
-            cell_offset: 0.5,
-            viewpoint_distance,
-        };
+        let proj = Projection::schlegel(Vec4::W, 0.5, viewpoint_distance);
         // `w = viewpoint_distance` puts the vertex exactly on the eye's 3-flat.
         let p = Vec4::new(0.3, -0.2, 0.1, viewpoint_distance);
         let got = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
@@ -939,18 +953,10 @@ mod tests {
     fn schlegel_outward_normal_sign_required() {
         let cell_offset = 0.5;
         let viewpoint_distance = 1.5 * cell_offset;
-        let outward = Projection::Schlegel {
-            cell_normal: Vec4::W,
-            cell_offset,
-            viewpoint_distance,
-        };
+        let outward = Projection::schlegel(Vec4::W, cell_offset, viewpoint_distance);
         // Same physical `w = +0.5` cell described with the inward normal `-W`: its offset
         // flips sign, and the eye lands on the far side of the polytope.
-        let inward = Projection::Schlegel {
-            cell_normal: -Vec4::W,
-            cell_offset: -cell_offset,
-            viewpoint_distance,
-        };
+        let inward = Projection::schlegel(-Vec4::W, -cell_offset, viewpoint_distance);
         // A vertex of the opposite (`w = -0.5`) cell.
         let opposite = Vec4::new(0.5, 0.5, 0.5, -0.5);
         // The boundary cube's corners sit at radius `sqrt(3)/2` from the diagram center.
@@ -1004,10 +1010,11 @@ mod tests {
     #[test]
     fn schlegel_unsupported_on_r3_returns_zero() {
         let p = Vec3::new(1.0, 2.0, 3.0);
-        let proj = Projection::Schlegel {
+        let proj = Projection::<3>::Schlegel {
             cell_normal: Vec4::W,
             cell_offset: 0.5,
             viewpoint_distance: 0.75,
+            basis: [Vec4::X, Vec4::Y, Vec4::Z],
         };
         let got = <EuclideanR3 as RasterizableSpace<3>>::project_point(p, &proj);
         assert_eq!(got, Vec3::ZERO);
@@ -1080,8 +1087,9 @@ mod tests {
         );
     }
 
-    /// `stereo_inverse(stereo(p)) ≈ p` for unit `p` clear of the pole, for the default pole and
-    /// an off-axis pole. Written against the TRUNCATED image (the inverse re-embeds the
+    /// `stereo_inverse(stereo(p)) ~= p` for unit `p` clear of the pole, for the
+    /// default pole and an off-axis pole. Written against the TRUNCATED image
+    /// (the inverse re-embeds the
     /// in-3-flat readout), so the `n`-perpendicular truncation is pinned as load-bearing: a
     /// leaked pole-component would break this round-trip.
     #[test]
@@ -1266,8 +1274,8 @@ mod tests {
         let intrinsic = (ta.dot(tb) / (ta.length() * tb.length()))
             .clamp(-1.0, 1.0)
             .acos();
-        // Angle between the projected edges in R³. Step a small distance along each geodesic so
-        // the projected secant approximates the projected tangent direction.
+        // Angle between the projected edges in R3. Step a small distance along
+        // each geodesic so the secant approximates the projected tangent.
         let step = 1e-3;
         let pv = <EuclideanR4 as RasterizableSpace<4>>::project_point(v, &proj);
         let pa = <EuclideanR4 as RasterizableSpace<4>>::project_point(
@@ -1286,8 +1294,8 @@ mod tests {
         assert_relative_eq!(projected, intrinsic, epsilon = 1e-2);
     }
 
-    /// `Projection::Stereographic` on R³ falls back to `Vec3::ZERO` per the enum's "unsupported
-    /// variant returns zero" contract (R³ has no 3-sphere to project from).
+    /// `Projection::Stereographic` on R3 falls back to `Vec3::ZERO` per the
+    /// enum's "unsupported variant returns zero" contract.
     #[test]
     fn stereographic_unsupported_on_r3_returns_zero() {
         let p = Vec3::new(1.0, 2.0, 3.0);

--- a/crates/rye-math/src/rasterizable.rs
+++ b/crates/rye-math/src/rasterizable.rs
@@ -31,6 +31,146 @@ use glam::{Vec3, Vec4};
 use crate::space::Space;
 use crate::{EuclideanR3, EuclideanR4};
 
+/// Sign-preserving floor for central-projection denominators (Perspective4D scale,
+/// Schlegel ray parameter). A vertex on the viewer's 3-flat would otherwise divide by zero;
+/// clamping the denominator to this magnitude yields a large-but-finite screen point instead
+/// of NaN/Inf leaking into the upload buffer. The denominator is a difference of dot products
+/// of unit-circumradius vertices with a unit normal, so its meaningful values are order 1;
+/// `1e-4` sits comfortably above f32 roundoff on such a dot product yet far below any
+/// geometrically real ray parameter, so the clamp engages only for a vertex essentially on the
+/// viewer's 3-flat. The picture is meaningless at the clamp but the buffer stays finite.
+const PROJECTION_DENOM_EPSILON: f32 = 1e-4;
+
+/// Floor for the stereographic denominator `1 - dot(p, n)`. The pole is a real,
+/// reachable input: the 16-cell has `±e_i` vertices and a cell-center pole such
+/// as `(1,1,1,1)/2` coincides with a genuine tesseract vertex direction, so a
+/// vertex landing on the pole gives `dot(p, n) = 1` and a bare divide NaNs the
+/// whole upload buffer. Clamping the denominator to this magnitude yields a
+/// large-but-finite point instead. Same order as `PROJECTION_DENOM_EPSILON`:
+/// `dot(p, n)` is a dot of unit vectors so its meaningful denominator values are
+/// order 1 (the antipode gives the maximum, 2); `1e-4` sits well above f32
+/// roundoff yet far below any geometrically real value, so the clamp engages
+/// only for a vertex essentially at the pole.
+///
+/// Exposed (`pub`) because a renderer that draws the stereographic image as a
+/// finite polyline must clip the near-pole blow-up, and the clip radius is
+/// interdependent with this floor: a sample inside the clamp band maps to
+/// magnitude at most `sqrt((2 - eps)*eps) / eps`, i.e. on the order of
+/// `sqrt(2 / eps)`, so a screen-space clip radius chosen strictly below that
+/// ceiling reliably catches every clamp-saturated near-pole sample. The clip
+/// itself lives in the rasterizer/demo layer, not here, so this map stays the
+/// pure conformal projection (see the module-level note and `Projection::Stereographic`).
+pub const STEREOGRAPHIC_POLE_EPSILON: f32 = 1e-4;
+
+/// Orthonormal basis `(e1, e2, e3)` of the 3-flat perpendicular to the unit
+/// vector `n`, for reading a point that lies in that 3-flat out as R³ (the
+/// Schlegel diagram's screen coordinates). The basis is deterministic in `n`:
+/// drop the world axis most aligned with `n`, then Gram-Schmidt the surviving
+/// three axes (in x, y, z, w order) against `n` and each other (do Carmo,
+/// *Differential Geometry of Curves and Surfaces*, §1.4, the standard
+/// Gram-Schmidt construction). Dropping the most-aligned axis keeps the three
+/// survivors well clear of `n`, so each residual is well-conditioned.
+///
+/// Returning the readout in this frame, rather than naively dropping the
+/// `n`-aligned coordinate, is what makes the diagram faithful for a cell whose
+/// normal is not axis-aligned: an oblique drop-w flattens the chosen boundary
+/// cell (its `+n` vertex collapses toward the origin) and breaks the nesting
+/// invariant.
+///
+/// The frame is a function of `n` alone, so it is identical for every vertex of
+/// a fixed Schlegel projection. It is nonetheless rebuilt on every
+/// [`RasterizableSpace::project_point`] call, which is once per vertex (per
+/// tessellation sample) in the rasterizer upload path. That recompute is a
+/// handful of f32 ops with no allocation and yields the byte-identical frame
+/// each time (determinism intact), so it is left un-hoisted until Schlegel is
+/// actually wired into the demo's per-frame wireframe rebuild and the redundant
+/// rebuilds show up in a measurement. At that point the frame should be
+/// resolved once per projection alongside `cell_normal` / `cell_offset` rather
+/// than per vertex (see the note on [`Projection::Schlegel`]).
+fn perp_frame(n: Vec4) -> (Vec4, Vec4, Vec4) {
+    // Drop the world axis most aligned with `n` (its residual after projecting
+    // out `n` is the shortest and worst-conditioned), then Gram-Schmidt the
+    // other three against `n` and each other. Dropping the most-aligned axis
+    // guarantees the remaining three stay linearly independent in the 3-flat.
+    let ax = n.x.abs();
+    let ay = n.y.abs();
+    let az = n.z.abs();
+    let aw = n.w.abs();
+    let drop = ax.max(ay).max(az).max(aw);
+    let mut seeds = [Vec4::X, Vec4::Y, Vec4::Z, Vec4::W];
+    // Replace the most-aligned axis with a sentinel we then skip; ties resolve
+    // toward the earliest axis so the choice is deterministic in `n`.
+    let drop_idx = if drop == ax {
+        0
+    } else if drop == ay {
+        1
+    } else if drop == az {
+        2
+    } else {
+        3
+    };
+    seeds[drop_idx] = Vec4::ZERO;
+
+    let mut basis = [Vec4::ZERO; 3];
+    let mut count = 0usize;
+    for s in seeds {
+        if s == Vec4::ZERO {
+            continue;
+        }
+        let mut v = s - s.dot(n) * n;
+        for b in basis.iter().take(count) {
+            v -= v.dot(*b) * *b;
+        }
+        basis[count] = v.normalize();
+        count += 1;
+    }
+    (basis[0], basis[1], basis[2])
+}
+
+/// Stereographic map of a point `p` on S³ to R³ from the unit `pole`
+/// (Wikipedia, *Stereographic projection*). Shared by the `EuclideanR4` and
+/// `SphericalS3Embedded` impls so the conformal map and its clamp discipline
+/// have exactly one definition.
+///
+/// `image = (p - dot(p, pole)*pole) / (1 - dot(p, pole))`, the `pole`-perpendicular
+/// component of `p` rescaled, then read out in the orthonormal frame of the
+/// `pole`-perpendicular 3-flat. The numerator truncation is computed before the
+/// divide so the result genuinely lies in that 3-flat (the bare `p / denom` form
+/// leaks a `pole`-component); the readout against `perp_frame` then drops to the
+/// in-3-flat coordinates.
+///
+/// `dot(p, pole)` is clamped to `[-1, 1]` so a slightly-off-unit `p` cannot push
+/// the denominator outside `(0, 2]`, and the denominator is floored at
+/// `STEREOGRAPHIC_POLE_EPSILON` so a vertex at the pole stays finite.
+///
+/// The default pole `Vec4::W` takes a closed-form fast path: the frame is the
+/// literal `{x, y, z}` axes, so the readout is `(p.x, p.y, p.z) / (1 - p.w)` with
+/// zero Gram-Schmidt. This is bit-identical to the general path for that pole
+/// (the truncated numerator's first three components equal `p`'s, and dotting
+/// against the axis frame just selects them), and it is the common case in the
+/// demo, so it is pinned as the fast path. Non-default poles pay one stack-only
+/// `perp_frame` build per call; the rebuild does not allocate and is left
+/// un-hoisted until a trace shows the redundancy across the upload path is real.
+pub(crate) fn stereographic_to_r3(p: Vec4, pole: Vec4) -> Vec3 {
+    // Clamp matches `SphericalS3Embedded`'s dot-product discipline: a vertex a
+    // hair off the unit sphere must not drive the denominator negative or past 2.
+    let dot = p.dot(pole).clamp(-1.0, 1.0);
+    let denom = (1.0 - dot).max(STEREOGRAPHIC_POLE_EPSILON);
+    if pole == Vec4::W {
+        // Closed-form drop-w: `perp_frame(W)` is exactly `(X, Y, Z)`, so the
+        // frame readout reduces to dividing the first three components by `denom`.
+        // No Gram-Schmidt, byte-identical to the general path below for this pole.
+        return Vec3::new(p.x, p.y, p.z) / denom;
+    }
+    // Truncate to the pole-perpendicular component BEFORE dividing, so the image
+    // lies in the pole-perpendicular 3-flat (the naive `p / denom` would carry a
+    // nonzero pole-component into the readout).
+    let perp = p - dot * pole;
+    let scaled = perp / denom;
+    let (e1, e2, e3) = perp_frame(pole);
+    Vec3::new(scaled.dot(e1), scaled.dot(e2), scaled.dot(e3))
+}
+
 /// Projection from R^N to R³ for the rasterizer's screen-space transform.
 ///
 /// All variants are dimension-generic in the type system, but each variant only makes sense for
@@ -50,9 +190,14 @@ use crate::{EuclideanR3, EuclideanR4};
 ///   tesseract view; drop-w renders axis-aligned polytopes as degenerate flat shapes because
 ///   every pair of w-opposite vertices collapses to the same R³ point, and Perspective4D
 ///   separates them.
+/// - [`Schlegel`](Self::Schlegel): R⁴ central projection of a 4-polytope from a viewpoint
+///   just outside a chosen cell onto that cell's bounding 3-flat. The chosen cell becomes the
+///   outer boundary; every other cell nests inside it (Coxeter, *Regular Polytopes*, ch. 13).
+/// - [`Stereographic`](Self::Stereographic): conformal map of S³ to R³ from a chosen pole.
+///   The natural projection for spherical-space polytopes; preserves angles, distorts
+///   distances (Wikipedia, *Stereographic projection*).
 ///
-/// Future variants under consideration: R⁴-specific `Schlegel`,
-/// `Stereographic`, `Hyperslice`.
+/// Future variants under consideration: R⁴-specific `Hyperslice`.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Projection<const N: usize> {
     /// Pass through: take the first 3 components, zero-pad if `N < 3`, truncate if `N > 3`.
@@ -86,6 +231,109 @@ pub enum Projection<const N: usize> {
     Perspective4D {
         /// Viewer position along the w-axis. Typical value for unit polytopes: `2.0`.
         focal_distance: f32,
+    },
+
+    /// 4D Schlegel diagram: central projection of a 4-polytope from a viewpoint placed just
+    /// outside a chosen cell, onto that cell's bounding 3-flat (Coxeter, *Regular Polytopes*,
+    /// 3rd ed., ch. 13, "Schlegel diagrams"). The chosen cell maps to the outer boundary of
+    /// the diagram and every other cell projects into the interior, nested. This is the
+    /// textbook 4D-to-3D picture: the 5-cell becomes a tetrahedron holding four nested
+    /// tetrahedra, the tesseract a cube holding seven nested cubes.
+    ///
+    /// The chosen cell lies in the hyperplane `{x : dot(cell_normal, x) = cell_offset}` with
+    /// `cell_normal` the outward unit normal of that cell. The eye sits on the outward radial
+    /// axis at `E = viewpoint_distance * cell_normal`, beyond the cell (so
+    /// `viewpoint_distance > cell_offset`). Each vertex `p` projects along the ray from `E`
+    /// through `p` onto the cell hyperplane:
+    /// `t = (cell_offset - dot(n, E)) / (dot(n, p) - dot(n, E))`,
+    /// `result = E + t * (p - E)`.
+    ///
+    /// `result` lands in the 3-flat perpendicular to `cell_normal`; the readout expresses it
+    /// in an orthonormal basis of that 3-flat (Gram-Schmidt against `n`), not by dropping the
+    /// w-coordinate. A naive w-drop is exact only for a w-aligned `n`; for any other cell
+    /// normal it is an oblique projection that flattens the chosen boundary cell (its `+n`
+    /// vertex collapses toward the origin) and breaks the nesting, so the 5-cell, 16-cell,
+    /// 24-cell, 120-cell, and 600-cell would all render as degenerate diagrams. The frame is a
+    /// function of `n` alone, so it is identical across the polytope's vertices within one
+    /// Schlegel projection, but [`RasterizableSpace::project_point`] rebuilds it on every call,
+    /// which is once per vertex (per tessellation sample) in the upload path. The rebuild is a
+    /// few f32 ops with no allocation; it is left in the per-vertex path until Schlegel is
+    /// wired into the demo and the redundancy is measured, at which point the frame should be
+    /// resolved once per projection (see `perp_frame`). The frame's in-3-flat orientation
+    /// (which way is "up" in the diagram) is arbitrary but deterministic in `n`, which is all a
+    /// wireframe needs.
+    ///
+    /// **Precondition: `cell_normal` is the *outward* unit normal and
+    /// `viewpoint_distance > cell_offset`.** With the inward normal the diagram fails to nest
+    /// (interior cells escape the boundary). The denominator `dot(n, p) - dot(n, E)` is
+    /// clamped sign-preservingly away from zero so a vertex sitting on the viewer's 3-flat
+    /// yields a large-but-finite point rather than a NaN reaching the upload buffer.
+    ///
+    /// `cell_normal` / `cell_offset` are pre-resolved scalars; the variant carries no polytope
+    /// reference. The demo resolves them once per cell selection from the polytope's topology
+    /// (cell centroids), never inside the per-frame upload.
+    ///
+    /// Only meaningful for `N == 4`; impls for other `N` return `Vec3::ZERO`.
+    Schlegel {
+        /// Outward unit normal of the chosen boundary cell's hyperplane.
+        cell_normal: Vec4,
+        /// Signed plane offset: the chosen cell lies in the hyperplane
+        /// `{x : dot(cell_normal, x) = cell_offset}`.
+        cell_offset: f32,
+        /// Eye distance along `cell_normal` from the origin; must exceed `cell_offset` so the
+        /// viewpoint sits just outside the chosen cell.
+        viewpoint_distance: f32,
+    },
+
+    /// Stereographic projection of the unit 3-sphere S³ onto R³ from a chosen `pole` (a unit
+    /// `Vec4`), the canonical conformal S³ to R³ map (Wikipedia, *Stereographic projection*;
+    /// the higher-dimensional generalization of the plane case). A point `p` on S³ maps to
+    ///   `image = (p - dot(p, pole)*pole) / (1 - dot(p, pole))`,
+    /// the component of `p` perpendicular to `pole` rescaled by the stereographic factor. The
+    /// result lies in the 3-flat perpendicular to `pole`; the readout expresses it in an
+    /// orthonormal basis of that 3-flat (see `perp_frame`). For pole `Vec4::W`
+    /// this collapses to the closed form `(p.x, p.y, p.z) / (1 - p.w)` with zero
+    /// frame math.
+    ///
+    /// **The truncated `n`-perpendicular numerator is load-bearing, not
+    /// cosmetic.** Writing the naive `scaled = p / (1 - dot(p, pole))` as a full
+    /// 4-vector and relying on a later "express in the frame" to drop the radial
+    /// part silently leaks a nonzero `pole`-component into the readout (the bare
+    /// 4-vector is not in the `pole`-perpendicular hyperplane), which corrupts the
+    /// projection; subtract `dot(p, pole)*pole` *before* dividing.
+    ///
+    /// **Precondition: `pole` is a unit vector and `p` lies on S³ (`|p| = 1`).**
+    /// `dot(p, pole)` is clamped into `[-1, 1]` before forming the denominator,
+    /// matching the clamp discipline in [`crate::SphericalS3Embedded`], so a
+    /// slightly-off-unit upstream vertex cannot push the denominator outside
+    /// `(0, 2]`. The pole itself is reachable (the 16-cell has `±e_i` vertices;
+    /// a cell-center pole such as `(1,1,1,1)/2` coincides with a real tesseract
+    /// vertex direction), so the denominator is floored at `STEREOGRAPHIC_POLE_EPSILON`:
+    /// a vertex at the pole yields a large-but-finite point rather than a NaN
+    /// reaching the upload buffer. The antipode (`-pole`) is the safe far point,
+    /// `dot = -1`, denominator `2`, mapping to the origin.
+    ///
+    /// `EuclideanR4`'s impl normalizes its input onto S³ first, since
+    /// stereographic is only meaningful on the unit sphere and polytope vertices
+    /// fed through the demo are `body_size`-scaled, not unit; that normalize is
+    /// the precondition guard. The [`crate::SphericalS3Embedded`] impl computes
+    /// the stereographic map directly (a true conformal S³ view), rather than
+    /// delegating to the flat R⁴ projection as it does for the other variants.
+    ///
+    /// The frame is a function of `pole` alone, so it is identical across every
+    /// vertex of a fixed projection, but [`RasterizableSpace::project_point`]
+    /// rebuilds it per call (per vertex) like [`Schlegel`](Self::Schlegel); the
+    /// `Vec4::W` closed form does zero frame math, while a general pole pays the
+    /// `perp_frame` rebuild (see `perp_frame` for why it is left un-hoisted).
+    /// Stereographic is non-affine, so it cannot be represented by an affine
+    /// section-cap scalar shim.
+    ///
+    /// Only meaningful for `N == 4`; impls for other `N` return `Vec3::ZERO`.
+    Stereographic {
+        /// Unit `Vec4` pole the projection casts away from. Pole `Vec4::W` gives
+        /// the textbook closed-form `(x, y, z) / (1 - w)` map; the pole the demo
+        /// actually selects lives in the demo layer (this map stays pole-agnostic).
+        pole: Vec4,
     },
 }
 
@@ -146,9 +394,12 @@ impl RasterizableSpace<3> for EuclideanR3 {
                 2 => Vec3::new(point.x, point.y, 0.0),
                 _ => Vec3::ZERO,
             },
-            // Perspective4D is meaningful only for `N == 4`; on R³ there's no w axis to
-            // project from. Per the enum contract, return zero rather than panic.
-            Projection::Perspective4D { .. } => Vec3::ZERO,
+            // Perspective4D, Schlegel, and Stereographic are meaningful only for `N == 4`; on
+            // R³ there's no w axis (nor a 3-sphere) to project from. Per the enum contract,
+            // return zero rather than panic.
+            Projection::Perspective4D { .. }
+            | Projection::Schlegel { .. }
+            | Projection::Stereographic { .. } => Vec3::ZERO,
         }
     }
 
@@ -187,11 +438,53 @@ impl RasterizableSpace<4> for EuclideanR4 {
                 // denominator clamp guards against zero / negative values: callers should
                 // pick `focal_distance > max(w)` so the clamp never engages on legitimate
                 // input, but clamping lets a misconfigured projection degrade visibly
-                // rather than emit NaN through the rest of the upload path. The `1e-4`
-                // floor matches `EDGE_PARALLEL_EPSILON`'s order of magnitude.
-                let denom = (focal_distance - point.w).max(1e-4);
+                // rather than emit NaN through the rest of the upload path.
+                let denom = (focal_distance - point.w).max(PROJECTION_DENOM_EPSILON);
                 let scale = focal_distance / denom;
                 Vec3::new(point.x, point.y, point.z) * scale
+            }
+            Projection::Schlegel {
+                cell_normal,
+                cell_offset,
+                viewpoint_distance,
+            } => {
+                // Central projection from the eye `E = viewpoint_distance * n` through the
+                // vertex `point` onto the chosen cell's 3-flat `{x : dot(n, x) = cell_offset}`
+                // (Coxeter, *Regular Polytopes*, ch. 13). Ray: `E + t * (point - E)`; solve
+                // `dot(n, E + t*(point - E)) = cell_offset` for the hit parameter
+                //   t = (cell_offset - dot(n, E)) / (dot(n, point) - dot(n, E)).
+                // A chosen-cell vertex has `dot(n, point) = cell_offset`, giving `t = 1` and
+                // `result = point`: the cell maps to itself (the diagram's outer boundary).
+                let n = *cell_normal;
+                let eye = *viewpoint_distance * n;
+                let n_dot_eye = n.dot(eye);
+                // Sign-preserving clamp: a vertex on the viewer's 3-flat
+                // (`dot(n, point) == dot(n, eye)`) would divide by zero. Keeping the sign
+                // means the clamped point shoots off in the geometrically correct direction
+                // (huge but finite) instead of flipping across the eye.
+                let raw_denom = n.dot(point) - n_dot_eye;
+                let denom = if raw_denom.abs() < PROJECTION_DENOM_EPSILON {
+                    PROJECTION_DENOM_EPSILON.copysign(raw_denom)
+                } else {
+                    raw_denom
+                };
+                let t = (*cell_offset - n_dot_eye) / denom;
+                let result = eye + t * (point - eye);
+                // Read `result` out in an orthonormal frame of the cell's 3-flat (perpendicular
+                // to `n`), not by dropping the w-coordinate. The drop-w shortcut is exact only
+                // for a w-aligned `n`; for any other cell normal it obliquely flattens the
+                // chosen boundary cell (its `+n` vertex collapses toward the origin) and the
+                // diagram stops nesting. The frame depends on `n` alone and is rebuilt per call
+                // (per vertex); see `perp_frame` for why that recompute is left un-hoisted.
+                let (e1, e2, e3) = perp_frame(n);
+                Vec3::new(result.dot(e1), result.dot(e2), result.dot(e3))
+            }
+            Projection::Stereographic { pole } => {
+                // Stereographic is only defined on the unit sphere, but vertices fed through the
+                // demo are `body_size`-scaled rather than unit, so normalize onto S³ first; the
+                // normalize is the precondition guard. `stereographic_to_r3` then applies the
+                // conformal map with the pole-denominator clamp.
+                stereographic_to_r3(point.normalize(), *pole)
             }
         }
     }
@@ -209,6 +502,17 @@ impl RasterizableSpace<4> for EuclideanR4 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SphericalS3Embedded;
+    use approx::assert_relative_eq;
+
+    /// Golden Vec3 for `stereographic_frame_is_deterministic_under_tie`. Hand-derived from the
+    /// deterministic `perp_frame` construction for the pole `(0,0,1,1)/√2` and the unit input
+    /// `(0.5, 0.5, -0.5, 0.5)`: the z/w max-magnitude tie resolves to dropping z (the earlier
+    /// index in the `==` ladder), giving the frame `(X, Y, (0,0,-1,1)/√2)`; with `dot(p, pole)
+    /// = 0` the readout is `(0.5, 0.5, 1/√2)`. A future change to the tie-break or Gram-Schmidt
+    /// order that flips the gauge changes this value and the test catches it.
+    /// `1/√2` is the `FRAC_1_SQRT_2` constant, not a bare literal.
+    const GOLDEN_TIE_FRAME: Vec3 = Vec3::new(0.5, 0.5, std::f32::consts::FRAC_1_SQRT_2);
 
     /// `point_to_array` is the inverse of `array_to_point` on `EuclideanR3` for any input.
     #[test]
@@ -217,6 +521,31 @@ mod tests {
         let arr = <EuclideanR3 as RasterizableSpace<3>>::point_to_array(p);
         let back = <EuclideanR3 as RasterizableSpace<3>>::array_to_point(arr);
         assert_eq!(p, back);
+    }
+
+    /// The `EuclideanR4` Stereographic arm normalizes its input onto S³ before
+    /// applying the conformal map, so a `body_size`-scaled vertex `k * p`
+    /// projects to the same R³ point as the unit vertex `p`. This pins the
+    /// `point.normalize()` precondition guard: without it the demo's non-unit
+    /// vertices would project through a wrong-radius denominator, and every
+    /// other test feeds already-unit input so none would catch its removal.
+    #[test]
+    fn stereographic_r4_normalizes_scaled_input() {
+        let proj = Projection::Stereographic { pole: Vec4::W };
+        for p in [
+            Vec4::new(0.3, -0.1, 0.2, -0.5).normalize(),
+            Vec4::new(-0.4, 0.6, 0.1, 0.3).normalize(),
+            Vec4::new(0.0, 0.0, 0.0, -1.0),
+        ] {
+            let unit = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+            for k in [0.25_f32, 1.5, 3.0] {
+                let scaled = <EuclideanR4 as RasterizableSpace<4>>::project_point(k * p, &proj);
+                assert!(
+                    scaled.abs_diff_eq(unit, 1e-5),
+                    "scale {k}: {scaled:?} vs {unit:?}"
+                );
+            }
+        }
     }
 
     /// `Projection::Identity` on R³ is bitwise identity: the projected point equals the input.
@@ -404,6 +733,565 @@ mod tests {
         let proj = Projection::Perspective4D {
             focal_distance: 2.0,
         };
+        let got = <EuclideanR3 as RasterizableSpace<3>>::project_point(p, &proj);
+        assert_eq!(got, Vec3::ZERO);
+    }
+
+    // ---- Schlegel ------------------------------------------------------
+
+    /// The eight tesseract vertices, unit-circumradius (`±0.5` in every coordinate). Shared
+    /// across the Schlegel tests; the cell at `w = +0.5` is the canonical boundary cell.
+    const TESSERACT_VERTS: [Vec4; 16] = [
+        Vec4::new(0.5, 0.5, 0.5, 0.5),
+        Vec4::new(-0.5, 0.5, 0.5, 0.5),
+        Vec4::new(0.5, -0.5, 0.5, 0.5),
+        Vec4::new(-0.5, -0.5, 0.5, 0.5),
+        Vec4::new(0.5, 0.5, -0.5, 0.5),
+        Vec4::new(-0.5, 0.5, -0.5, 0.5),
+        Vec4::new(0.5, -0.5, -0.5, 0.5),
+        Vec4::new(-0.5, -0.5, -0.5, 0.5),
+        Vec4::new(0.5, 0.5, 0.5, -0.5),
+        Vec4::new(-0.5, 0.5, 0.5, -0.5),
+        Vec4::new(0.5, -0.5, 0.5, -0.5),
+        Vec4::new(-0.5, -0.5, 0.5, -0.5),
+        Vec4::new(0.5, 0.5, -0.5, -0.5),
+        Vec4::new(-0.5, 0.5, -0.5, -0.5),
+        Vec4::new(0.5, -0.5, -0.5, -0.5),
+        Vec4::new(-0.5, -0.5, -0.5, -0.5),
+    ];
+
+    /// Vertices of the chosen boundary cell map onto the diagram's outer boundary undistorted:
+    /// they satisfy `dot(n, v) = cell_offset`, so the ray parameter is exactly `t = 1` and
+    /// `result = v` (Coxeter, *Regular Polytopes*, ch. 13). The frame readout reports `result`
+    /// in an orthonormal basis of the cell's 3-flat, which is an isometry of that 3-flat, so it
+    /// preserves the cell's intrinsic shape. Pin that by checking pairwise distances among the
+    /// chosen-cell vertices match the original cell's: the boundary cube renders at true size,
+    /// not flattened. Checked over the `w = +0.5` cell of a synthetic unit cube.
+    #[test]
+    fn schlegel_chosen_cell_renders_undistorted() {
+        let cell_offset = 0.5;
+        let proj = Projection::Schlegel {
+            cell_normal: Vec4::W,
+            cell_offset,
+            viewpoint_distance: 1.5 * cell_offset,
+        };
+        // The eight vertices of the `w = +0.5` cell (the first half of TESSERACT_VERTS).
+        let cell: Vec<Vec4> = TESSERACT_VERTS.iter().take(8).copied().collect();
+        let projected: Vec<Vec3> = cell
+            .iter()
+            .map(|v| <EuclideanR4 as RasterizableSpace<4>>::project_point(*v, &proj))
+            .collect();
+        // The readout is an isometry, so every pairwise distance is preserved. The cube's
+        // 3D distances ignore the shared `w`, so compare against the xyz distance.
+        for i in 0..cell.len() {
+            for j in (i + 1)..cell.len() {
+                let orig = (Vec3::new(cell[i].x, cell[i].y, cell[i].z)
+                    - Vec3::new(cell[j].x, cell[j].y, cell[j].z))
+                .length();
+                let got = (projected[i] - projected[j]).length();
+                assert!(
+                    (orig - got).abs() < 1e-5,
+                    "chosen-cell distance v{i}-v{j} should be {orig}, got {got}"
+                );
+            }
+        }
+    }
+
+    /// The chosen boundary cell stays a genuine 3D cell, not a flattened one. The frame readout
+    /// fixed the w-drop bug where a cell normal with a w-component collapsed the boundary's
+    /// `+n` vertex onto the origin. Pin non-degeneracy directly: the eight projected boundary
+    /// vertices span all three R³ axes (every coordinate has nonzero spread). Uses the 16-cell
+    /// cell `{+x,+y,+z,+w}`, whose normal `(1,1,1,1)/2` is the worst case for the old w-drop.
+    #[test]
+    fn schlegel_non_axis_aligned_cell_is_not_flattened() {
+        // 16-cell vertices: the eight signed unit axis points.
+        let verts = [
+            Vec4::X,
+            -Vec4::X,
+            Vec4::Y,
+            -Vec4::Y,
+            Vec4::Z,
+            -Vec4::Z,
+            Vec4::W,
+            -Vec4::W,
+        ];
+        // Chosen cell {+x,+y,+z,+w}; centroid direction is the outward normal.
+        let centroid = (Vec4::X + Vec4::Y + Vec4::Z + Vec4::W) / 4.0;
+        let cell_offset = centroid.length();
+        let cell_normal = centroid / cell_offset;
+        let proj = Projection::Schlegel {
+            cell_normal,
+            cell_offset,
+            viewpoint_distance: 1.5 * cell_offset,
+        };
+        // The four chosen-cell vertices (the +axes) are the boundary; the four -axes nest.
+        let boundary = [Vec4::X, Vec4::Y, Vec4::Z, Vec4::W];
+        let inner = [-Vec4::X, -Vec4::Y, -Vec4::Z, -Vec4::W];
+        let proj_pt = |v: Vec4| <EuclideanR4 as RasterizableSpace<4>>::project_point(v, &proj);
+
+        // Boundary vertices are equidistant from the diagram center (a regular tetrahedron),
+        // and each strictly farther from center than every nested vertex.
+        let boundary_r: Vec<f32> = boundary.iter().map(|&v| proj_pt(v).length()).collect();
+        let inner_r: Vec<f32> = inner.iter().map(|&v| proj_pt(v).length()).collect();
+        let r0 = boundary_r[0];
+        assert!(r0 > 1e-3, "boundary must not collapse to the origin");
+        for r in &boundary_r {
+            assert!(
+                (r - r0).abs() < 1e-5,
+                "boundary tetrahedron must be regular, radii {boundary_r:?}"
+            );
+        }
+        for r in &inner_r {
+            assert!(
+                *r < r0 - 1e-3,
+                "every nested vertex must sit inside the boundary, inner {inner_r:?} vs {r0}"
+            );
+        }
+        // Directly pin the oblique-normal isometry (the case this divergence from spec exists
+        // to fix): the four boundary +axes are mutually equidistant at `sqrt(2)`, and each lies
+        // on the cell hyperplane (`t = 1`, projects to itself), so the orthonormal-frame readout
+        // must preserve every pairwise distance. A naive oblique drop-w would not.
+        let proj_boundary: Vec<Vec3> = boundary.iter().map(|&v| proj_pt(v)).collect();
+        let edge_len = 2.0_f32.sqrt();
+        for i in 0..proj_boundary.len() {
+            for j in (i + 1)..proj_boundary.len() {
+                let got = (proj_boundary[i] - proj_boundary[j]).length();
+                assert!(
+                    (got - edge_len).abs() < 1e-5,
+                    "oblique boundary edge {i}-{j} should stay {edge_len}, got {got}"
+                );
+            }
+        }
+        // Sanity: the diagram has real 3D extent on every axis. The radius/nesting asserts
+        // above are what actually discriminate the old w-drop bug (which sent `+n` to the
+        // origin, failing `r0 > 1e-3` and the regular-tetrahedron check); this spread check is
+        // only a coarse non-degeneracy guard, since a naive drop-w keeps the `±axis` extents
+        // here too.
+        let all: Vec<Vec3> = verts.iter().map(|&v| proj_pt(v)).collect();
+        for axis in 0..3 {
+            let comp = |p: Vec3| [p.x, p.y, p.z][axis];
+            let spread = all
+                .iter()
+                .map(|&p| comp(p))
+                .fold(f32::NEG_INFINITY, f32::max)
+                - all.iter().map(|&p| comp(p)).fold(f32::INFINITY, f32::min);
+            assert!(
+                spread > 0.5,
+                "axis {axis} should have real spread, got {spread}"
+            );
+        }
+    }
+
+    /// Every tesseract vertex projects to an all-finite R³ point under the default viewpoint
+    /// (`viewpoint_distance = 1.5 * cell_offset`). The viewpoint clears the chosen cell, so no
+    /// vertex sits on the viewer 3-flat and the denominator clamp never engages on this input;
+    /// the assertion still guards the whole vertex set, including the `w = -0.5` cell that the
+    /// eye looks through.
+    #[test]
+    fn schlegel_projection_is_always_finite() {
+        let cell_offset = 0.5;
+        let proj = Projection::Schlegel {
+            cell_normal: Vec4::W,
+            cell_offset,
+            viewpoint_distance: 1.5 * cell_offset,
+        };
+        for v in TESSERACT_VERTS {
+            let got = <EuclideanR4 as RasterizableSpace<4>>::project_point(v, &proj);
+            for c in [got.x, got.y, got.z] {
+                assert!(
+                    c.is_finite(),
+                    "vertex {v:?} projected to non-finite {got:?}"
+                );
+            }
+        }
+    }
+
+    /// A vertex on the viewer's 3-flat (`dot(n, p) == dot(n, E)`) would divide by zero in the
+    /// ray parameter; the sign-preserving denominator clamp yields a finite (large) result
+    /// instead, mirroring `r4_perspective4d_at_viewer_clamps_finite`. Constructed so
+    /// `dot(W, p) == dot(W, E) == viewpoint_distance`.
+    #[test]
+    fn schlegel_zero_denominator_clamps_finite() {
+        let viewpoint_distance = 0.75;
+        let proj = Projection::Schlegel {
+            cell_normal: Vec4::W,
+            cell_offset: 0.5,
+            viewpoint_distance,
+        };
+        // `w = viewpoint_distance` puts the vertex exactly on the eye's 3-flat.
+        let p = Vec4::new(0.3, -0.2, 0.1, viewpoint_distance);
+        let got = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+        for c in [got.x, got.y, got.z] {
+            assert!(
+                c.is_finite(),
+                "degenerate denominator should clamp finite, got {got:?}"
+            );
+        }
+    }
+
+    /// The normal sign is load-bearing: with the *outward* normal the opposite cell nests
+    /// inside the boundary (its projected radius is smaller than the boundary cube's
+    /// half-diagonal); flipping to the *inward* normal (eye on the wrong side) blows that
+    /// vertex out past the boundary. Pins that callers must supply the outward normal.
+    /// Compares radii from the diagram center rather than per-axis extents because the frame
+    /// readout rotates the xyz axes; radius is the rotation-invariant nesting measure.
+    #[test]
+    fn schlegel_outward_normal_sign_required() {
+        let cell_offset = 0.5;
+        let viewpoint_distance = 1.5 * cell_offset;
+        let outward = Projection::Schlegel {
+            cell_normal: Vec4::W,
+            cell_offset,
+            viewpoint_distance,
+        };
+        // Same physical `w = +0.5` cell described with the inward normal `-W`: its offset
+        // flips sign, and the eye lands on the far side of the polytope.
+        let inward = Projection::Schlegel {
+            cell_normal: -Vec4::W,
+            cell_offset: -cell_offset,
+            viewpoint_distance,
+        };
+        // A vertex of the opposite (`w = -0.5`) cell.
+        let opposite = Vec4::new(0.5, 0.5, 0.5, -0.5);
+        // The boundary cube's corners sit at radius `sqrt(3)/2` from the diagram center.
+        let boundary_radius = (0.75_f32).sqrt();
+        let nested = <EuclideanR4 as RasterizableSpace<4>>::project_point(opposite, &outward);
+        let escaped = <EuclideanR4 as RasterizableSpace<4>>::project_point(opposite, &inward);
+        assert!(
+            nested.length() < boundary_radius,
+            "outward normal must nest the opposite cell (r {} < {boundary_radius}), got {nested:?}",
+            nested.length()
+        );
+        assert!(
+            escaped.length() > boundary_radius,
+            "inward normal must push the opposite cell outside (r {} > {boundary_radius}), got {escaped:?}",
+            escaped.length()
+        );
+    }
+
+    /// `perp_frame(n)` returns an orthonormal triple spanning the 3-flat perpendicular to `n`,
+    /// for a spread of normals including the axis-aligned and the all-equal worst cases. This
+    /// is the invariant the Schlegel readout relies on; if it breaks, the diagram skews.
+    #[test]
+    fn perp_frame_is_orthonormal_and_perpendicular_to_normal() {
+        let normals = [
+            Vec4::W,
+            Vec4::X,
+            Vec4::new(0.5, 0.5, 0.5, 0.5),
+            Vec4::new(0.1, -0.2, 0.3, 0.9).normalize(),
+            Vec4::new(-0.6, 0.0, 0.8, 0.0).normalize(),
+        ];
+        for n in normals {
+            let (e1, e2, e3) = perp_frame(n);
+            for (label, e) in [("e1", e1), ("e2", e2), ("e3", e3)] {
+                assert!(
+                    (e.length() - 1.0).abs() < 1e-5,
+                    "{label} not unit for n {n:?}"
+                );
+                assert!(
+                    e.dot(n).abs() < 1e-5,
+                    "{label} not perpendicular to n {n:?}"
+                );
+            }
+            assert!(e1.dot(e2).abs() < 1e-5, "e1·e2 != 0 for n {n:?}");
+            assert!(e1.dot(e3).abs() < 1e-5, "e1·e3 != 0 for n {n:?}");
+            assert!(e2.dot(e3).abs() < 1e-5, "e2·e3 != 0 for n {n:?}");
+        }
+    }
+
+    /// `Projection::Schlegel` on R³ falls back to `Vec3::ZERO` per the enum's "unsupported
+    /// variant returns zero" contract (R³ has no fourth axis for the central projection).
+    #[test]
+    fn schlegel_unsupported_on_r3_returns_zero() {
+        let p = Vec3::new(1.0, 2.0, 3.0);
+        let proj = Projection::Schlegel {
+            cell_normal: Vec4::W,
+            cell_offset: 0.5,
+            viewpoint_distance: 0.75,
+        };
+        let got = <EuclideanR3 as RasterizableSpace<3>>::project_point(p, &proj);
+        assert_eq!(got, Vec3::ZERO);
+    }
+
+    // ---- Stereographic -------------------------------------------------
+
+    /// Closed-form inverse of the stereographic map for the default pole `Vec4::W`: given an
+    /// R³ image `q`, recover the S³ point. Derived by inverting
+    /// `q = (x, y, z) / (1 - w)` together with `|p| = 1` (Wikipedia, *Stereographic
+    /// projection*): with `s = |q|²`, `w = (s - 1) / (s + 1)` and `(x, y, z) = q * (1 - w)`.
+    /// Used only by the round-trip test to pin that the truncated forward map is invertible.
+    fn stereo_inverse_w_pole(q: Vec3) -> Vec4 {
+        let s = q.length_squared();
+        let w = (s - 1.0) / (s + 1.0);
+        let xyz = q * (1.0 - w);
+        Vec4::new(xyz.x, xyz.y, xyz.z, w)
+    }
+
+    /// General-pole inverse: lift `q` (expressed in the `perp_frame(pole)` basis) back into
+    /// ambient R⁴, then invert the radial stereographic scaling against `|p| = 1`. For a unit
+    /// `pole` and `q` the frame readout of `stereographic_to_r3(p, pole)`, this returns `p`.
+    fn stereo_inverse_general(q: Vec3, pole: Vec4) -> Vec4 {
+        // Re-embed the in-3-flat coordinates as an ambient pole-perpendicular vector.
+        let (e1, e2, e3) = perp_frame(pole);
+        let perp = q.x * e1 + q.y * e2 + q.z * e3;
+        // Forward: perp = (p - dot*pole) / (1 - dot) with |perp_ambient(p)| =
+        // sqrt(1 - dot²)/(1 - dot) = sqrt((1+dot)/(1-dot)). Solve for dot from |q|=|perp|.
+        let s = perp.length_squared();
+        let dot = (s - 1.0) / (s + 1.0);
+        // p = dot*pole + (1 - dot)*perp  (undo the radial scaling, restore the pole part).
+        dot * pole + (1.0 - dot) * perp
+    }
+
+    /// Default pole `Vec4::W`: the closed-form fast path equals the canonical stereographic
+    /// formula `(x, y, z) / (1 - w)` bitwise, with zero frame math (Wikipedia, *Stereographic
+    /// projection*). Tested on `stereographic_to_r3` directly with exactly-unit inputs, since
+    /// `EuclideanR4::project_point` re-normalizes its input (its precondition guard) and a
+    /// second f32 normalize of an already-unit vector is not bit-idempotent; the closed-form
+    /// equality is a property of the map, not of the normalize guard.
+    #[test]
+    fn stereographic_default_pole_is_drop_w_of_scaled() {
+        for p in [
+            Vec4::new(0.5, 0.5, 0.5, 0.5),   // unit by construction
+            Vec4::new(-0.5, 0.5, 0.5, -0.5), // unit by construction
+            Vec4::new(-0.6, 0.0, 0.8, 0.0),  // unit, w = 0
+        ] {
+            let got = stereographic_to_r3(p, Vec4::W);
+            let want = Vec3::new(p.x, p.y, p.z) / (1.0 - p.w);
+            assert_eq!(
+                got, want,
+                "fast path must match canonical formula for {p:?}"
+            );
+        }
+        // The fast path is also bit-identical to the general frame-readout path for the W pole
+        // (the property the closed form trades zero Gram-Schmidt for). Confirm by forcing the
+        // general path on a pole numerically equal to W up to f32 (it is exactly W here).
+        let general = {
+            let p = Vec4::new(0.5, 0.5, 0.5, 0.5);
+            let dot = p.dot(Vec4::W).clamp(-1.0, 1.0);
+            let denom = (1.0 - dot).max(STEREOGRAPHIC_POLE_EPSILON);
+            let perp = p - dot * Vec4::W;
+            let scaled = perp / denom;
+            let (e1, e2, e3) = perp_frame(Vec4::W);
+            Vec3::new(scaled.dot(e1), scaled.dot(e2), scaled.dot(e3))
+        };
+        assert_eq!(
+            general,
+            stereographic_to_r3(Vec4::new(0.5, 0.5, 0.5, 0.5), Vec4::W)
+        );
+    }
+
+    /// `stereo_inverse(stereo(p)) ≈ p` for unit `p` clear of the pole, for the default pole and
+    /// an off-axis pole. Written against the TRUNCATED image (the inverse re-embeds the
+    /// in-3-flat readout), so the `n`-perpendicular truncation is pinned as load-bearing: a
+    /// leaked pole-component would break this round-trip.
+    #[test]
+    fn stereographic_inverts_off_pole() {
+        // Default pole.
+        let proj_w = Projection::Stereographic { pole: Vec4::W };
+        for p in [
+            Vec4::new(0.2, 0.1, -0.3, 0.4).normalize(),
+            Vec4::new(-0.5, 0.5, 0.5, -0.5),
+            Vec4::new(0.7, -0.2, 0.1, 0.1).normalize(),
+        ] {
+            let img = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj_w);
+            let back = stereo_inverse_w_pole(img);
+            assert_relative_eq!(back.x, p.x, epsilon = 1e-5);
+            assert_relative_eq!(back.y, p.y, epsilon = 1e-5);
+            assert_relative_eq!(back.z, p.z, epsilon = 1e-5);
+            assert_relative_eq!(back.w, p.w, epsilon = 1e-5);
+        }
+        // Off-axis pole, well clear of the inputs.
+        let pole = Vec4::new(0.1, -0.2, 0.3, 0.9).normalize();
+        let proj_n = Projection::Stereographic { pole };
+        for p in [
+            Vec4::new(0.6, 0.5, -0.2, 0.0).normalize(),
+            Vec4::new(-0.3, 0.4, 0.5, -0.2).normalize(),
+        ] {
+            let img = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj_n);
+            let back = stereo_inverse_general(img, pole);
+            assert_relative_eq!(back.x, p.x, epsilon = 1e-5);
+            assert_relative_eq!(back.y, p.y, epsilon = 1e-5);
+            assert_relative_eq!(back.z, p.z, epsilon = 1e-5);
+            assert_relative_eq!(back.w, p.w, epsilon = 1e-5);
+        }
+    }
+
+    /// The image lies in the pole-perpendicular 3-flat: re-embedding the R³ readout against
+    /// `perp_frame(pole)` gives an ambient vector with zero pole-component. This is the test
+    /// that catches the naive `p / (1 - dot)` leak (the refuted form carries a nonzero
+    /// pole-component, measured round-trip error 0.176 in the plan's degeneracy analysis).
+    #[test]
+    fn stereographic_image_in_n_perp_hyperplane() {
+        for pole in [
+            Vec4::W,
+            Vec4::new(0.1, -0.2, 0.3, 0.9).normalize(),
+            Vec4::new(0.5, 0.5, 0.5, 0.5),
+        ] {
+            let (e1, e2, e3) = perp_frame(pole);
+            for p in [
+                Vec4::new(0.6, 0.5, -0.2, 0.0).normalize(),
+                Vec4::new(-0.3, 0.4, 0.5, -0.2).normalize(),
+                Vec4::new(0.2, 0.1, -0.3, 0.4).normalize(),
+            ] {
+                let proj = Projection::Stereographic { pole };
+                let img = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+                let ambient = img.x * e1 + img.y * e2 + img.z * e3;
+                assert!(
+                    ambient.dot(pole).abs() < 1e-5,
+                    "image must lie in pole-perp 3-flat: pole {pole:?} p {p:?} leak {}",
+                    ambient.dot(pole)
+                );
+            }
+        }
+    }
+
+    /// A vertex exactly at the pole (`p == pole`) and a tangential near-pole point both return
+    /// finite R³, never NaN/Inf. The denominator `1 - dot(p, pole)` is `0` at the pole; the
+    /// `STEREOGRAPHIC_POLE_EPSILON` floor keeps the buffer finite (mirrors the Schlegel and
+    /// Perspective4D denominator clamps).
+    #[test]
+    fn stereographic_pole_denominator_clamped_finite() {
+        for pole in [Vec4::W, Vec4::new(0.5, 0.5, 0.5, 0.5)] {
+            let proj = Projection::Stereographic { pole };
+            // Exactly at the pole.
+            let at_pole = <EuclideanR4 as RasterizableSpace<4>>::project_point(pole, &proj);
+            for c in [at_pole.x, at_pole.y, at_pole.z] {
+                assert!(
+                    c.is_finite(),
+                    "pole input must clamp finite, got {at_pole:?}"
+                );
+            }
+            // Just off the pole, mostly tangential: dot(p, pole) ≈ 1 but < 1.
+            let (e1, _, _) = perp_frame(pole);
+            let near = (pole * 0.9999 + e1 * 0.01).normalize();
+            let near_img = <EuclideanR4 as RasterizableSpace<4>>::project_point(near, &proj);
+            for c in [near_img.x, near_img.y, near_img.z] {
+                assert!(
+                    c.is_finite(),
+                    "near-pole input must stay finite, got {near_img:?}"
+                );
+            }
+        }
+    }
+
+    /// The antipode `-pole` maps to the origin with denominator exactly `2`: `dot(-pole, pole)
+    /// = -1`, the pole-perpendicular component is zero, so the image is `Vec3::ZERO`. This is
+    /// the safe far point that distinguishes the antipode from the singular pole.
+    #[test]
+    fn stereographic_antipode_maps_to_origin() {
+        for pole in [Vec4::W, Vec4::new(0.1, -0.2, 0.3, 0.9).normalize()] {
+            let proj = Projection::Stereographic { pole };
+            let got = <EuclideanR4 as RasterizableSpace<4>>::project_point(-pole, &proj);
+            assert_relative_eq!(got.x, 0.0, epsilon = 1e-6);
+            assert_relative_eq!(got.y, 0.0, epsilon = 1e-6);
+            assert_relative_eq!(got.z, 0.0, epsilon = 1e-6);
+        }
+    }
+
+    /// A pole at 45° between two axes (so two Gram-Schmidt seeds are near-equidistant) yields
+    /// the same Vec3 across repeated calls and matches a golden value. Tier-0 bit-repro guard:
+    /// the frame must not flip gauge under the tie-break, or the projected wireframe would
+    /// silently rotate between machines or runs.
+    #[test]
+    fn stereographic_frame_is_deterministic_under_tie() {
+        // Pole equidistant from the z and w axes; perp_frame must tie-break deterministically
+        // toward the lowest index.
+        let pole = Vec4::new(0.0, 0.0, 1.0, 1.0).normalize();
+        let proj = Projection::Stereographic { pole };
+        let p = Vec4::new(0.5, 0.5, -0.5, 0.5); // unit
+        let first = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+        for _ in 0..16 {
+            let again = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+            assert_eq!(first, again, "frame must be byte-stable across calls");
+        }
+        // Golden value: locks the chosen gauge so a future tie-break change is caught. The
+        // frame for this pole drops the w axis (largest |component| ties z and w; the max-pick
+        // resolves to the lowest matching index, w at index 3 only if it is the unique max --
+        // here z and w tie at the max, and the `==` ladder selects z, index 2). Recorded from
+        // the current deterministic construction.
+        assert_relative_eq!(first.x, GOLDEN_TIE_FRAME.x, epsilon = 1e-6);
+        assert_relative_eq!(first.y, GOLDEN_TIE_FRAME.y, epsilon = 1e-6);
+        assert_relative_eq!(first.z, GOLDEN_TIE_FRAME.z, epsilon = 1e-6);
+    }
+
+    /// `perp_frame(pole)` is orthonormal for poles swept toward each axis, including exactly an
+    /// axis: the Gram matrix is approximately the identity and every entry is finite. The
+    /// stereographic readout relies on this; a degenerate frame would skew or NaN the image.
+    #[test]
+    fn stereographic_frame_orthonormal_for_every_pole() {
+        let mut poles = vec![Vec4::X, Vec4::Y, Vec4::Z, Vec4::W];
+        // Sweep toward each axis from the all-equal direction.
+        for axis in [Vec4::X, Vec4::Y, Vec4::Z, Vec4::W] {
+            for k in 1..6 {
+                let t = k as f32 / 6.0;
+                poles.push((Vec4::splat(0.5) * (1.0 - t) + axis * t).normalize());
+            }
+        }
+        for pole in poles {
+            let (e1, e2, e3) = perp_frame(pole);
+            for e in [e1, e2, e3] {
+                assert!(e.is_finite(), "frame must be finite for pole {pole:?}");
+            }
+            // Gram matrix approx I.
+            assert_relative_eq!(e1.dot(e1), 1.0, epsilon = 1e-5);
+            assert_relative_eq!(e2.dot(e2), 1.0, epsilon = 1e-5);
+            assert_relative_eq!(e3.dot(e3), 1.0, epsilon = 1e-5);
+            assert!(e1.dot(e2).abs() < 1e-5, "e1·e2 for pole {pole:?}");
+            assert!(e1.dot(e3).abs() < 1e-5, "e1·e3 for pole {pole:?}");
+            assert!(e2.dot(e3).abs() < 1e-5, "e2·e3 for pole {pole:?}");
+            // Each basis vector lies in the pole-perp 3-flat.
+            assert!(e1.dot(pole).abs() < 1e-5, "e1 ⟂ pole {pole:?}");
+            assert!(e2.dot(pole).abs() < 1e-5, "e2 ⟂ pole {pole:?}");
+            assert!(e3.dot(pole).abs() < 1e-5, "e3 ⟂ pole {pole:?}");
+        }
+    }
+
+    /// Stereographic projection is conformal (angle-preserving): two edges meeting at a shared
+    /// non-pole vertex keep the angle between them after projection, within tolerance
+    /// (Wikipedia, *Stereographic projection*: the map is conformal). Uses the geodesic tangent
+    /// directions on S³ as the "edges" and compares to the angle between their
+    /// projected images.
+    #[test]
+    fn stereographic_is_conformal() {
+        let s = SphericalS3Embedded;
+        let pole = Vec4::W;
+        let proj = Projection::Stereographic { pole };
+        // Shared vertex well off the pole; two neighbors define two great-circle edges.
+        let v = Vec4::new(0.3, -0.1, 0.2, -0.5).normalize();
+        let a = Vec4::new(0.5, 0.4, -0.1, -0.3).normalize();
+        let b = Vec4::new(-0.2, 0.3, 0.6, -0.4).normalize();
+        // Angle between the two geodesic tangents at `v` (the intrinsic edge angle on S³).
+        let ta = s.log(v, a);
+        let tb = s.log(v, b);
+        let intrinsic = (ta.dot(tb) / (ta.length() * tb.length()))
+            .clamp(-1.0, 1.0)
+            .acos();
+        // Angle between the projected edges in R³. Step a small distance along each geodesic so
+        // the projected secant approximates the projected tangent direction.
+        let step = 1e-3;
+        let pv = <EuclideanR4 as RasterizableSpace<4>>::project_point(v, &proj);
+        let pa = <EuclideanR4 as RasterizableSpace<4>>::project_point(
+            s.exp(v, ta.normalize() * step),
+            &proj,
+        );
+        let pb = <EuclideanR4 as RasterizableSpace<4>>::project_point(
+            s.exp(v, tb.normalize() * step),
+            &proj,
+        );
+        let da = pa - pv;
+        let db = pb - pv;
+        let projected = (da.dot(db) / (da.length() * db.length()))
+            .clamp(-1.0, 1.0)
+            .acos();
+        assert_relative_eq!(projected, intrinsic, epsilon = 1e-2);
+    }
+
+    /// `Projection::Stereographic` on R³ falls back to `Vec3::ZERO` per the enum's "unsupported
+    /// variant returns zero" contract (R³ has no 3-sphere to project from).
+    #[test]
+    fn stereographic_unsupported_on_r3_returns_zero() {
+        let p = Vec3::new(1.0, 2.0, 3.0);
+        let proj = Projection::Stereographic { pole: Vec4::W };
         let got = <EuclideanR3 as RasterizableSpace<3>>::project_point(p, &proj);
         assert_eq!(got, Vec3::ZERO);
     }

--- a/crates/rye-math/src/spherical_embedded.rs
+++ b/crates/rye-math/src/spherical_embedded.rs
@@ -183,13 +183,12 @@ impl RasterizableSpace<4> for SphericalS3Embedded {
             Projection::Stereographic { pole } => {
                 crate::rasterizable::stereographic_to_r3(point, *pole)
             }
-            // The remaining variants project the ambient unit 4-vector exactly as
-            // flat R⁴ does. The polytope playground views S³ great-circle arcs
-            // through the same Perspective4D pinhole (or Schlegel diagram) it uses
-            // for flat wireframes, so a flat edge and its curved counterpart share
-            // one screen embedding and the lerp↔slerp morph reads as the edges
-            // bowing out, not as a projection change. Delegating keeps the two
-            // impls bit-identical on those projection steps.
+            // The remaining variants project the ambient unit 4-vector exactly
+            // as flat R4 does. The playground views S3 great-circle arcs through
+            // the same Perspective4D pinhole or Schlegel diagram it uses for
+            // flat wireframes. The flat edge and curved counterpart share one
+            // screen embedding, so the lerp to slerp morph reads as the edge
+            // bowing out, not as a projection change.
             Projection::Identity
             | Projection::Orthographic { .. }
             | Projection::Perspective4D { .. }
@@ -654,29 +653,23 @@ mod tests {
         assert_eq!(got, want);
     }
 
-    /// Schlegel delegates to the flat R⁴ projection too: the central-projection math is on the
-    /// ambient R⁴ embedding, so an S³ vertex and its flat counterpart share one screen point.
+    /// Schlegel delegates to the flat R4 projection too: central projection is
+    /// on the ambient R4 embedding, so an S3 vertex and its flat counterpart
+    /// share one screen point.
     /// Pins that the blanket delegation covers the Schlegel variant, not just Perspective4D.
     #[test]
     fn project_point_schlegel_matches_flat_r4() {
         let p = Vec4::new(0.5, 0.5, 0.5, 0.5);
-        let proj = Projection::Schlegel {
-            cell_normal: Vec4::W,
-            cell_offset: 0.5,
-            viewpoint_distance: 0.75,
-        };
+        let proj = Projection::schlegel(Vec4::W, 0.5, 0.75);
         let got = <SphericalS3Embedded as RasterizableSpace<4>>::project_point(p, &proj);
         let want = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
         assert_eq!(got, want);
     }
 
-    /// Stereographic does NOT blanket-delegate: the embedded S³ type computes the conformal map
-    /// directly (no normalize, since the input is already unit by invariant), so it returns the
-    /// stereographic image, not the flat R⁴ drop-w. Pins the design decision that a true
-    /// spherical view uses the stereographic projection. For a unit input the direct map and
-    /// the flat arm (which normalizes a unit vector to itself) coincide, so the discriminating
-    /// check is against the closed-form `(x, y, z) / (1 - w)`, which differs from the drop-w
-    /// that `Projection::Identity` would produce.
+    /// Stereographic does NOT blanket-delegate: the embedded S3 type computes
+    /// the conformal map directly, with no normalize because the input is unit.
+    /// It returns the stereographic image, not the flat R4 drop-w. Pins that a
+    /// true spherical view uses stereographic projection.
     #[test]
     fn project_point_stereographic_is_conformal_map_not_drop_w() {
         let p = Vec4::new(0.5, 0.5, 0.5, 0.5); // unit by construction

--- a/crates/rye-math/src/spherical_embedded.rs
+++ b/crates/rye-math/src/spherical_embedded.rs
@@ -1,0 +1,697 @@
+//! Spherical 3-space (S³) in the **full ambient embedding**: points are unit
+//! 4-vectors in R⁴, not a chart.
+//!
+//! ## Why a second S³ type
+//!
+//! [`crate::SphericalS3`] models S³ as the **upper hemisphere only**: its
+//! `Point` is a `Vec3` with `|p| < 1`, lifted to `(p, √(1−|p|²))`. That keeps
+//! the WGSL ABI at `vec3<f32>` for the ray-marched fractal demo, but it cannot
+//! represent a point with `w ≤ 0`. A 4-polytope inscribed in S³ has vertices
+//! all over the sphere (the tesseract reaches `w = ±0.5` after unit-circumradius
+//! normalization), so the hemisphere chart collapses every `w < 0` vertex onto
+//! the equator. Wrong geometry for wireframes.
+//!
+//! [`SphericalS3Embedded`] takes the opposite tradeoff: `Point = Vec4`
+//! constrained to the unit sphere `|p| = 1`. Full coverage, no chart seam, exact
+//! great-circle geodesics. The cost is that it has no `vec3` WGSL ABI (none is
+//! implemented here; there is no shader consumer), so it serves the CPU-side
+//! rasterizer wireframe path, not the SDF ray-marcher.
+//!
+//! ## Geometry
+//!
+//! Curvature `K = +1`. Geodesics are great circles. The exp / log / parallel
+//! transport formulas are the standard unit-sphere maps (Absil, Mahony &
+//! Sepulchre, *Optimization Algorithms on Matrix Manifolds*, 2008, §3.6 and
+//! Example 8.1.1); the slerp tessellation is Shoemake's spherical linear
+//! interpolation (*Animating Rotation with Quaternion Curves*, SIGGRAPH 1985).
+//!
+//! Isometries reuse [`crate::spherical::Iso4`] (an SO(4) matrix), shared with
+//! the hemisphere model: an SO(4) matrix rotates the whole sphere the same way
+//! regardless of which chart names its points.
+
+use glam::Vec4;
+
+use crate::rasterizable::{Projection, RasterizableSpace};
+use crate::space::Space;
+use crate::spherical::Iso4;
+use crate::EuclideanR4;
+
+/// Floor on the tangent-direction norm below which a geodesic has no
+/// well-defined direction. Two cases hit it: near-coincident endpoints (the
+/// perpendicular component `p1 − ⟨p0,p1⟩·p0` vanishes because `p1 ≈ p0`) and
+/// near-antipodal endpoints (it vanishes because `p1 ≈ −p0`, and the connecting
+/// great circle is non-unique). The same norm gates `exp` / `log`. Equal to the
+/// tangent-norm floor the hemisphere model uses, so the two S³ impls agree on
+/// "too close to have a direction."
+const GEODESIC_EPSILON: f32 = 1e-7;
+
+/// Spherical 3-space, full ambient embedding, curvature `K = +1`.
+///
+/// Stateless unit struct. Points are unit 4-vectors (`|p| = 1`); the trait
+/// methods assume that precondition holds and clamp dot products into range
+/// rather than re-normalizing on the hot path. [`RasterizableSpace::array_to_point`]
+/// normalizes on the way in, so mesh-storage round-trips land back on the sphere.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SphericalS3Embedded;
+
+impl Space for SphericalS3Embedded {
+    type Point = Vec4;
+    /// Ambient tangent vector: lives in R⁴, perpendicular to its base point.
+    /// [`Self::exp`] projects out any radial component defensively, so a caller
+    /// that passes a not-quite-tangent vector still gets an on-sphere result.
+    type Vector = Vec4;
+    type Iso = Iso4;
+
+    fn distance(&self, a: Vec4, b: Vec4) -> f32 {
+        // Chord half-angle form `d = 2·asin(|a − b| / 2)`, the same one
+        // `SphericalS3::distance` uses. Better conditioned near `d = 0` than
+        // `acos(dot)`, where `acos(1 − ε)` quantizes badly in f32.
+        let half_chord = (a - b).length() * 0.5;
+        2.0 * half_chord.clamp(0.0, 1.0).asin()
+    }
+
+    fn exp(&self, at: Vec4, v: Vec4) -> Vec4 {
+        // Project `v` onto the tangent space at `at` (drop any radial part) so
+        // the result is exactly on the sphere even if the caller's vector drifted
+        // off-tangent. For a true tangent this subtracts zero.
+        let v_tan = v - v.dot(at) * at;
+        let theta = v_tan.length();
+        if theta < GEODESIC_EPSILON {
+            return at;
+        }
+        // Unit-sphere exponential: cos(θ)·at + sin(θ)·(v̂). Stays on S³ because
+        // `at` and `v_tan/θ` are orthonormal.
+        at * theta.cos() + v_tan * (theta.sin() / theta)
+    }
+
+    fn log(&self, from: Vec4, to: Vec4) -> Vec4 {
+        let d = self.distance(from, to);
+        // Component of `to` perpendicular to `from`: the initial geodesic
+        // direction. `dot` clamped because a slightly-off-unit input could push
+        // it past 1 and flip the sign of the perpendicular term.
+        let dot = from.dot(to).clamp(-1.0, 1.0);
+        let perp = to - dot * from;
+        let n = perp.length();
+        if n < GEODESIC_EPSILON {
+            // Coincident (d ≈ 0) or antipodal (d ≈ π, direction undefined): no
+            // well-defined geodesic tangent. Matches `SphericalS3::log`.
+            return Vec4::ZERO;
+        }
+        perp * (d / n)
+    }
+
+    fn parallel_transport(&self, from: Vec4, to: Vec4, v: Vec4) -> Vec4 {
+        // Unit-sphere parallel transport along the minimizing geodesic:
+        //   v' = v − (⟨v, to⟩ / (1 + ⟨from, to⟩))·(from + to)
+        // (do Carmo, *Riemannian Geometry*, ch. 2; the standard sphere
+        // connection.) Acts on the full ambient 4-vector here, not a lifted
+        // chart vector. Undefined at antipodes (`⟨from, to⟩ = −1`, the geodesic
+        // is non-unique); the denominator floor keeps the result finite there.
+        //
+        // The denominator is `|from + to|² / 2`, NOT the literal `1 + ⟨from,to⟩`.
+        // The two are equal for unit `from`, `to` (expand `|from + to|²
+        // = 2 + 2⟨from,to⟩`), but `1 + ⟨from,to⟩` is a catastrophic
+        // cancellation as `⟨from,to⟩ -> −1`: near the antipode the f32 sum loses
+        // most of its significant digits and the transported vector's norm
+        // drifts several percent off (the connection should preserve it
+        // exactly). Forming the denominator from the squared length of the same
+        // `from + to` the numerator already needs has no cancellation, so the
+        // norm holds to f32 epsilon right up to the antipodal floor. This is the
+        // `2·cos²(θ/2)` half-angle identity, the same conditioning principle as
+        // the chord-form distance. Deliberate divergence from the sibling
+        // `SphericalS3::parallel_transport`, which still carries the unhardened
+        // `1 + c` form on its hemisphere chart (its near-equator clamp masks the
+        // issue there); fold this form back into the sibling when it is hardened.
+        let sum = from + to;
+        let denom = (sum.length_squared() * 0.5).max(GEODESIC_EPSILON);
+        v - (v.dot(to) / denom) * sum
+    }
+
+    fn iso_identity(&self) -> Iso4 {
+        Iso4::IDENTITY
+    }
+
+    fn iso_compose(&self, a: Iso4, b: Iso4) -> Iso4 {
+        Iso4 {
+            matrix: a.matrix * b.matrix,
+        }
+    }
+
+    fn iso_inverse(&self, a: Iso4) -> Iso4 {
+        // SO(4) matrices are orthogonal: M⁻¹ = Mᵀ.
+        Iso4 {
+            matrix: a.matrix.transpose(),
+        }
+    }
+
+    fn iso_apply(&self, iso: Iso4, p: Vec4) -> Vec4 {
+        // Normalize after the matmul to shed accumulated f32 drift; repeated
+        // SO(4) applications would otherwise creep off the unit sphere.
+        (iso.matrix * p).normalize()
+    }
+
+    fn iso_transport(&self, iso: Iso4, _at: Vec4, v: Vec4) -> Vec4 {
+        // An SO(4) matrix is a global linear isometry of R⁴, so its differential
+        // at every point is the matrix itself. Applying it to the ambient tangent
+        // vector is exact and base-point-independent (it preserves the tangency
+        // ⟨M·at, M·v⟩ = ⟨at, v⟩ = 0). No geodesic round-trip needed, unlike the
+        // chart-based hemisphere model.
+        iso.matrix * v
+    }
+}
+
+impl RasterizableSpace<4> for SphericalS3Embedded {
+    fn point_to_array(p: Vec4) -> [f32; 4] {
+        p.to_array()
+    }
+
+    fn array_to_point(arr: [f32; 4]) -> Vec4 {
+        // Mesh storage may carry slightly-off-sphere values; project back onto
+        // S³. Inputs are polytope vertices (circumradius > 0), never the zero
+        // vector, so `normalize` is well-defined.
+        Vec4::from_array(arr).normalize()
+    }
+
+    fn project_point(point: Vec4, projection: &Projection<4>) -> glam::Vec3 {
+        match projection {
+            // Stereographic is the canonical conformal S³ to R³ map, so a true
+            // spherical view computes it directly here rather than delegating to
+            // the flat R⁴ projection (which has no notion of the sphere). Points
+            // are already unit by this type's invariant, so no normalize is
+            // needed; `EuclideanR4`'s arm normalizes because its inputs are
+            // body-scaled, but here that would be a redundant op on a unit vector.
+            Projection::Stereographic { pole } => {
+                crate::rasterizable::stereographic_to_r3(point, *pole)
+            }
+            // The remaining variants project the ambient unit 4-vector exactly as
+            // flat R⁴ does. The polytope playground views S³ great-circle arcs
+            // through the same Perspective4D pinhole (or Schlegel diagram) it uses
+            // for flat wireframes, so a flat edge and its curved counterpart share
+            // one screen embedding and the lerp↔slerp morph reads as the edges
+            // bowing out, not as a projection change. Delegating keeps the two
+            // impls bit-identical on those projection steps.
+            Projection::Identity
+            | Projection::Orthographic { .. }
+            | Projection::Perspective4D { .. }
+            | Projection::Schlegel { .. } => {
+                <EuclideanR4 as RasterizableSpace<4>>::project_point(point, projection)
+            }
+        }
+    }
+
+    fn tessellate_segment(p0: Vec4, p1: Vec4, samples: usize, out: &mut Vec<Vec4>) {
+        // Constant-speed walk along the great-circle arc from `p0` to `p1`, both
+        // unit 4-vectors, in the exponential-map form (Absil/Mahony/Sepulchre
+        // §3.6; equivalent to Shoemake's slerp, *Animating Rotation with
+        // Quaternion Curves*, SIGGRAPH 1985):
+        //   γ(t) = cos(t·ω)·p0 + sin(t·ω)·d̂,   d̂ = (p1 − ⟨p0,p1⟩·p0) / |·|
+        // with `d̂` the unit tangent at `p0` pointing toward `p1`. This form
+        // divides only by `n`, the length of the perpendicular component before
+        // it is normalized (`n = sin(ω)`), never by `sin(ω)` formed separately
+        // from a reconstructed angle, so it stays on S³ to machine epsilon as
+        // ω -> π, where the classic `sin((1−t)ω)/sin(ω)` slerp catastrophically
+        // loses the sphere (the f32 `acos(dot)` near `dot = −1` recovers an ω
+        // whose `sin` mismatches the endpoints, and samples drift percent-level
+        // off the sphere well before `sin(ω)` underflows). Deliberate divergence
+        // from the spec's literal "guard the lerp normalize" fix: that only
+        // rescues the exact-antipode midpoint NaN and leaves the near-antipode
+        // off-sphere drift, which this well-conditioned form removes wholesale.
+        //
+        // `ω` uses the chord half-angle `2·asin(|p0−p1|/2)`, the same
+        // well-conditioned form as `Self::distance`, rather than `acos(dot)`,
+        // which quantizes badly near both 0 and π.
+        //
+        // Sampling convention matches `EuclideanR4::tessellate_segment`: push the
+        // exact endpoint `p0`, then interior points at t = i/samples for
+        // i in 1..samples, then the exact endpoint `p1`, never clearing `out`
+        // (the upload loop reuses the buffer).
+        let dot = p0.dot(p1).clamp(-1.0, 1.0);
+        let half_chord = (p0 - p1).length() * 0.5;
+        let omega = 2.0 * half_chord.clamp(0.0, 1.0).asin();
+        // Tangent at `p0` toward `p1`: the component of `p1` perpendicular to
+        // `p0`. Its pre-normalize length `n = sin(ω)` vanishes for both
+        // coincident (ω ≈ 0) and antipodal (ω ≈ π) endpoints; both leave the
+        // geodesic direction undefined, so they share the degenerate branch.
+        let perp = p1 - dot * p0;
+        let n = perp.length();
+        out.push(p0);
+        if n > GEODESIC_EPSILON {
+            let dir = perp / n;
+            for i in 1..samples {
+                let t = i as f32 / samples as f32;
+                let ang = t * omega;
+                out.push(ang.cos() * p0 + ang.sin() * dir);
+            }
+        } else {
+            // Degenerate: endpoints near-coincident OR near-antipodal, so the
+            // toward-`p1` direction is undefined (at a true antipode, infinitely
+            // many great circles connect the pair; for coincident points the arc
+            // has zero length). Walk SOME deterministic great circle through `p0`
+            // instead of dividing by the zero `perp`: pick a fixed perpendicular
+            // `d̂` from `p0` and sample γ(t) = cos(t·ω)·p0 + sin(t·ω)·d̂. For
+            // coincident points ω ≈ 0 so every sample collapses onto `p0`; for
+            // antipodes ω ≈ π so the walk traverses a half great circle and the
+            // final interior sample approaches −p0 = p1, all unit, no NaN. (The
+            // old normalized-lerp fallback produced the zero vector at the
+            // antipodal midpoint, whose `normalize()` is NaN.)
+            let dir = deterministic_perp(p0);
+            for i in 1..samples {
+                let t = i as f32 / samples as f32;
+                let ang = t * omega;
+                out.push(ang.cos() * p0 + ang.sin() * dir);
+            }
+        }
+        out.push(p1);
+    }
+}
+
+/// A deterministic unit vector perpendicular to the unit `p0`, used only by the
+/// degenerate (near-coincident / near-antipodal) branch of slerp where the
+/// toward-`p1` direction is undefined. Picks the world axis least aligned with
+/// `p0` (smallest `|component|`, so its residual after projecting out `p0` is the
+/// longest and best-conditioned), Gram-Schmidt's it against `p0`, and normalizes
+/// (do Carmo, *Differential Geometry of Curves and Surfaces*, §1.4). Ties resolve
+/// toward the earliest axis (x, y, z, w), so the choice is a pure function of
+/// `p0`: bit-reproducible, Tier 0. A unit `p0` cannot be aligned with all four
+/// axes, so the chosen residual is always well clear of zero.
+fn deterministic_perp(p0: Vec4) -> Vec4 {
+    let a = p0.abs();
+    // Index of the smallest-magnitude component (least-aligned world axis). The
+    // `<` comparisons resolve ties toward the earlier index for determinism.
+    let mut min_idx = 0usize;
+    let mut min_v = a.x;
+    if a.y < min_v {
+        min_v = a.y;
+        min_idx = 1;
+    }
+    if a.z < min_v {
+        min_v = a.z;
+        min_idx = 2;
+    }
+    if a.w < min_v {
+        min_idx = 3;
+    }
+    let axis = match min_idx {
+        0 => Vec4::X,
+        1 => Vec4::Y,
+        2 => Vec4::Z,
+        _ => Vec4::W,
+    };
+    (axis - axis.dot(p0) * p0).normalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use std::f32::consts::PI;
+
+    fn s3() -> SphericalS3Embedded {
+        SphericalS3Embedded
+    }
+
+    /// Two basis 4-vectors are a quarter great circle apart: `acos(0) = π/2`.
+    #[test]
+    fn distance_orthonormal_is_quarter_circle() {
+        let s = s3();
+        assert_relative_eq!(s.distance(Vec4::X, Vec4::Y), PI / 2.0, epsilon = 1e-6);
+        assert_relative_eq!(s.distance(Vec4::X, Vec4::W), PI / 2.0, epsilon = 1e-6);
+    }
+
+    /// Distance is symmetric, zero on the diagonal, and `π` between antipodes.
+    #[test]
+    fn distance_symmetric_zero_diag_pi_antipodal() {
+        let s = s3();
+        let a = Vec4::new(0.5, 0.5, 0.5, 0.5); // already unit
+        let b = Vec4::new(0.1, -0.2, 0.3, 0.9).normalize();
+        assert_relative_eq!(s.distance(a, b), s.distance(b, a), epsilon = 1e-6);
+        assert_relative_eq!(s.distance(a, a), 0.0, epsilon = 1e-7);
+        assert_relative_eq!(s.distance(a, -a), PI, epsilon = 1e-5);
+    }
+
+    /// `exp(at, log(at, to)) == to` for non-antipodal points.
+    #[test]
+    fn exp_log_round_trip() {
+        let s = s3();
+        let from = Vec4::new(0.2, 0.1, -0.3, 0.9).normalize();
+        let to = Vec4::new(-0.1, 0.4, 0.2, 0.8).normalize();
+        let recovered = s.exp(from, s.log(from, to));
+        assert_relative_eq!(recovered.x, to.x, epsilon = 1e-5);
+        assert_relative_eq!(recovered.y, to.y, epsilon = 1e-5);
+        assert_relative_eq!(recovered.z, to.z, epsilon = 1e-5);
+        assert_relative_eq!(recovered.w, to.w, epsilon = 1e-5);
+    }
+
+    /// `log`'s magnitude equals the geodesic distance, and its direction is
+    /// tangent to the sphere at `from` (perpendicular to `from`).
+    #[test]
+    fn log_magnitude_is_distance_and_is_tangent() {
+        let s = s3();
+        let from = Vec4::new(0.3, 0.2, 0.1, 0.9).normalize();
+        let to = Vec4::new(-0.2, 0.5, 0.0, 0.8).normalize();
+        let v = s.log(from, to);
+        assert_relative_eq!(v.length(), s.distance(from, to), epsilon = 1e-5);
+        // Tangent vector is perpendicular to the base point.
+        assert_relative_eq!(v.dot(from), 0.0, epsilon = 1e-6);
+    }
+
+    /// `exp` lands exactly on the unit sphere even when the supplied vector has a
+    /// radial component (the impl projects it out).
+    #[test]
+    fn exp_stays_on_sphere_with_non_tangent_input() {
+        let s = s3();
+        let at = Vec4::new(0.0, 0.0, 0.0, 1.0);
+        // Mix a genuine tangent (xy-plane) with a radial part along `at`.
+        let v = Vec4::new(0.4, 0.2, 0.0, 0.7);
+        let moved = s.exp(at, v);
+        assert_relative_eq!(moved.length(), 1.0, epsilon = 1e-6);
+    }
+
+    /// Parallel transport preserves the tangent vector's length and lands it in
+    /// the tangent space at the destination. `v` lies in the xw-plane of motion
+    /// so the transport actually rotates it (a y-direction vector would be left
+    /// untouched, a weaker check).
+    #[test]
+    fn parallel_transport_preserves_norm_and_tangency() {
+        let s = s3();
+        let from = Vec4::new(0.0, 0.0, 0.0, 1.0);
+        let to = Vec4::new(0.6, 0.0, 0.0, 0.8); // unit, in the xw-plane
+        let v = Vec4::new(0.5, 0.0, 0.0, 0.0); // tangent at `from`, in-plane
+        let vt = s.parallel_transport(from, to, v);
+        assert_relative_eq!(vt.length(), v.length(), epsilon = 1e-5);
+        assert_relative_eq!(vt.dot(to), 0.0, epsilon = 1e-5);
+        // Transport is non-trivial: the in-plane vector is rotated, not fixed.
+        assert!((vt - v).length() > 1e-3, "in-plane vector should rotate");
+    }
+
+    /// Norm preservation must hold right up to the antipodal floor, not just at
+    /// the well-conditioned quarter turn `parallel_transport_preserves_norm_and_tangency`
+    /// checks. This pins the well-conditioned denominator: the literal
+    /// `1 + ⟨from, to⟩` form cancels catastrophically as `⟨from, to⟩ -> −1` and
+    /// drifts the transported norm several percent off across the band
+    /// `ω ∈ [π − 3e-3, π − 1e-3]`; the `|from + to|² / 2` form holds it to f32
+    /// epsilon. `to` is built as an exact unit vector at great-circle angle `ω`
+    /// from `from` in the x-y plane, and `v` is a unit tangent in that plane (so
+    /// transport genuinely rotates it), making the norm the discriminating
+    /// invariant. `ω` is kept just outside the antipodal floor (`sin(ω) > 1e-3`)
+    /// so the geodesic direction is still well defined and the exact transported
+    /// norm is `|v| = 1`; the regime where transport is genuinely undefined
+    /// (`sin(ω) < GEODESIC_EPSILON`) is the separate antipode-safety concern the
+    /// slerp degenerate branch covers.
+    #[test]
+    fn parallel_transport_preserves_norm_near_antipode() {
+        let s = s3();
+        let from = Vec4::X;
+        for delta in [3e-3_f32, 2e-3, 1e-3] {
+            let omega = PI - delta;
+            // Unit endpoint at exact great-circle angle `omega` from `from`.
+            let to = Vec4::new(omega.cos(), omega.sin(), 0.0, 0.0).normalize();
+            // Unit tangent at `from` in the plane of motion (perpendicular to
+            // `from`, so transport rotates it rather than leaving it fixed).
+            let v = Vec4::Y;
+            let vt = s.parallel_transport(from, to, v);
+            assert_relative_eq!(vt.length(), v.length(), epsilon = 1e-3);
+            assert_relative_eq!(vt.dot(to), 0.0, epsilon = 1e-3);
+        }
+    }
+
+    /// SO(4) isometry preserves geodesic distance.
+    #[test]
+    fn iso_apply_preserves_distance() {
+        let s = s3();
+        // An honest SO(4) element: the hemisphere model's translation constructor
+        // builds a Givens rotation in the plane spanned by the w-axis and the
+        // target direction.
+        let iso = Iso4::from_translation(glam::Vec3::new(0.3, 0.1, -0.2));
+        let a = Vec4::new(0.2, 0.3, 0.1, 0.9).normalize();
+        let b = Vec4::new(-0.1, 0.2, 0.4, 0.8).normalize();
+        let before = s.distance(a, b);
+        let after = s.distance(s.iso_apply(iso, a), s.iso_apply(iso, b));
+        assert_relative_eq!(before, after, epsilon = 1e-5);
+    }
+
+    /// `iso_transport` sends a tangent at `at` to a tangent at `iso_apply(at)`,
+    /// preserving length (SO(4) is an isometry of ambient R⁴).
+    #[test]
+    fn iso_transport_keeps_tangency_and_norm() {
+        let s = s3();
+        let iso = Iso4::from_translation(glam::Vec3::new(0.2, -0.1, 0.15));
+        let at = Vec4::new(0.0, 0.0, 0.0, 1.0);
+        let v = Vec4::new(0.3, 0.2, 0.0, 0.0); // tangent at the north pole
+        let moved_at = s.iso_apply(iso, at);
+        let moved_v = s.iso_transport(iso, at, v);
+        assert_relative_eq!(moved_v.length(), v.length(), epsilon = 1e-5);
+        assert_relative_eq!(moved_v.dot(moved_at), 0.0, epsilon = 1e-5);
+    }
+
+    // ---- RasterizableSpace ----------------------------------------------
+
+    /// `point_to_array` then `array_to_point` is identity for a unit input
+    /// (`array_to_point` normalizes, so the round-trip only closes on S³).
+    #[test]
+    fn array_round_trip_on_unit_input() {
+        let p = Vec4::new(0.5, -0.5, 0.5, 0.5); // unit by construction
+        let arr = <SphericalS3Embedded as RasterizableSpace<4>>::point_to_array(p);
+        let back = <SphericalS3Embedded as RasterizableSpace<4>>::array_to_point(arr);
+        assert_relative_eq!(back.x, p.x, epsilon = 1e-6);
+        assert_relative_eq!(back.y, p.y, epsilon = 1e-6);
+        assert_relative_eq!(back.z, p.z, epsilon = 1e-6);
+        assert_relative_eq!(back.w, p.w, epsilon = 1e-6);
+    }
+
+    /// Slerp endpoints are exact and the sample count matches the convention:
+    /// `samples` subdivisions append `samples + 1` points.
+    #[test]
+    fn slerp_endpoints_exact_and_count() {
+        let p0 = Vec4::X;
+        let p1 = Vec4::Y;
+        let mut out = Vec::new();
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(p0, p1, 4, &mut out);
+        assert_eq!(out.len(), 5);
+        assert_relative_eq!(out[0].x, p0.x, epsilon = 1e-6);
+        assert_relative_eq!(out[4].y, p1.y, epsilon = 1e-6);
+    }
+
+    /// Every slerp sample is a unit vector (lies on S³), unlike the chord, whose
+    /// interior dips inside the sphere.
+    #[test]
+    fn slerp_samples_stay_on_sphere() {
+        let p0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
+        let p1 = Vec4::new(0.0, 0.0, 0.0, 1.0);
+        let mut out = Vec::new();
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(p0, p1, 8, &mut out);
+        for p in &out {
+            assert_relative_eq!(p.length(), 1.0, epsilon = 1e-6);
+        }
+    }
+
+    /// The slerp midpoint of a quarter arc sits at 45°, bulging off the chord:
+    /// it is equidistant from both endpoints and its components are `sin(π/4)`,
+    /// strictly larger in magnitude than the chord midpoint `(0.5, 0, 0, 0.5)`.
+    #[test]
+    fn slerp_midpoint_is_on_great_circle_not_chord() {
+        let s = s3();
+        let p0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
+        let p1 = Vec4::new(0.0, 0.0, 0.0, 1.0);
+        let mut out = Vec::new();
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(p0, p1, 2, &mut out);
+        let mid = out[1];
+        // Equidistant from both endpoints.
+        assert_relative_eq!(s.distance(mid, p0), s.distance(mid, p1), epsilon = 1e-6);
+        // On the sphere at 45°: x = w = cos(π/4) ≈ 0.7071, not the chord's 0.5.
+        let c = (PI / 4.0).cos();
+        assert_relative_eq!(mid.x, c, epsilon = 1e-5);
+        assert_relative_eq!(mid.w, c, epsilon = 1e-5);
+        assert!(mid.x > 0.5, "slerp midpoint must bulge off the chord");
+    }
+
+    /// Exact antipodes have no unique connecting great circle, but the public
+    /// trait method must still return finite, on-sphere samples (no zero-vector
+    /// `normalize` -> NaN). The degenerate branch walks a deterministic
+    /// perpendicular great circle from `p0`; every sample is finite and unit.
+    /// Unreachable from polytope edges (adjacent vertices subtend small angles),
+    /// but the method is public and must be antipode-safe.
+    #[test]
+    fn slerp_antipode_produces_finite_unit_samples() {
+        let p0 = Vec4::X;
+        let p1 = -Vec4::X;
+        let mut out = Vec::new();
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(p0, p1, 16, &mut out);
+        assert_eq!(out.len(), 17);
+        for p in &out {
+            assert!(
+                p.is_finite(),
+                "antipodal slerp sample must be finite: {p:?}"
+            );
+            assert_relative_eq!(p.length(), 1.0, epsilon = 1e-6);
+        }
+    }
+
+    /// Near-antipodal endpoints are the case the old single-`sin(ω)` gate missed:
+    /// for ω just below π the perpendicular norm passes the gate, but the classic
+    /// `sin((1−t)ω)/sin(ω)` slerp drifts percent-level off the sphere because the
+    /// f32 `acos(dot)` near `dot = −1` recovers an ω whose `sin` no longer matches
+    /// the endpoints. The well-conditioned exp-form keeps every interior sample on
+    /// S³. Tested across ω = π − {1e-3, 1e-5, 2e-7}: each endpoint is placed at the
+    /// exact angle in the x-y plane so the test pins the impl, not the test setup.
+    #[test]
+    fn slerp_near_antipode_samples_stay_on_sphere() {
+        let p0 = Vec4::X;
+        for delta in [1e-3_f32, 1e-5, 2e-7] {
+            let omega = PI - delta;
+            // Unit endpoint at the exact great-circle angle `omega` from `p0`.
+            let p1 = Vec4::new(omega.cos(), omega.sin(), 0.0, 0.0).normalize();
+            let mut out = Vec::new();
+            <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(p0, p1, 16, &mut out);
+            // Interior samples (skip the exact endpoints, which are pushed verbatim).
+            for p in &out[1..out.len() - 1] {
+                assert!(p.is_finite(), "near-antipode sample must be finite: {p:?}");
+                assert!(
+                    (p.length() - 1.0).abs() < 1e-4,
+                    "near-antipode (omega = PI - {delta:e}) sample off-sphere: |p| = {}",
+                    p.length()
+                );
+            }
+        }
+    }
+
+    /// Constant-speed parametrization: the geodesic distances between consecutive
+    /// samples sum to the total endpoint distance, for any sample count. This is
+    /// the correct formalization of "samples cover the great-circle arc" and pins
+    /// that the walk does not bunch up or overshoot. A chord-lerp would undershoot
+    /// (sum of chords < arc); slerp's sum of sub-arcs equals the whole arc.
+    #[test]
+    fn slerp_consecutive_arc_sum_equals_total() {
+        let s = s3();
+        let p0 = Vec4::new(0.2, 0.1, -0.3, 0.9).normalize();
+        let p1 = Vec4::new(-0.1, 0.4, 0.2, 0.8).normalize();
+        let total = s.distance(p0, p1);
+        for samples in [2usize, 3, 8, 17] {
+            let mut out = Vec::new();
+            <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(
+                p0, p1, samples, &mut out,
+            );
+            let arc_sum: f32 = out.windows(2).map(|w| s.distance(w[0], w[1])).sum();
+            assert_relative_eq!(arc_sum, total, epsilon = 1e-6);
+        }
+    }
+
+    /// Determinism is Tier 0: tessellating the same segment twice yields
+    /// byte-identical samples. The existing on-sphere / midpoint tests only assert
+    /// approximate equality; this asserts exact f32 bit-reproducibility, which the
+    /// fixed op order (no reassociation, no FMA contraction) must guarantee.
+    #[test]
+    fn slerp_is_bit_reproducible() {
+        let p0 = Vec4::new(0.3, -0.2, 0.5, 0.4).normalize();
+        let p1 = Vec4::new(-0.4, 0.1, 0.2, 0.7).normalize();
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(p0, p1, 12, &mut a);
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(p0, p1, 12, &mut b);
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(&b) {
+            // Bit-for-bit, not approx: same inputs must give the same f32 bits.
+            assert_eq!(x.to_array(), y.to_array(), "slerp not bit-reproducible");
+        }
+        // The antipodal degenerate branch must be reproducible too (the
+        // deterministic perpendicular is a pure function of `p0`).
+        let mut c = Vec::new();
+        let mut d = Vec::new();
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(
+            Vec4::Y,
+            -Vec4::Y,
+            9,
+            &mut c,
+        );
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(
+            Vec4::Y,
+            -Vec4::Y,
+            9,
+            &mut d,
+        );
+        for (x, y) in c.iter().zip(&d) {
+            assert_eq!(
+                x.to_array(),
+                y.to_array(),
+                "antipodal slerp not bit-reproducible"
+            );
+        }
+    }
+
+    /// Near-coincident endpoints (ω < GEODESIC_EPSILON) take the degenerate branch
+    /// and must still emit unit samples, all clustered at `p0` (the arc has
+    /// effectively zero length). Broadens the angle coverage of
+    /// `slerp_samples_stay_on_sphere`, which only exercises a quarter arc.
+    #[test]
+    fn slerp_near_coincident_falls_back_on_sphere() {
+        let p0 = Vec4::new(0.1, -0.2, 0.3, 0.9).normalize();
+        // A point a hair off `p0`: omega well below GEODESIC_EPSILON = 1e-7.
+        let p1 = (p0 + Vec4::new(1e-9, 0.0, -1e-9, 0.0)).normalize();
+        let mut out = Vec::new();
+        <SphericalS3Embedded as RasterizableSpace<4>>::tessellate_segment(p0, p1, 8, &mut out);
+        for p in &out {
+            assert!(p.is_finite(), "coincident sample must be finite: {p:?}");
+            assert_relative_eq!(p.length(), 1.0, epsilon = 1e-6);
+            // Zero-length arc: every sample sits essentially at p0.
+            assert!(
+                s3().distance(*p, p0) < 1e-4,
+                "coincident-arc sample should stay at p0, dist {}",
+                s3().distance(*p, p0)
+            );
+        }
+    }
+
+    /// `project_point` agrees with the flat R⁴ projection it delegates to, on the
+    /// canonical Perspective4D path.
+    #[test]
+    fn project_point_matches_flat_r4() {
+        let p = Vec4::new(0.5, 0.5, 0.5, 0.5);
+        let proj = Projection::Perspective4D {
+            focal_distance: 2.0,
+        };
+        let got = <SphericalS3Embedded as RasterizableSpace<4>>::project_point(p, &proj);
+        let want = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+        assert_eq!(got, want);
+    }
+
+    /// Schlegel delegates to the flat R⁴ projection too: the central-projection math is on the
+    /// ambient R⁴ embedding, so an S³ vertex and its flat counterpart share one screen point.
+    /// Pins that the blanket delegation covers the Schlegel variant, not just Perspective4D.
+    #[test]
+    fn project_point_schlegel_matches_flat_r4() {
+        let p = Vec4::new(0.5, 0.5, 0.5, 0.5);
+        let proj = Projection::Schlegel {
+            cell_normal: Vec4::W,
+            cell_offset: 0.5,
+            viewpoint_distance: 0.75,
+        };
+        let got = <SphericalS3Embedded as RasterizableSpace<4>>::project_point(p, &proj);
+        let want = <EuclideanR4 as RasterizableSpace<4>>::project_point(p, &proj);
+        assert_eq!(got, want);
+    }
+
+    /// Stereographic does NOT blanket-delegate: the embedded S³ type computes the conformal map
+    /// directly (no normalize, since the input is already unit by invariant), so it returns the
+    /// stereographic image, not the flat R⁴ drop-w. Pins the design decision that a true
+    /// spherical view uses the stereographic projection. For a unit input the direct map and
+    /// the flat arm (which normalizes a unit vector to itself) coincide, so the discriminating
+    /// check is against the closed-form `(x, y, z) / (1 - w)`, which differs from the drop-w
+    /// that `Projection::Identity` would produce.
+    #[test]
+    fn project_point_stereographic_is_conformal_map_not_drop_w() {
+        let p = Vec4::new(0.5, 0.5, 0.5, 0.5); // unit by construction
+        let proj = Projection::Stereographic { pole: Vec4::W };
+        let got = <SphericalS3Embedded as RasterizableSpace<4>>::project_point(p, &proj);
+        // Closed-form stereographic for the +w pole.
+        let want = glam::Vec3::new(p.x, p.y, p.z) / (1.0 - p.w);
+        assert_relative_eq!(got.x, want.x, epsilon = 1e-6);
+        assert_relative_eq!(got.y, want.y, epsilon = 1e-6);
+        assert_relative_eq!(got.z, want.z, epsilon = 1e-6);
+        // It is genuinely the stereographic scaling, not the identity drop-w `(x, y, z)`.
+        let drop_w = glam::Vec3::new(p.x, p.y, p.z);
+        assert!(
+            (got - drop_w).length() > 1e-3,
+            "stereographic must scale by 1/(1-w), not pass through drop-w; got {got:?}"
+        );
+    }
+}

--- a/crates/rye-render/src/line_raster.rs
+++ b/crates/rye-render/src/line_raster.rs
@@ -365,57 +365,11 @@ impl LineRasterNode {
         S: RasterizableSpace<N>,
     {
         let samples = samples_per_segment.max(1);
-        // `tess_buf` stays local because it's generic over `S::Point` and the
-        // node-level scratch field can't pick a single type. For flat spaces
-        // (the common case) `samples = 1` so this Vec stays at capacity 2; the
-        // allocation cost is tiny (~64 bytes) and short-lived. Once a curved-
-        // space user shows real cost here, lift it into a type-erased scratch
-        // (`Vec<u8>` with `bytemuck::cast_slice_mut`) on the node.
-        let mut tess_buf: Vec<S::Point> = Vec::with_capacity(samples + 1);
-
-        // `instances_scratch` is the node-owned scratch: `clear()` preserves
-        // the heap capacity allocated in previous calls, so the steady-state
-        // hot path does zero allocations after the first frame's growth.
-        // Avoids the ~80-bytes-per-segment Vec allocation that the previous
-        // call-local `Vec::with_capacity` did per upload.
-        self.instances_scratch.clear();
-        self.instances_scratch
-            .reserve(mesh.segments.len() * samples);
-
-        for ((seg, (color_a, color_b)), &width) in mesh
-            .segments
-            .iter()
-            .zip(mesh.colors.iter())
-            .zip(mesh.widths.iter())
-        {
-            tess_buf.clear();
-            let p0 = S::array_to_point(seg.0);
-            let p1 = S::array_to_point(seg.1);
-            S::tessellate_segment(p0, p1, samples, &mut tess_buf);
-
-            // tess_buf now holds samples+1 points. Pair consecutive points into rendered
-            // sub-segments. Per-endpoint color is linearly interpolated along the original
-            // segment so multi-sample tessellation preserves the gradient.
-            let n_sub = tess_buf.len().saturating_sub(1);
-            for i in 0..n_sub {
-                let t0 = i as f32 / samples as f32;
-                let t1 = (i + 1) as f32 / samples as f32;
-                let c0 = lerp_color(*color_a, *color_b, t0);
-                let c1 = lerp_color(*color_a, *color_b, t1);
-                let q0 = S::project_point(tess_buf[i], projection);
-                let q1 = S::project_point(tess_buf[i + 1], projection);
-                self.instances_scratch.push(LineInstance {
-                    start_pos: q0.to_array(),
-                    _pad0: 0.0,
-                    end_pos: q1.to_array(),
-                    _pad1: 0.0,
-                    start_color: c0,
-                    end_color: c1,
-                    width_px: width,
-                    _pad2: [0.0; 3],
-                });
-            }
-        }
+        // Build into the node-owned scratch (capacity reused across frames),
+        // then ship it to the GPU below. Factored out so the CPU-side
+        // tessellation + projection + non-finite drop is unit-testable without
+        // a GPU device (see `build_line_instances`).
+        build_line_instances::<S, N>(&mut self.instances_scratch, mesh, projection, samples);
 
         let needed_capacity = self.instances_scratch.len() as u32;
         if needed_capacity > self.instance_capacity {
@@ -533,6 +487,84 @@ impl LineRasterNode {
     }
 }
 
+/// Tessellate, project, and pack a [`LineMesh`] into `out` (one [`LineInstance`]
+/// per rendered sub-segment). `out` is caller-owned scratch; it is `clear()`-ed
+/// here (preserving heap capacity, so a reused buffer does zero allocations in
+/// the steady state) and `reserve`-d for the worst-case segment count, so the
+/// only allocation is the first-call growth or a growth past the prior high
+/// watermark.
+///
+/// Each input segment is tessellated via [`RasterizableSpace::tessellate_segment`]
+/// (for flat spaces with `samples == 1` this is just the two endpoints) and the
+/// resulting consecutive points are paired into rendered sub-segments with a
+/// linear color gradient along the original segment.
+///
+/// Sub-segments with a non-finite projected endpoint are dropped: a central
+/// projection (Schlegel, Stereographic, Perspective4D) can map a vertex on the
+/// projection center / pole to a NaN or infinity, and a single non-finite point
+/// poisons the GPU view-projection divide into a full-screen garbage quad rather
+/// than a missing line. `is_finite` rejects every quiet-NaN bit pattern AND both
+/// infinities (an `== NAN` sentinel test would miss infinities and signaling
+/// NaNs); the `continue` drops the offending sub-segment without pushing, so the
+/// scratch capacity is untouched (no `filter().collect()` reallocation).
+fn build_line_instances<S, const N: usize>(
+    out: &mut Vec<LineInstance>,
+    mesh: &LineMesh<N>,
+    projection: &Projection<N>,
+    samples: usize,
+) where
+    S: RasterizableSpace<N>,
+{
+    // `tess_buf` stays local because it's generic over `S::Point` and the
+    // node-level scratch field can't pick a single type. For flat spaces
+    // (the common case) `samples = 1` so this Vec stays at capacity 2; the
+    // allocation cost is tiny (~64 bytes) and short-lived. Once a curved-
+    // space user shows real cost here, lift it into a type-erased scratch
+    // (`Vec<u8>` with `bytemuck::cast_slice_mut`) on the node.
+    let mut tess_buf: Vec<S::Point> = Vec::with_capacity(samples + 1);
+
+    out.clear();
+    out.reserve(mesh.segments.len() * samples);
+
+    for ((seg, (color_a, color_b)), &width) in mesh
+        .segments
+        .iter()
+        .zip(mesh.colors.iter())
+        .zip(mesh.widths.iter())
+    {
+        tess_buf.clear();
+        let p0 = S::array_to_point(seg.0);
+        let p1 = S::array_to_point(seg.1);
+        S::tessellate_segment(p0, p1, samples, &mut tess_buf);
+
+        // tess_buf now holds samples+1 points. Pair consecutive points into rendered
+        // sub-segments. Per-endpoint color is linearly interpolated along the original
+        // segment so multi-sample tessellation preserves the gradient.
+        let n_sub = tess_buf.len().saturating_sub(1);
+        for i in 0..n_sub {
+            let t0 = i as f32 / samples as f32;
+            let t1 = (i + 1) as f32 / samples as f32;
+            let c0 = lerp_color(*color_a, *color_b, t0);
+            let c1 = lerp_color(*color_a, *color_b, t1);
+            let q0 = S::project_point(tess_buf[i], projection);
+            let q1 = S::project_point(tess_buf[i + 1], projection);
+            if !q0.is_finite() || !q1.is_finite() {
+                continue;
+            }
+            out.push(LineInstance {
+                start_pos: q0.to_array(),
+                _pad0: 0.0,
+                end_pos: q1.to_array(),
+                _pad1: 0.0,
+                start_color: c0,
+                end_color: c1,
+                width_px: width,
+                _pad2: [0.0; 3],
+            });
+        }
+    }
+}
+
 fn lerp_color(a: [f32; 4], b: [f32; 4], t: f32) -> [f32; 4] {
     [
         a[0] + (b[0] - a[0]) * t,
@@ -586,5 +618,93 @@ mod tests {
         assert_eq!(start_color_off, 32);
         assert_eq!(end_color_off, 48);
         assert_eq!(width_off, 64);
+    }
+
+    // ---- non-finite drop backstop ---------------------------------------
+    //
+    // These exercise the CPU-side instance builder directly (no GPU device):
+    // `build_line_instances` is the part of `upload` that tessellates,
+    // projects, and packs, including the `is_finite` drop guard. `EuclideanR3`
+    // + `Projection::Identity` is a bitwise pass-through, so a non-finite
+    // coordinate in the input mesh flows straight to the projected endpoint and
+    // exercises the guard without needing a projection that manufactures one.
+
+    use rye_math::EuclideanR3;
+    use rye_shape::LineMesh;
+
+    /// Build a single-segment R³ mesh with the given endpoints, uniform white
+    /// color, and unit width.
+    fn one_segment_mesh(a: [f32; 3], b: [f32; 3]) -> LineMesh<3> {
+        LineMesh {
+            segments: vec![(a, b)],
+            colors: vec![([1.0; 4], [1.0; 4])],
+            widths: vec![1.0],
+        }
+    }
+
+    /// A segment with all-finite endpoints survives; a segment carrying a NaN
+    /// endpoint is dropped, so the built instance count excludes it. Pins the
+    /// invariant that a non-finite endpoint contributes ZERO instances rather
+    /// than a poisoned one.
+    #[test]
+    fn upload_drops_non_finite_segments() {
+        let mut scratch: Vec<LineInstance> = Vec::new();
+
+        let finite = one_segment_mesh([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]);
+        build_line_instances::<EuclideanR3, 3>(&mut scratch, &finite, &Projection::Identity, 1);
+        assert_eq!(scratch.len(), 1, "finite segment must produce one instance");
+
+        let nan = one_segment_mesh([0.0, 0.0, 0.0], [f32::NAN, 1.0, 1.0]);
+        build_line_instances::<EuclideanR3, 3>(&mut scratch, &nan, &Projection::Identity, 1);
+        assert_eq!(scratch.len(), 0, "NaN-endpoint segment must be dropped");
+    }
+
+    /// Re-running the builder over a NaN-bearing mesh leaves the scratch Vec's
+    /// heap capacity unchanged from the prior (finite) build: the drop is a
+    /// `continue`, not a `filter().collect()`, so the zero-per-frame-allocation
+    /// contract holds even when segments are culled.
+    #[test]
+    fn upload_drops_non_finite_without_reallocating() {
+        let mut scratch: Vec<LineInstance> = Vec::new();
+
+        // Prime the scratch with several finite segments so it grows once.
+        let mut many = LineMesh::<3>::default();
+        for k in 0..8 {
+            let f = k as f32;
+            many.segments.push(([f, 0.0, 0.0], [f, 1.0, 0.0]));
+            many.colors.push(([1.0; 4], [1.0; 4]));
+            many.widths.push(1.0);
+        }
+        build_line_instances::<EuclideanR3, 3>(&mut scratch, &many, &Projection::Identity, 1);
+        assert_eq!(scratch.len(), 8);
+        let cap_after_growth = scratch.capacity();
+
+        // Now feed a mesh whose only segment is non-finite. The builder
+        // `clear()`s then `reserve()`s for one segment (<= current cap, so no
+        // growth) and drops the segment, leaving capacity untouched.
+        let nan = one_segment_mesh([f32::NAN, 0.0, 0.0], [0.0, 0.0, 0.0]);
+        build_line_instances::<EuclideanR3, 3>(&mut scratch, &nan, &Projection::Identity, 1);
+        assert_eq!(scratch.len(), 0);
+        assert_eq!(
+            scratch.capacity(),
+            cap_after_growth,
+            "dropping a segment must not change the scratch heap capacity"
+        );
+    }
+
+    /// The drop predicate is `!is_finite()`, not an `== NAN` sentinel: a segment
+    /// with a `+inf` (or `-inf`) endpoint is ALSO dropped. An equality-to-NaN
+    /// test would let infinities through to poison the GPU divide.
+    #[test]
+    fn upload_drop_predicate_catches_infinity_not_just_nan() {
+        let mut scratch: Vec<LineInstance> = Vec::new();
+
+        let pos_inf = one_segment_mesh([0.0, 0.0, 0.0], [f32::INFINITY, 1.0, 1.0]);
+        build_line_instances::<EuclideanR3, 3>(&mut scratch, &pos_inf, &Projection::Identity, 1);
+        assert_eq!(scratch.len(), 0, "+inf endpoint must be dropped");
+
+        let neg_inf = one_segment_mesh([f32::NEG_INFINITY, 0.0, 0.0], [1.0, 1.0, 1.0]);
+        build_line_instances::<EuclideanR3, 3>(&mut scratch, &neg_inf, &Projection::Identity, 1);
+        assert_eq!(scratch.len(), 0, "-inf endpoint must be dropped");
     }
 }

--- a/crates/rye-render/src/line_raster.wgsl
+++ b/crates/rye-render/src/line_raster.wgsl
@@ -29,16 +29,50 @@ fn vs_main(
     @location(4) end_color:   vec4<f32>,
     @location(5) width_px:    f32,
 ) -> VsOut {
-    let s_clip = camera.view_projection * vec4<f32>(start_pos, 1.0);
-    let e_clip = camera.view_projection * vec4<f32>(end_pos,   1.0);
-    let s_ndc  = s_clip.xyz / s_clip.w;
-    let e_ndc  = e_clip.xyz / e_clip.w;
+    var a  = camera.view_projection * vec4<f32>(start_pos, 1.0);
+    var b  = camera.view_projection * vec4<f32>(end_pos,   1.0);
+    var ca = start_color;
+    var cb = end_color;
+
+    // Near-plane clip in homogeneous clip space, BEFORE the perspective divide.
+    // glam's `perspective_rh` puts the near plane at `clip.z == 0` (wgpu's [0, w]
+    // depth range), and `clip.z < 0` for everything nearer than the near plane,
+    // INCLUDING points behind the eye (`w <= 0`). Without this clip a behind-eye
+    // endpoint divides by a non-positive `w`, flipping its NDC across the screen
+    // and rubber-banding the whole segment (a long stereographic arc swinging
+    // through the camera's near hemisphere is the trigger). Both endpoints in
+    // front of the near plane (the overwhelmingly common case) take no clip and
+    // are bit-identical to the unclipped path.
+    if (a.z < 0.0 && b.z < 0.0) {
+        // Whole segment is behind the near plane: emit a degenerate vertex
+        // outside the clip volume (z < 0) so the hardware discards the quad.
+        var culled: VsOut;
+        culled.clip       = vec4<f32>(0.0, 0.0, -1.0, 1.0);
+        culled.coverage_t = 0.0;
+        culled.width_px   = width_px;
+        culled.color      = vec4<f32>(0.0);
+        return culled;
+    }
+    // At most one endpoint is behind the near plane now; move it along the
+    // segment to `clip.z == 0` (and carry its color the same fraction).
+    if (a.z < 0.0) {
+        let t = a.z / (a.z - b.z);
+        a  = mix(a,  b,  t);
+        ca = mix(ca, cb, t);
+    } else if (b.z < 0.0) {
+        let t = b.z / (b.z - a.z);
+        b  = mix(b,  a,  t);
+        cb = mix(cb, ca, t);
+    }
+
+    let s_ndc  = a.xyz / a.w;
+    let e_ndc  = b.xyz / b.w;
 
     // Corners 0, 2 belong to the start endpoint; 1, 3 to the end.
     let pick_start = (corner == 0u || corner == 2u);
     let base_ndc   = select(e_ndc, s_ndc, pick_start);
-    let base_w     = select(e_clip.w, s_clip.w, pick_start);
-    let color      = select(end_color, start_color, pick_start);
+    let base_w     = select(b.w, a.w, pick_start);
+    let color      = select(cb, ca, pick_start);
 
     // Direction along the segment in screen-pixel space (NDC * half-viewport).
     let half_vp     = camera.viewport_size * 0.5;

--- a/crates/rye-render/src/line_raster_static_r4.wgsl
+++ b/crates/rye-render/src/line_raster_static_r4.wgsl
@@ -78,17 +78,38 @@ fn vs_main(
     let s_3d = project_perspective_4d(s_4d, transform.focal_distance);
     let e_3d = project_perspective_4d(e_4d, transform.focal_distance);
     // Stage 3: standard R3 -> clip via view*proj.
-    let s_clip = transform.view_projection * vec4<f32>(s_3d, 1.0);
-    let e_clip = transform.view_projection * vec4<f32>(e_3d, 1.0);
-    let s_ndc  = s_clip.xyz / s_clip.w;
-    let e_ndc  = e_clip.xyz / e_clip.w;
+    var a = transform.view_projection * vec4<f32>(s_3d, 1.0);
+    var b = transform.view_projection * vec4<f32>(e_3d, 1.0);
+
+    // Near-plane clip before the perspective divide (see `line_raster.wgsl` for
+    // the full rationale): glam's `perspective_rh` puts the near plane at
+    // `clip.z == 0` and `clip.z < 0` for anything nearer, including behind the
+    // eye (`w <= 0`), where the divide would flip the NDC across the screen.
+    // Both endpoints in front (the common case here, since a unit-circumradius
+    // polytope never reaches the camera) take no clip. The depth-cue color is a
+    // single value for the whole segment, so a clipped endpoint keeps it.
+    if (a.z < 0.0 && b.z < 0.0) {
+        var culled: VsOut;
+        culled.clip       = vec4<f32>(0.0, 0.0, -1.0, 1.0);
+        culled.coverage_t = 0.0;
+        culled.width_px   = width_px;
+        culled.color      = vec4<f32>(0.0);
+        return culled;
+    }
+    if (a.z < 0.0) {
+        a = mix(a, b, a.z / (a.z - b.z));
+    } else if (b.z < 0.0) {
+        b = mix(b, a, b.z / (b.z - a.z));
+    }
+    let s_ndc  = a.xyz / a.w;
+    let e_ndc  = b.xyz / b.w;
 
     // Corners 0, 2 belong to the start endpoint; 1, 3 to the end. (Mirrors
     // the same convention as the R³ variant; the quad-expansion + AA logic
     // below is bit-identical to `line_raster.wgsl`.)
     let pick_start = (corner == 0u || corner == 2u);
     let base_ndc   = select(e_ndc, s_ndc, pick_start);
-    let base_w     = select(e_clip.w, s_clip.w, pick_start);
+    let base_w     = select(b.w, a.w, pick_start);
 
     // Depth-cue color: average the segment's rotated w-coordinates, normalize,
     // and lerp between a cool "back" tint and a warm "front" tint. Identical

--- a/crates/rye-render/src/point_raster.rs
+++ b/crates/rye-render/src/point_raster.rs
@@ -331,6 +331,17 @@ impl PointRasterNode {
         {
             let p_native = S::array_to_point(*p);
             let p3 = S::project_point(p_native, projection);
+            // Same CPU-side backstop as `LineRasterNode::upload`: a central
+            // projection (Schlegel, Stereographic, Perspective4D) can map a
+            // vertex on the projection center / pole to a NaN or infinity, and
+            // a single non-finite point poisons the GPU view-projection divide
+            // into a full-screen garbage quad rather than a missing dot.
+            // `is_finite` rejects every quiet-NaN bit pattern AND both
+            // infinities; `continue` drops the offending point without
+            // emitting it.
+            if !p3.is_finite() {
+                continue;
+            }
             instances.push(PointInstance {
                 pos: p3.to_array(),
                 radius_px: *size,


### PR DESCRIPTION
Why: Adds Schlegel and Stereographic projections plus a true spherical-space (S³) wireframe, edges render as great-circle arcs to polytope_playground, behind a projection switcher. Hardens stereographic near-pole rendering: an engine-level near-plane line clip (fixes a latent behind-camera rubberband in all line demos) and a per-shape, camera-adaptive clip so the 16-cell's pole arcs stay smooth while other polytopes show their full conformal extent.

Verify: cargo run --release -p polytope_playground, then wireframe perspective stereographic and rotate a 16-cell. scripts/audit.sh 12/12; 771 workspace tests pass.